### PR TITLE
build: rewrite relative image paths to absolute URLs for PyPI README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Non-interactive, programmatic alternative to `git add -p`.
 Every hunk gets a stable, content-based ID so you can inspect, filter, and
 stage changes without interactive prompts.
 
-<img src="https://github.com/wkentaro/git-hunk/blob/main/assets/teaser.png?raw=true" alt="git-hunk teaser" width="800">
+<img src="assets/teaser.png" alt="git-hunk teaser" width="800">
 
 ## Why?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatch-vcs", "hatchling"]
+requires = ["hatch-fancy-pypi-readme", "hatch-vcs", "hatchling"]
 
 [project]
 authors = [{ name = "Kentaro Wada" }]
@@ -19,11 +19,10 @@ classifiers = [
 ]
 dependencies = ["click>=8", "rich>=13"]
 description = "Non-interactive, programmatic git hunk staging with stable IDs."
-dynamic = ["version"]
+dynamic = ["readme", "version"]
 keywords = ["automation", "diff", "git", "hunk", "staging", "version-control"]
 license = "MIT"
 name = "git-hunk"
-readme = "README.md"
 requires-python = ">=3.10"
 
 [project.urls]
@@ -33,6 +32,18 @@ Repository = "https://github.com/wkentaro/git-hunk"
 
 [project.scripts]
 git-hunk = "git_hunk._cli:cli"
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+fragments = [{ path = "README.md" }]
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = 'src="(?!https?://)([^"]+)"'
+replacement = 'src="https://raw.githubusercontent.com/wkentaro/git-hunk/main/\1"'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '!\[([^\]]*)\]\((?!https?://)([^)]+)\)'
+replacement = '![\1](https://raw.githubusercontent.com/wkentaro/git-hunk/main/\2)'
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
## Summary
- Add a `hatch-fancy-pypi-readme` substitution rule that rewrites relative `src="..."` attributes to absolute `raw.githubusercontent.com` URLs at build time
- Already-absolute URLs (shields.io badges, etc.) are left untouched via negative lookahead
- Switch the README teaser image to a relative path so GitHub renders it directly while PyPI gets the rewritten URL

## Why
Images using relative paths like `src="assets/teaser.png"` don't resolve on pypi.org. Following the same pattern adopted in [wkentaro/labelme#1954](https://github.com/wkentaro/labelme/pull/1954), they're rewritten to absolute GitHub raw URLs at build time, so the same README works on both GitHub and PyPI.

## Test plan
- [x] `uv build` succeeds
- [x] `twine check` passes on built artifacts
- [x] Verified `PKG-INFO` in built tarball — `assets/teaser.png` rewritten to `https://raw.githubusercontent.com/wkentaro/git-hunk/main/assets/teaser.png`