### PR TITLE
fix: handle non-UTF-8 bytes in git output without crashing

### DIFF
--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -6,16 +6,18 @@ def is_git_repo() -> bool:
 
 
 def run_git(*args: str, input: str | None = None, check: bool = True) -> str:
+    # Git output and input may contain bytes that are not valid UTF-8 (e.g. a
+    # Latin-1 source file). surrogateescape round-trips those bytes losslessly
+    # so a rebuilt patch hands git back exactly what it emitted.
     result = subprocess.run(
         ["git", "-c", "core.quotePath=false"] + list(args),
         capture_output=True,
-        input=input.encode() if input is not None else None,
+        input=input.encode(errors="surrogateescape") if input is not None else None,
     )
     if check and result.returncode != 0:
-        raise RuntimeError(
-            f"git {' '.join(args)} failed: {result.stderr.decode().strip()}"
-        )
-    return result.stdout.decode()
+        stderr = result.stderr.decode(errors="surrogateescape").strip()
+        raise RuntimeError(f"git {' '.join(args)} failed: {stderr}")
+    return result.stdout.decode(errors="surrogateescape")
 
 
 def get_diff(staged: bool = False, files: list[str] | None = None) -> str:

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -48,12 +48,15 @@ def _body_id(filepath: str, diff_content: str) -> str:
     body = "\n".join(
         line for line in diff_content.split("\n") if not line.startswith("@@")
     )
-    return hashlib.sha256(f"{filepath}:{body}".encode()).hexdigest()[:7]
+    # surrogateescape mirrors _git.run_git's decode so non-UTF-8 bytes hash.
+    data = f"{filepath}:{body}".encode(errors="surrogateescape")
+    return hashlib.sha256(data).hexdigest()[:7]
 
 
 def _full_id(filepath: str, diff_content: str) -> str:
     """Fallback for identical changed lines — includes @@ line numbers."""
-    return hashlib.sha256(f"{filepath}:{diff_content}".encode()).hexdigest()[:7]
+    data = f"{filepath}:{diff_content}".encode(errors="surrogateescape")
+    return hashlib.sha256(data).hexdigest()[:7]
 
 
 def _with_stable_ids(hunks: list[Hunk]) -> list[Hunk]:

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -28,6 +28,13 @@ def _err() -> Console:
     return Console(stderr=True, highlight=False)
 
 
+def _safe(text: str) -> str:
+    # git output decoded with surrogateescape (see _git.run_git) may carry lone
+    # surrogates for non-UTF-8 bytes; backslash-escape them so writing to a
+    # strict stdout does not raise UnicodeEncodeError.
+    return text.encode("utf-8", errors="backslashreplace").decode("utf-8")
+
+
 def _append_stats(text: Text, hunk: Hunk) -> None:
     if hunk.additions:
         text.append(f"+{hunk.additions}", style="green")
@@ -42,9 +49,9 @@ def _print_hunk_line(out: Console, hunk: Hunk) -> None:
     line.append("  ")
     line.append(hunk.id, style="cyan")
     line.append("  ")
-    line.append(hunk.header, style="dim")
+    line.append(_safe(hunk.header), style="dim")
     if hunk.context_before:
-        line.append(f"  {hunk.context_before}", style="dim italic")
+        line.append(f"  {_safe(hunk.context_before)}", style="dim italic")
     line.append("  ")
     _append_stats(line, hunk)
     out.print(line)
@@ -53,7 +60,7 @@ def _print_hunk_line(out: Console, hunk: Hunk) -> None:
 def _print_file_group(
     out: Console, filepath: str, file_hunks: list[Hunk], *, color: str
 ) -> None:
-    out.print(f"[{color}]{escape(filepath)}[/{color}]")
+    out.print(f"[{color}]{escape(_safe(filepath))}[/{color}]")
     for hunk in file_hunks:
         _print_hunk_line(out, hunk)
 
