### PR TITLE
fix: preserve no-newline-at-EOF markers through parse and patch build

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -4,7 +4,14 @@ from collections import Counter
 from dataclasses import dataclass
 from dataclasses import replace
 from typing import Any
+from typing import Final
 from typing import TypedDict
+
+NO_NEWLINE_MARKER: Final = "\\ No newline at end of file"
+
+
+def is_no_newline_marker(line: str) -> bool:
+    return line == NO_NEWLINE_MARKER
 
 
 @dataclass(frozen=True)
@@ -101,6 +108,8 @@ def _advance_offsets(
 ) -> tuple[int, int]:
     for j in range(start, end):
         line = body_lines[j]
+        if is_no_newline_marker(line):
+            continue
         if line.startswith("+"):
             new += 1
         elif line.startswith("-"):
@@ -149,7 +158,11 @@ def _build_sub_hunks(
 
         sub_body = body_lines[body_start:body_end]
         additions, deletions = count_changes(sub_body)
-        ctx = sum(1 for line in sub_body if not _is_change(line))
+        ctx = sum(
+            1
+            for line in sub_body
+            if not _is_change(line) and not is_no_newline_marker(line)
+        )
         old_count = ctx + deletions
         new_count = ctx + additions
 
@@ -222,9 +235,7 @@ def parse_diff(diff_output: str) -> list[Hunk]:
         for part in parts[1:]:
             lines = part.split("\n")
             header_line = lines[0]
-            body_lines = [
-                line for line in lines[1:] if line != "\\ No newline at end of file"
-            ]
+            body_lines = lines[1:]
 
             while body_lines and body_lines[-1] == "":
                 body_lines = body_lines[:-1]

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 
 from ._hunk import Hunk
 from ._hunk import count_changes
+from ._hunk import is_no_newline_marker
 
 
 def parse_line_spec(spec: str) -> tuple[set[int], bool]:
@@ -43,19 +44,29 @@ def parse_line_spec(spec: str) -> tuple[set[int], bool]:
 
 
 def _filter_body_lines(
-    body: list,
+    body: list[str],
     selected: set[int],
-) -> list:
+) -> list[str]:
     new_body = []
-    for i, line in enumerate(body, start=1):
-        if i in selected:
-            new_body.append(line)
-        elif line.startswith("+"):
+    line_num = 0
+    prev_kept = False
+    for line in body:
+        if is_no_newline_marker(line):
+            if prev_kept:
+                new_body.append(line)
             continue
+        line_num += 1
+        if line_num in selected:
+            new_body.append(line)
+            prev_kept = True
+        elif line.startswith("+"):
+            prev_kept = False
         elif line.startswith("-"):
             new_body.append(" " + line[1:])
+            prev_kept = True
         else:
             new_body.append(line)
+            prev_kept = True
     return new_body
 
 
@@ -72,7 +83,7 @@ def filter_hunk_lines(hunk: Hunk, lines: set[int], *, exclude: bool) -> Hunk:
     while body and body[-1] == "":
         body = body[:-1]
 
-    total = len(body)
+    total = sum(1 for line in body if not is_no_newline_marker(line))
 
     out_of_range = {n for n in lines if n < 1 or n > total}
     if out_of_range:
@@ -90,7 +101,8 @@ def filter_hunk_lines(hunk: Hunk, lines: set[int], *, exclude: bool) -> Hunk:
     if additions == 0 and deletions == 0:
         raise ValueError("no changes remain after line filtering")
 
-    context_count = len(new_body) - additions - deletions
+    markers = sum(1 for line in new_body if is_no_newline_marker(line))
+    context_count = len(new_body) - additions - deletions - markers
     old_count = context_count + deletions
     new_count = context_count + additions
 

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -15,6 +15,7 @@ from rich.rule import Rule
 from rich.text import Text
 
 from ._hunk import Hunk
+from ._hunk import is_no_newline_marker
 from ._skills import Skill
 
 
