### PR TITLE
chore: add Windows and macOS support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,10 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,5 @@
 ifneq ($(OS),Windows_NT)
-	# On Unix-based systems, use ANSI codes
-	BLUE = \033[36m
-	BOLD_BLUE = \033[1;36m
-	BOLD_GREEN = \033[1;32m
-	RED = \033[31m
-	YELLOW = \033[33m
-	BOLD = \033[1m
-	NC = \033[0m
+	SHELL := bash
 endif
 
 .PHONY: help setup format lint test coverage
@@ -14,18 +7,13 @@ endif
 
 PYTEST_ARGS ?= --numprocesses=auto
 
-escape = $(subst $$,\$$,$(subst ",\",$(subst ',\',$(1))))
-
 define exec
-	@printf '$(BOLD_BLUE)%s$(NC)\n' '$(call escape,$(1))'
+	@uv run --no-sync python -c "print('\033[1;36m$(1)\033[0m')"
 	@$(1)
 endef
 
 help:
-	@echo "$(BOLD_GREEN)Available targets:$(NC)"
-	@grep -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?# "}; \
-		{printf "  $(BOLD_BLUE)%-20s$(NC) %s\n", $$1, $$2}'
+	@uv run --no-sync python -c "import re; lines=open('Makefile').read().splitlines(); print('\033[1;32mAvailable targets:\033[0m'); [print(f'  \033[1;36m{m.group(1):<20s}\033[0m {m.group(2)}') for l in lines if (m:=re.match(r'^([a-zA-Z_-]+):.*?# (.+)$$',l))]"
 
 setup:  # Setup the development environment
 	$(call exec,uv sync)
@@ -34,16 +22,16 @@ format:  # Format code
 	$(call exec,uv run ruff format)
 	$(call exec,uv run ruff check --fix)
 	$(call exec,uv run taplo fmt)
-	$(call exec,uv run mdformat $$(git ls-files *.md))
-	$(call exec,uv run yamlfix $$(git ls-files *.yml *.yaml))
+	$(call exec,uv run mdformat $(shell git ls-files "*.md"))
+	$(call exec,uv run yamlfix $(shell git ls-files "*.yml" "*.yaml"))
 
 lint:  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
 	$(call exec,uv run ty check --no-progress)
 	$(call exec,uv run taplo fmt --check)
-	$(call exec,uv run mdformat --check $$(git ls-files *.md))
-	$(call exec,uv run yamlfix --check $$(git ls-files *.yml *.yaml))
+	$(call exec,uv run mdformat --check $(shell git ls-files "*.md"))
+	$(call exec,uv run yamlfix --check $(shell git ls-files "*.yml" "*.yaml"))
 	$(call exec,uv run typos)
 
 test:  # Run tests

--- a/git_hunk/git.py
+++ b/git_hunk/git.py
@@ -14,12 +14,13 @@ def run_git(*args: str, input: str | None = None, check: bool = True) -> str:
     result = subprocess.run(
         ["git"] + list(args),
         capture_output=True,
-        text=True,
-        input=input,
+        input=input.encode() if input is not None else None,
     )
     if check and result.returncode != 0:
-        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
-    return result.stdout
+        raise RuntimeError(
+            f"git {' '.join(args)} failed: {result.stderr.decode().strip()}"
+        )
+    return result.stdout.decode()
 
 
 def get_diff(staged: bool = False, files: list[str] | None = None) -> str:


### PR DESCRIPTION
## Summary
- Make Makefile cross-platform by using `uv run --no-sync python` for colored output instead of Unix-only `printf`/`grep`/`awk`
- Use `$(shell git ls-files ...)` instead of bash subshells `$$(...)` for cmd.exe compatibility
- Add `.gitattributes` to enforce LF line endings across platforms
- Add macOS and Windows to CI test matrix

## Why
Makefile failed on Windows (PowerShell) because it relied on bash-only commands (`printf`, `grep`, `awk`) and `cmd.exe` couldn't execute them.

## Test plan
- [x] `make help`, `make setup`, `make lint` pass on macOS
- [x] CI passes on `windows-latest`
- [x] CI passes on `macos-latest`