### PR TITLE
fix: parse git's quoted and escaped file paths

### DIFF
--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -2,17 +2,12 @@ import subprocess
 
 
 def is_git_repo() -> bool:
-    result = subprocess.run(
-        ["git", "rev-parse", "--is-inside-work-tree"],
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout.strip() == "true"
+    return run_git("rev-parse", "--is-inside-work-tree", check=False).strip() == "true"
 
 
 def run_git(*args: str, input: str | None = None, check: bool = True) -> str:
     result = subprocess.run(
-        ["git"] + list(args),
+        ["git", "-c", "core.quotePath=false"] + list(args),
         capture_output=True,
         input=input.encode() if input is not None else None,
     )
@@ -34,8 +29,8 @@ def get_diff(staged: bool = False, files: list[str] | None = None) -> str:
 
 
 def get_untracked_files() -> list[str]:
-    output = run_git("ls-files", "--others", "--exclude-standard")
-    return [f for f in output.strip().split("\n") if f]
+    output = run_git("ls-files", "--others", "--exclude-standard", "-z")
+    return [f for f in output.split("\0") if f]
 
 
 def apply_patch(patch: str, *, cached: bool = False, reverse: bool = False) -> None:

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -182,6 +182,17 @@ def _split_hunk(
     return _build_sub_hunks(header_line, body_lines, regions, split_points)
 
 
+def extract_file_path(file_diff: str) -> str | None:
+    first_line = file_diff.split("\n", 1)[0]
+    # For non-renames git emits `diff --git a/<path> b/<path>` with both halves
+    # identical; the backreference resolves paths that contain " b/".
+    m = re.match(r"diff --git a/(.+) b/\1$", first_line)
+    if m:
+        return m.group(1)
+    m = re.match(r"diff --git a/(.*?) b/(.*)", first_line)
+    return m.group(2) if m else None
+
+
 def _extract_context_before(header: str) -> str:
     match = re.search(r"@@.*@@\s*(.*)", header)
     return match.group(1).strip() if match and match.group(1).strip() else ""
@@ -198,10 +209,9 @@ def parse_diff(diff_output: str) -> list[Hunk]:
         if not file_diff.strip():
             continue
 
-        m = re.match(r"diff --git a/(.*?) b/(.*)", file_diff)
-        if not m:
+        filepath = extract_file_path(file_diff)
+        if filepath is None:
             continue
-        filepath = m.group(2)
 
         if re.search(r"^Binary files .* differ$", file_diff, flags=re.MULTILINE):
             hunks.append(

--- a/git_hunk/_patch.py
+++ b/git_hunk/_patch.py
@@ -1,13 +1,13 @@
 import re
 
 from ._hunk import Hunk
+from ._hunk import extract_file_path
 
 
 def _get_file_header(diff_output: str, filepath: str) -> str:
     file_diffs = re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE)
     for file_diff in file_diffs:
-        m = re.match(r"diff --git a/(.*?) b/(.*)", file_diff)
-        if m and m.group(2) == filepath:
+        if extract_file_path(file_diff) == filepath:
             # Return everything up to the first @@ line
             parts = re.split(r"(?=^@@)", file_diff, flags=re.MULTILINE)
             return parts[0]

--- a/tests/e2e/quoted_paths_test.py
+++ b/tests/e2e/quoted_paths_test.py
@@ -1,0 +1,54 @@
+from .conftest import GitHunkCLI
+
+
+def _hunk_id_for(cli: GitHunkCLI, path: str) -> str:
+    hunks = cli.run_json("list", "--unstaged", "--json")
+    return next(h["id"] for h in hunks if h["file"] == path)
+
+
+def test_non_ascii_modified_file_round_trips(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("файл.txt", "a\nb\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("файл.txt", "a\nB\n")
+
+    cli.run_ok("stage", _hunk_id_for(cli, "файл.txt"))
+    assert cli.repo.git("show", ":файл.txt") == "a\nB\n"
+
+    staged = cli.run_json("list", "--staged", "--json")
+    cli.run_ok("unstage", staged[0]["id"])
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+    cli.run_ok("discard", _hunk_id_for(cli, "файл.txt"))
+    assert cli.repo.git("diff").strip() == ""
+
+
+def test_non_ascii_untracked_shows_real_path(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("keep.txt", "x\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("untrack𝟙.txt", "new\n")
+
+    hunks = cli.run_json("list", "--json")
+    untracked = [h for h in hunks if h["status"] == "untracked"]
+    assert [h["file"] for h in untracked] == ["untrack𝟙.txt"]
+
+
+def test_filename_with_b_slash_substring_stages(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("a b/c.txt", "x\ny\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("a b/c.txt", "x\nY\n")
+
+    hunks = cli.run_json("list", "--unstaged", "--json")
+    assert [h["file"] for h in hunks] == ["a b/c.txt"]
+
+    cli.run_ok("stage", _hunk_id_for(cli, "a b/c.txt"))
+    assert cli.repo.git("show", ":a b/c.txt") == "x\nY\n"
+
+    staged = cli.run_json("list", "--staged", "--json")
+    cli.run_ok("unstage", staged[0]["id"])
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+    cli.run_ok("discard", _hunk_id_for(cli, "a b/c.txt"))
+    assert cli.repo.git("diff").strip() == ""

--- a/tests/unit/_hunk/extract_file_path_test.py
+++ b/tests/unit/_hunk/extract_file_path_test.py
@@ -1,0 +1,45 @@
+from git_hunk._hunk import extract_file_path
+from git_hunk._hunk import parse_diff
+
+
+def test_plain_path() -> None:
+    assert extract_file_path("diff --git a/src/foo.py b/src/foo.py") == "src/foo.py"
+
+
+def test_non_ascii_path_unquoted() -> None:
+    assert extract_file_path("diff --git a/файл.txt b/файл.txt") == "файл.txt"
+
+
+def test_path_containing_b_slash_substring() -> None:
+    line = "diff --git a/a b/c.txt b/a b/c.txt"
+    assert extract_file_path(line) == "a b/c.txt"
+
+
+def test_uses_only_the_first_line() -> None:
+    file_diff = (
+        "diff --git a/файл.txt b/файл.txt\n"
+        "index 422c2b7..55dce13 100644\n"
+        "--- a/файл.txt\n"
+        "+++ b/файл.txt\n"
+    )
+    assert extract_file_path(file_diff) == "файл.txt"
+
+
+def test_no_match_returns_none() -> None:
+    assert extract_file_path("index abc..def 100644") is None
+
+
+def test_parse_diff_uses_b_slash_path() -> None:
+    diff = (
+        "diff --git a/a b/c.txt b/a b/c.txt\n"
+        "index b77b4eb..7061c57 100644\n"
+        "--- a/a b/c.txt\t\n"
+        "+++ b/a b/c.txt\t\n"
+        "@@ -1,2 +1,2 @@\n"
+        " x\n"
+        "-y\n"
+        "+Y\n"
+    )
+    hunks = parse_diff(diff)
+    assert len(hunks) == 1
+    assert hunks[0].file == "a b/c.txt"


### PR DESCRIPTION
Fixes #10.

With git's default `core.quotePath=true`, non-ASCII file paths are octal-escaped and double-quoted in diff headers (`diff --git "a/\321\204..." "b/..."`) and in `git ls-files` output. git-hunk's path regex expected a bare `a/...`, so it failed to match and silently dropped the whole file from `list`/`stage`. A filename containing the literal substring ` b/` was also mis-split by the non-greedy regex.

## Summary
- Force `core.quotePath=false` on every git invocation (via `run_git`) so paths arrive literally, and read untracked paths NUL-delimited (`-z`).
- Add a shared `extract_file_path` helper used by both `parse_diff` and the patch builder. It anchors on the fact that the two halves of `diff --git a/<p> b/<p>` are identical for non-renames (backreference `a/(.+) b/\1$`), so a path containing ` b/` splits correctly; a non-greedy fallback preserves prior behavior for the rename case.
- Route `is_git_repo` through `run_git` so all git calls share one invocation path.

## Known limitations / follow-ups
- Non-UTF-8 byte paths still need surrogateescape decode/encode — tracked in #11.
- Filenames containing tab/newline/backslash/quote are always quoted by git regardless of `core.quotePath`, so they remain unparsed — tracked in #30.

## Test plan
- [x] e2e: non-ASCII modified file round-trips (stage/unstage/discard), non-ASCII untracked shows its real path in `list`/`--json`, and a ` b/`-containing path round-trips: `tests/e2e/quoted_paths_test.py`
- [x] unit: `extract_file_path` for plain, non-ASCII, and ` b/` paths: `tests/unit/_hunk/extract_file_path_test.py`
- [x] `make lint` and `uv run pytest` (104 passed)
