### PR TITLE
fix: apply partial -l selection correctly for unstage and discard

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -109,14 +109,16 @@ def _find_hunks_by_ids(hunks: list[Hunk], ids: list[str]) -> list[Hunk]:
     return found
 
 
-def _apply_line_filter(hunks: list[Hunk], line_spec: str | None) -> list[Hunk]:
+def _apply_line_filter(
+    hunks: list[Hunk], line_spec: str | None, *, reverse: bool
+) -> list[Hunk]:
     if line_spec is None:
         return hunks
     if len(hunks) != 1:
         raise CliError("line selection (-l) requires exactly one hunk id")
     try:
         lines, exclude = parse_line_spec(line_spec)
-        return [filter_hunk_lines(hunks[0], lines, exclude=exclude)]
+        return [filter_hunk_lines(hunks[0], lines, exclude=exclude, reverse=reverse)]
     except ValueError as exc:
         raise CliError(str(exc)) from exc
 
@@ -144,7 +146,7 @@ def _run_patch_command(
 
     hunks, diff_output = _get_hunks(staged=staged)
     selected = _find_hunks_by_ids(hunks, ids)
-    selected = _apply_line_filter(selected, line_spec)
+    selected = _apply_line_filter(selected, line_spec, reverse=reverse)
 
     binary = [h for h in selected if _is_binary_hunk(h)]
     text = [h for h in selected if not _is_binary_hunk(h)]

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -56,7 +56,15 @@ def parse_line_spec(spec: str) -> tuple[set[int], bool]:
 def _filter_body_lines(
     body: list[str],
     selected: set[int],
+    *,
+    reverse: bool,
 ) -> list[str]:
+    # Unselected changes must survive as context in the form the apply direction
+    # expects. A forward (stage) apply matches OLD content, so unselected '-'
+    # lines become context and unselected '+' lines drop; a reverse (unstage,
+    # discard) apply matches NEW content, so the two sides swap.
+    drop_prefix = "-" if reverse else "+"
+    keep_prefix = "+" if reverse else "-"
     new_body = []
     line_num = 0
     prev_kept = False
@@ -69,9 +77,9 @@ def _filter_body_lines(
         if line_num in selected:
             new_body.append(line)
             prev_kept = True
-        elif line.startswith("+"):
+        elif line.startswith(drop_prefix):
             prev_kept = False
-        elif line.startswith("-"):
+        elif line.startswith(keep_prefix):
             new_body.append(" " + line[1:])
             prev_kept = True
         else:
@@ -80,11 +88,15 @@ def _filter_body_lines(
     return new_body
 
 
-def filter_hunk_lines(hunk: Hunk, lines: set[int], *, exclude: bool) -> Hunk:
+def filter_hunk_lines(
+    hunk: Hunk, lines: set[int], *, exclude: bool, reverse: bool = False
+) -> Hunk:
     """Return a new Hunk with only the selected lines as changes.
 
-    Unselected '+' lines are removed; unselected '-' lines become context.
-    This matches git add -p edit mode semantics.
+    Unselected changes on the side the apply consumes become context; the other
+    side drops. A forward apply keeps unselected '-' lines and drops '+';
+    reverse=True (unstage, discard) swaps those so the patch applies against the
+    NEW content the index or working tree already holds.
     """
     diff_lines = hunk.diff.split("\n")
     header = diff_lines[0]
@@ -105,7 +117,7 @@ def filter_hunk_lines(hunk: Hunk, lines: set[int], *, exclude: bool) -> Hunk:
     else:
         selected = lines
 
-    new_body = _filter_body_lines(body, selected)
+    new_body = _filter_body_lines(body, selected, reverse=reverse)
 
     additions, deletions = count_changes(new_body)
     if additions == 0 and deletions == 0:

--- a/tests/e2e/line_selection_test.py
+++ b/tests/e2e/line_selection_test.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import pytest
+
+from .conftest import GitHunkCLI
+
+# HEAD "a b c d" -> working "a B c D": one hunk, two change groups.
+# Body line numbers: 1=" a" 2="-b" 3="+B" 4=" c" 5="-d" 6="+D".
+# Group A = lines 2,3 (b->B); group B = lines 5,6 (d->D).
+
+
+@pytest.fixture
+def two_group(cli: GitHunkCLI) -> GitHunkCLI:
+    cli.repo.write_file("f.txt", "a\nb\nc\nd\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "a\nB\nc\nD\n")
+    return cli
+
+
+def _only_id(cli: GitHunkCLI, *flags: str) -> str:
+    hunks = cli.run_json("list", *flags, "--json")
+    assert len(hunks) == 1
+    return hunks[0]["id"]
+
+
+def _working(cli: GitHunkCLI) -> str:
+    return (Path(cli.repo.path) / "f.txt").read_text()
+
+
+def test_stage_include_first_group(two_group: GitHunkCLI) -> None:
+    two_group.run_ok("stage", _only_id(two_group, "--unstaged"), "-l", "2,3")
+    assert two_group.repo.git("show", ":f.txt") == "a\nB\nc\nd\n"
+
+
+def test_stage_exclude_first_group(two_group: GitHunkCLI) -> None:
+    two_group.run_ok("stage", _only_id(two_group, "--unstaged"), "-l", "^2,^3")
+    assert two_group.repo.git("show", ":f.txt") == "a\nb\nc\nD\n"
+
+
+def test_unstage_include_first_group(two_group: GitHunkCLI) -> None:
+    two_group.run_ok("stage", _only_id(two_group, "--unstaged"))
+    two_group.run_ok("unstage", _only_id(two_group, "--staged"), "-l", "2,3")
+    assert two_group.repo.git("show", ":f.txt") == "a\nb\nc\nD\n"
+
+
+def test_unstage_exclude_first_group(two_group: GitHunkCLI) -> None:
+    two_group.run_ok("stage", _only_id(two_group, "--unstaged"))
+    two_group.run_ok("unstage", _only_id(two_group, "--staged"), "-l", "^2,^3")
+    assert two_group.repo.git("show", ":f.txt") == "a\nB\nc\nd\n"
+
+
+def test_discard_include_first_group(two_group: GitHunkCLI) -> None:
+    two_group.run_ok("discard", _only_id(two_group, "--unstaged"), "-l", "2,3")
+    assert _working(two_group) == "a\nb\nc\nD\n"
+
+
+def test_discard_exclude_first_group(two_group: GitHunkCLI) -> None:
+    two_group.run_ok("discard", _only_id(two_group, "--unstaged"), "-l", "^2,^3")
+    assert _working(two_group) == "a\nB\nc\nd\n"
+
+
+def test_full_round_trip(two_group: GitHunkCLI) -> None:
+    two_group.run_ok("stage", _only_id(two_group, "--unstaged"), "-l", "2,3")
+    assert two_group.repo.git("show", ":f.txt") == "a\nB\nc\nd\n"
+
+    two_group.run_ok("stage", _only_id(two_group, "--unstaged"))
+    assert two_group.repo.git("show", ":f.txt") == "a\nB\nc\nD\n"
+
+    two_group.run_ok("unstage", _only_id(two_group, "--staged"), "-l", "2,3")
+    assert two_group.repo.git("show", ":f.txt") == "a\nb\nc\nD\n"
+
+    two_group.run_ok("discard", _only_id(two_group, "--unstaged"), "-l", "2,3")
+    assert _working(two_group) == "a\nb\nc\nD\n"

--- a/tests/unit/_lines/filter_test.py
+++ b/tests/unit/_lines/filter_test.py
@@ -84,3 +84,29 @@ def test_mixed_changes() -> None:
     assert "+new1" in result.diff
     assert " old" in result.diff
     assert "new2" not in result.diff
+
+
+_TWO_GROUP = "@@ -1,4 +1,4 @@\n a\n-b\n+B\n c\n-d\n+D"
+
+
+def test_reverse_include_drops_unselected_deletion_keeps_addition() -> None:
+    # Reverse (unstage/discard): unselected '+' becomes context, '-' drops.
+    hunk = _make_hunk(_TWO_GROUP)
+    result = filter_hunk_lines(hunk, {2, 3}, exclude=False, reverse=True)
+    assert result.additions == 1
+    assert result.deletions == 1
+    assert "-b" in result.diff
+    assert "+B" in result.diff
+    assert " D" in result.diff  # unselected +D kept as NEW context
+    assert "-d" not in result.diff  # unselected -d dropped
+
+
+def test_reverse_exclude_first_group() -> None:
+    hunk = _make_hunk(_TWO_GROUP)
+    result = filter_hunk_lines(hunk, {2, 3}, exclude=True, reverse=True)
+    assert result.additions == 1
+    assert result.deletions == 1
+    assert "-d" in result.diff
+    assert "+D" in result.diff
+    assert " B" in result.diff  # excluded +B kept as NEW context
+    assert "-b" not in result.diff  # excluded -b dropped


### PR DESCRIPTION
Fixes #12.

`git-hunk unstage <id> -l <subset>` and `discard <id> -l <subset>` failed with `patch does not apply` whenever the hunk had more than one change group. The line filter always converted unselected `-` lines into context carrying the OLD content, which only matches a forward (stage) apply; unstage and discard reverse-apply against content that already holds the NEW side, so the context did not match.

## Summary
- Make the line filter direction-aware: a forward apply keeps unselected `-` lines as context and drops `+`, while a reverse apply (unstage, discard) keeps unselected `+` as context and drops `-`.
- Thread a `reverse` flag from `_run_patch_command` through `_apply_line_filter` to `filter_hunk_lines`. Forward (`stage`) behavior is byte-identical to before.

## Test plan
- [x] e2e: multi-group hunk for stage/unstage/discard with both include and exclude (`^`) specs, plus a full `stage -l A` → `stage` remainder → `unstage -l A` → `discard -l A` round-trip: `tests/e2e/line_selection_test.py`
- [x] unit: `filter_hunk_lines(..., reverse=True)` include and exclude keep the NEW side as context and drop the OLD side: `tests/unit/_lines/filter_test.py`
- [x] `make lint` and `uv run pytest` (104 passed)
