### PR TITLE
feat: make show ID optional, default to showing all hunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ git-hunk list --json                   # JSON output for scripting
 ### Show hunks
 
 ```bash
+git-hunk show                          # show all hunks (staged + unstaged)
 git-hunk show d161935                  # show a single hunk
 git-hunk show d161935 a3f82c1          # show multiple hunks
-git-hunk show --all                    # show all hunks (staged + unstaged)
-git-hunk show --all --staged           # show all staged hunks
-git-hunk show --all --unstaged         # show all unstaged hunks
+git-hunk show --staged                 # show all staged hunks
+git-hunk show --unstaged               # show all unstaged hunks
 ```
 
 ### Stage, unstage, discard

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -24,7 +24,6 @@ from ._ui import HELP_STAGE
 from ._ui import HELP_UNSTAGE
 from ._ui import USAGE
 from ._ui import USAGE_DISCARD
-from ._ui import USAGE_SHOW
 from ._ui import USAGE_STAGE
 from ._ui import USAGE_UNSTAGE
 from ._ui import print_applied
@@ -230,13 +229,11 @@ def cmd_list(
 
 
 @cli.command("show", add_help_option=False)
-@click.option("--all", "show_all", is_flag=True)
 @click.option("--staged", is_flag=True)
 @click.option("--unstaged", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("ids", nargs=-1)
 def cmd_show(
-    show_all: bool,
     staged: bool,
     unstaged: bool,
     show_help: bool,
@@ -249,12 +246,6 @@ def cmd_show(
     if staged and unstaged:
         raise CliError("cannot use --staged and --unstaged together")
 
-    if show_all and ids:
-        raise CliError("--all cannot be combined with specific hunk ids")
-
-    if not show_all and not ids:
-        raise CliError("show requires at least one hunk id", usage=USAGE_SHOW)
-
     if staged:
         hunks, _ = _get_hunks(staged=True)
     elif unstaged:
@@ -264,10 +255,10 @@ def cmd_show(
         hunks_unstaged, _ = _get_hunks(staged=False)
         hunks = hunks_staged + hunks_unstaged
 
-    if show_all:
-        matched = hunks
-    else:
+    if ids:
         matched = _find_hunks_by_ids(hunks, list(ids))
+    else:
+        matched = hunks
 
     print_hunk_diffs(matched)
 

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -171,7 +171,7 @@ _LINE_OPTS = """\
              Examples: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""  # noqa: E501
 
 USAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk[/bold cyan] [cyan]<COMMAND>[/cyan]"  # noqa: E501
-USAGE_SHOW = "[bold green]Usage:[/bold green] [bold cyan]git-hunk show[/bold cyan] [cyan]<id>[/cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
+USAGE_SHOW = "[bold green]Usage:[/bold green] [bold cyan]git-hunk show[/bold cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_STAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk stage[/bold cyan] [cyan]<id>[/cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_UNSTAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk unstage[/bold cyan] [cyan]<id>[/cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_DISCARD = "[bold green]Usage:[/bold green] [bold cyan]git-hunk discard[/bold cyan] [cyan]<id>[/cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
@@ -203,12 +203,12 @@ List hunks (unstaged, staged, and untracked by default).
   [bold cyan]--json[/bold cyan]        Output as JSON"""  # noqa: E501
 
 HELP_SHOW = f"""\
-Show the diff for one or more hunks. IDs support prefix matching.
+Show the diff for one or more hunks. Shows all hunks when no IDs given.
+IDs support prefix matching.
 
 {USAGE_SHOW}
 
 [bold green]Options:[/bold green]
-  [bold cyan]--all[/bold cyan]        Show all hunks
   [bold cyan]--staged[/bold cyan]     Show only staged hunks
   [bold cyan]--unstaged[/bold cyan]   Show only unstaged hunks"""
 

--- a/skills/git-hunk/SKILL.md
+++ b/skills/git-hunk/SKILL.md
@@ -19,7 +19,7 @@ Requires: `uv tool install git-hunk` (or `pip install git-hunk`)
 ## Workflow
 
 1. `git-hunk list` — see all hunks (file, id, +/- stats). No diffs.
-1. `git-hunk show <id> [<id>...]` or `git-hunk show --all` when headers aren't clear enough.
+1. `git-hunk show [<id>...]` when headers aren't clear enough (no args shows all).
 1. Plan commits before staging. For each planned commit, list the hunk IDs (and `-l` line ranges for partial hunks). A single hunk may need to be split across commits. Ask the user if grouping is ambiguous.
 1. Stage and commit each group:
    ```bash

--- a/tests/e2e/show_test.py
+++ b/tests/e2e/show_test.py
@@ -60,7 +60,7 @@ def test_show_finds_staged_hunk_without_flag(cli: GitHunkCLI) -> None:
     assert "+new" in r.stdout
 
 
-def test_show_all_includes_staged_and_unstaged(cli: GitHunkCLI) -> None:
+def test_show_no_args_shows_all(cli: GitHunkCLI) -> None:
     cli.repo.write_file("a.py", "old\n")
     cli.repo.write_file("b.py", "old\n")
     cli.repo.git("add", ".")
@@ -69,7 +69,7 @@ def test_show_all_includes_staged_and_unstaged(cli: GitHunkCLI) -> None:
     cli.repo.git("add", "a.py")
     cli.repo.write_file("b.py", "unstaged\n")
 
-    r = cli.run("show", "--all")
+    r = cli.run("show")
     assert r.returncode == 0
     assert "+staged" in r.stdout
     assert "+unstaged" in r.stdout
@@ -81,5 +81,5 @@ def test_show_staged_and_unstaged_together_errors(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "new\n")
 
-    r = cli.run("show", "--staged", "--unstaged", "--all")
+    r = cli.run("show", "--staged", "--unstaged")
     assert r.returncode != 0


### PR DESCRIPTION
## Summary
- Make `git-hunk show` with no arguments show all hunks (staged + unstaged), mirroring `list` behavior
- Remove the `--all` flag entirely — bare `show` replaces it
- Update help text, usage strings, README, and SKILL.md

## Why
`git-hunk show` required either `--all` or explicit IDs, adding friction for the most common case (seeing all diffs). This aligns `show` with `list`, which already defaults to showing everything.

## Test plan
- [x] All 77 tests pass
- [x] `ruff check` clean
- [x] `test_show_no_args_shows_all` covers bare `show` with both staged and unstaged hunks
- [x] `test_show_staged_and_unstaged_together_errors` updated (no longer uses `--all`)
- [x] Reviewed by fresh Claude Code context (`/review-fix` — LGTM in 2 cycles)