@@ -112,6 +113,8 @@ def _print_hunk_diff(out: Console, hunk: Hunk) -> None:
     for line in hunk.diff.split("\n"):
         if line.startswith("@@"):
             out.print(Text(line, style="cyan"))
+        elif is_no_newline_marker(line):
+            out.print(Text("    " + line, style="dim"))
         else:
             line_num += 1
             prefix = Text(f"{line_num:3d} ", style="dim")

--- a/tests/e2e/no_newline_test.py
+++ b/tests/e2e/no_newline_test.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from git_hunk._hunk import NO_NEWLINE_MARKER
+
+from .conftest import GitHunkCLI
+
+
+def _commit(cli: GitHunkCLI, content: str) -> None:
+    cli.repo.write_file("f.txt", content)
+    cli.repo.git("add", "f.txt")
+    cli.repo.git("commit", "-m", "init")
+
+
+def _only_hunk_id(cli: GitHunkCLI) -> str:
+    hunks = cli.run_json("list", "--unstaged", "--json")
+    assert len(hunks) == 1
+    return hunks[0]["id"]
+
+
+def test_stage_edit_last_line_no_newline(cli: GitHunkCLI) -> None:
+    _commit(cli, "a\nb\nc")
+    cli.repo.write_file("f.txt", "a\nb\ncX")
+
+    cli.run_ok("stage", _only_hunk_id(cli))
+
+    assert cli.repo.git("show", ":f.txt") == "a\nb\ncX"
+
+
+def test_stage_newline_to_no_newline_removes_trailing_newline(cli: GitHunkCLI) -> None:
+    _commit(cli, "a\nb\nc\n")
+    cli.repo.write_file("f.txt", "a\nb\nc")
+
+    cli.run_ok("stage", _only_hunk_id(cli))
+
+    assert cli.repo.git("show", ":f.txt") == "a\nb\nc"
+
+
+def test_stage_no_newline_to_newline_adds_trailing_newline(cli: GitHunkCLI) -> None:
+    _commit(cli, "a\nb\nc")
+    cli.repo.write_file("f.txt", "a\nb\nc\n")
+
+    cli.run_ok("stage", _only_hunk_id(cli))
+
+    assert cli.repo.git("show", ":f.txt") == "a\nb\nc\n"
+
+
+def test_unstage_round_trips_no_newline(cli: GitHunkCLI) -> None:
+    _commit(cli, "a\nb\nc")
+    cli.repo.write_file("f.txt", "a\nb\ncX")
+
+    cli.run_ok("stage", _only_hunk_id(cli))
+    staged = cli.run_json("list", "--staged", "--json")
+    cli.run_ok("unstage", staged[0]["id"])
+
+    assert cli.repo.git("diff", "--cached").strip() == ""
+    assert cli.repo.git("show", ":f.txt") == "a\nb\nc"
+
+
+def test_discard_round_trips_no_newline(cli: GitHunkCLI) -> None:
+    _commit(cli, "a\nb\nc")
+    cli.repo.write_file("f.txt", "a\nb\ncX")
+
+    cli.run_ok("discard", _only_hunk_id(cli))
+
+    assert (Path(cli.repo.path) / "f.txt").read_text() == "a\nb\nc"
+
+
+def test_stage_line_selection_on_no_newline_hunk(cli: GitHunkCLI) -> None:
+    _commit(cli, "a\nb\nc")
+    cli.repo.write_file("f.txt", "aX\nb\ncX")
+
+    # Body lines (markers unnumbered): 1=-a 2=+aX 3= b 4=-c 5=+cX.
+    # Select the first change only; the no-newline tail must survive intact.
+    cli.run_ok("stage", _only_hunk_id(cli), "-l", "1,2")
+
+    assert cli.repo.git("show", ":f.txt") == "aX\nb\nc"
+
+    # The dropped change still carries its no-newline marker in the remainder.
+    remaining = cli.run_json("list", "--unstaged", "--json")
+    assert NO_NEWLINE_MARKER in remaining[0]["diff"]
+
+
+def test_list_counts_ignore_no_newline_marker(cli: GitHunkCLI) -> None:
+    _commit(cli, "a\nb\nc")
+    cli.repo.write_file("f.txt", "a\nb\ncX")
+
+    hunks = cli.run_json("list", "--unstaged", "--json")
+    assert hunks[0]["additions"] == 1
+    assert hunks[0]["deletions"] == 1