@@ -78,7 +85,7 @@ def _print_status_section(
             if i < len(by_file) - 1:
                 out.print()
         else:
-            out.print(f"[{color}]{escape(filepath)}[/{color}]")
+            out.print(f"[{color}]{escape(_safe(filepath))}[/{color}]")
 
 
 def print_hunk_list(hunks: list[Hunk]) -> None:
@@ -109,11 +116,11 @@ def print_hunk_list(hunks: list[Hunk]) -> None:
 
 
 def _print_hunk_diff(out: Console, hunk: Hunk) -> None:
-    out.print(f"[bold]{escape(hunk.file)}[/bold]  [dim]{escape(hunk.id)}[/dim]")
+    out.print(f"[bold]{escape(_safe(hunk.file))}[/bold]  [dim]{escape(hunk.id)}[/dim]")
     line_num = 0
     for line in hunk.diff.split("\n"):
         if line.startswith("@@"):
-            out.print(Text(line, style="cyan"))
+            out.print(Text(_safe(line), style="cyan"))
         elif is_no_newline_marker(line):
             out.print(Text("    " + line, style="dim"))
         else:
@@ -125,7 +132,7 @@ def _print_hunk_diff(out: Console, hunk: Hunk) -> None:
                 style = "red"
             else:
                 style = ""
-            out.print(Text.assemble(prefix, Text(line, style=style)))
+            out.print(Text.assemble(prefix, Text(_safe(line), style=style)))
 
 
 def print_skill_list(skills: list[Skill]) -> None:
@@ -156,10 +163,10 @@ def print_applied(hunks: list[Hunk], *, verb: str) -> None:
         line.append(f"  {verb} ", style="bold green")
         line.append(hunk.id, style="cyan")
         line.append("  ")
-        line.append(hunk.file, style="bold")
-        line.append(f"  {hunk.header}", style="dim")
+        line.append(_safe(hunk.file), style="bold")
+        line.append(f"  {_safe(hunk.header)}", style="dim")
         if hunk.context_before:
-            line.append(f"  {hunk.context_before}", style="dim italic")
+            line.append(f"  {_safe(hunk.context_before)}", style="dim italic")
         line.append("  ")
         _append_stats(line, hunk)
         err.print(line)
@@ -172,9 +179,9 @@ def print_error(
     usage: str | None = None,
 ) -> None:
     err = _err()
-    err.print(f"[bold red]error[/bold red]: {escape(msg)}")
+    err.print(f"[bold red]error[/bold red]: {escape(_safe(msg))}")
     if tip:
-        err.print(f"\n  [green]tip[/green]: {escape(tip)}")
+        err.print(f"\n  [green]tip[/green]: {escape(_safe(tip))}")
     if usage:
         err.print(f"\n{usage}")
         err.print("\nFor more information, try '[bold cyan]--help[/bold cyan]'.")

--- a/tests/e2e/non_utf8_test.py
+++ b/tests/e2e/non_utf8_test.py
@@ -1,0 +1,43 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from .conftest import GitHunkCLI
+
+# 0xe9 is "é" in Latin-1 and an invalid standalone UTF-8 byte.
+_BEFORE = b"pass\xe9\nline2\n"
+_AFTER = b"pass\xe9\nLINE2\n"
+
+
+@pytest.fixture
+def latin1_repo(cli: GitHunkCLI) -> GitHunkCLI:
+    path = Path(cli.repo.path) / "latin1.txt"
+    path.write_bytes(_BEFORE)
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    path.write_bytes(_AFTER)
+    return cli
+
+
+def test_list_does_not_crash_on_non_utf8_content(latin1_repo: GitHunkCLI) -> None:
+    hunks = latin1_repo.run_json("list", "--unstaged", "--json")
+    assert [h["file"] for h in hunks] == ["latin1.txt"]
+
+    latin1_repo.run_ok("list", "--unstaged")
+
+
+def test_show_does_not_crash_on_non_utf8_content(latin1_repo: GitHunkCLI) -> None:
+    latin1_repo.run_ok("show", "--unstaged")
+
+
+def test_stage_preserves_non_utf8_bytes(latin1_repo: GitHunkCLI) -> None:
+    hunk_id = latin1_repo.run_json("list", "--unstaged", "--json")[0]["id"]
+    latin1_repo.run_ok("stage", hunk_id)
+
+    staged = subprocess.run(
+        ["git", "show", ":latin1.txt"],
+        capture_output=True,
+        cwd=latin1_repo.repo.path,
+    ).stdout
+    assert staged == _AFTER

--- a/tests/unit/_ui/safe_test.py
+++ b/tests/unit/_ui/safe_test.py
@@ -1,0 +1,17 @@
+from git_hunk._ui import _safe
+
+
+def test_identity_on_ascii() -> None:
+    assert _safe("hello world") == "hello world"
+
+
+def test_identity_on_valid_utf8() -> None:
+    assert _safe("café — π") == "café — π"
+
+
+def test_surrogates_become_strict_utf8_encodable() -> None:
+    # 0xe9 decoded with surrogateescape becomes the lone surrogate U+DCE9.
+    result = _safe("a\udce9b")
+    # The point of _safe: the result can be written to a strict UTF-8 stream.
+    result.encode("utf-8")
+    assert "\udce9" not in result


### PR DESCRIPTION
Fixes #11.

A diff containing bytes that are not valid UTF-8 (e.g. a Latin-1 source file) crashed git-hunk with an uncaught `UnicodeDecodeError` traceback at `result.stdout.decode()`.

## Summary
- Decode and encode git's stdin/stdout/stderr with `errors="surrogateescape"` so undecodable bytes round-trip losslessly: the rebuilt patch hands `git apply` exactly the bytes git emitted.
- Hash hunk ids with the same handler so id computation does not crash on the resulting surrogate code points.
- Backslash-escape surrogates for display (`list`, `show`, the applied message, and error output) so they never crash the Rich layer with `UnicodeEncodeError`, while patch building keeps the raw bytes.

## Known limitation
- `list --json` emits surrogates as `\udcXX` escapes (lone surrogates), which Python's `json` round-trips but stricter parsers reject. The right place to settle the JSON byte representation is the schema work in #23, so it's deliberately out of scope here.

## Test plan
- [x] e2e: `list`, `show`, and `stage` on a repo with non-UTF-8 file content exit 0; staging applies the original bytes unchanged (`git show :file` byte-compare): `tests/e2e/non_utf8_test.py`
- [x] unit: `_safe` is identity on valid text and makes surrogate-bearing strings strict-UTF-8 encodable: `tests/unit/_ui/safe_test.py`
- [x] `make lint` and `uv run pytest` (101 passed)