--- a/tests/unit/_hunk/no_newline_test.py
+++ b/tests/unit/_hunk/no_newline_test.py
@@ -1,0 +1,54 @@
+from git_hunk._hunk import NO_NEWLINE_MARKER
+from git_hunk._hunk import parse_diff
+
+_DIFF = (
+    "diff --git a/f.txt b/f.txt\n"
+    "index 1c943a9..5de31a1 100644\n"
+    "--- a/f.txt\n"
+    "+++ b/f.txt\n"
+    "@@ -1,3 +1,3 @@\n"
+    " a\n"
+    " b\n"
+    "-c\n"
+    f"{NO_NEWLINE_MARKER}\n"
+    "+cX\n"
+    f"{NO_NEWLINE_MARKER}\n"
+)
+
+
+def test_preserves_no_newline_marker_in_diff() -> None:
+    hunks = parse_diff(_DIFF)
+    assert len(hunks) == 1
+    assert hunks[0].diff.count(NO_NEWLINE_MARKER) == 2
+    assert hunks[0].diff.endswith(NO_NEWLINE_MARKER)
+
+
+def test_marker_not_counted_as_change() -> None:
+    hunks = parse_diff(_DIFF)
+    assert hunks[0].additions == 1
+    assert hunks[0].deletions == 1
+
+
+def test_split_keeps_marker_and_correct_counts() -> None:
+    # Two change regions far enough apart to split; the file ends with no
+    # newline, so the last sub-hunk must carry the marker without it leaking
+    # into the @@ line counts.
+    body = "".join(
+        [" line1\n", "-old\n", "+new\n"]
+        + [f" line{i}\n" for i in range(2, 10)]
+        + ["-last\n", f"{NO_NEWLINE_MARKER}\n", "+lastX\n", f"{NO_NEWLINE_MARKER}\n"]
+    )
+    diff = (
+        "diff --git a/f.txt b/f.txt\n"
+        "index 1c943a9..5de31a1 100644\n"
+        "--- a/f.txt\n"
+        "+++ b/f.txt\n"
+        "@@ -1,11 +1,11 @@\n" + body
+    )
+    hunks = parse_diff(diff)
+    assert len(hunks) == 2
+    tail = hunks[-1]
+    assert tail.diff.count(NO_NEWLINE_MARKER) == 2
+    assert tail.diff.endswith(NO_NEWLINE_MARKER)
+    # Marker lines must not inflate the @@ header line counts.
+    assert tail.header == "@@ -8,4 +8,4 @@"


### PR DESCRIPTION
Fixes #9.

Every `\ No newline at end of file` marker was dropped while parsing the diff, so the patch git-hunk rebuilt always claimed the file ended in a newline. Staging the last line of a no-newline file failed with `patch does not apply`, and a newline -> no-newline change reported success while silently staging nothing.

This preserves the markers end-to-end (parse -> hunk split -> built patch) and treats them as non-change, non-context lines so they never corrupt addition/deletion counts, hunk-header line counts, or split offsets. `show` line numbers and `-l` line selection skip markers consistently, and a marker is dropped only when its preceding line is.

A representational follow-up (model the marker as a property of its line rather than a free-floating body line) is tracked in #28.

## Test plan
- [x] e2e covers edit-last-line-no-newline, newline -> no-newline, no-newline -> newline, plus unstage/discard round-trips and `-l` selection: `tests/e2e/no_newline_test.py`
- [x] unit covers marker preservation, counts, and split offsets: `tests/unit/_hunk/no_newline_test.py`
- [x] `make lint` and `uv run pytest` (105 passed)
