### PR TITLE
fix: escape user-controlled text in Rich console output

### DIFF
--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from typing import Final
 
 from rich.console import Console
+from rich.markup import escape
 from rich.rule import Rule
 from rich.text import Text
 
@@ -51,7 +52,7 @@ def _print_hunk_line(out: Console, hunk: Hunk) -> None:
 def _print_file_group(
     out: Console, filepath: str, file_hunks: list[Hunk], *, color: str
 ) -> None:
-    out.print(f"[{color}]{filepath}[/{color}]")
+    out.print(f"[{color}]{escape(filepath)}[/{color}]")
     for hunk in file_hunks:
         _print_hunk_line(out, hunk)
 
@@ -76,7 +77,7 @@ def _print_status_section(
             if i < len(by_file) - 1:
                 out.print()
         else:
-            out.print(f"[{color}]{filepath}[/{color}]")
+            out.print(f"[{color}]{escape(filepath)}[/{color}]")
 
 
 def print_hunk_list(hunks: list[Hunk]) -> None:
@@ -107,7 +108,7 @@ def print_hunk_list(hunks: list[Hunk]) -> None:
 
 
 def _print_hunk_diff(out: Console, hunk: Hunk) -> None:
-    out.print(f"[bold]{hunk.file}[/bold]  [dim]{hunk.id}[/dim]")
+    out.print(f"[bold]{escape(hunk.file)}[/bold]  [dim]{escape(hunk.id)}[/dim]")
     line_num = 0
     for line in hunk.diff.split("\n"):
         if line.startswith("@@"):
@@ -168,9 +169,9 @@ def print_error(
     usage: str | None = None,
 ) -> None:
     err = _err()
-    err.print(f"[bold red]error[/bold red]: {msg}")
+    err.print(f"[bold red]error[/bold red]: {escape(msg)}")
     if tip:
-        err.print(f"\n  [green]tip[/green]: {tip}")
+        err.print(f"\n  [green]tip[/green]: {escape(tip)}")
     if usage:
         err.print(f"\n{usage}")
         err.print("\nFor more information, try '[bold cyan]--help[/bold cyan]'.")

--- a/tests/e2e/markup_test.py
+++ b/tests/e2e/markup_test.py
@@ -1,0 +1,44 @@
+import pytest
+
+from .conftest import GitHunkCLI
+
+# A path like a Next.js/SvelteKit route; the brackets must not be read as Rich
+# markup tags.
+_PATH = "src/[id].tsx"
+
+
+@pytest.fixture
+def bracket_repo(cli: GitHunkCLI) -> GitHunkCLI:
+    cli.repo.write_file(_PATH, "a\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file(_PATH, "A\n")
+    return cli
+
+
+def test_list_renders_bracketed_path_verbatim(bracket_repo: GitHunkCLI) -> None:
+    assert _PATH in bracket_repo.run_ok("list")
+
+
+def test_show_renders_bracketed_path_verbatim(bracket_repo: GitHunkCLI) -> None:
+    assert _PATH in bracket_repo.run_ok("show")
+
+
+def test_list_renders_bracketed_untracked_path_verbatim(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("keep.txt", "x\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file(_PATH, "new\n")  # left untracked
+
+    assert _PATH in cli.run_ok("list")
+
+
+def test_error_renders_bracketed_value_verbatim(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.txt", "a\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "A\n")
+
+    r = cli.run("stage", "[bogus]")
+    assert r.returncode != 0
+    assert "hunk '[bogus]' not found" in r.stderr

--- a/tests/unit/_ui/print_error_test.py
+++ b/tests/unit/_ui/print_error_test.py
@@ -1,0 +1,13 @@
+import pytest
+
+from git_hunk._ui import print_error
+
+
+def test_escapes_brackets_in_message(capsys: pytest.CaptureFixture[str]) -> None:
+    print_error("hunk '[id]' not found")
+    assert "[id]" in capsys.readouterr().err
+
+
+def test_escapes_brackets_in_tip(capsys: pytest.CaptureFixture[str]) -> None:
+    print_error("not found", tip="try [foo] instead")
+    assert "[foo]" in capsys.readouterr().err


### PR DESCRIPTION
Fixes #14.

File paths and error text were interpolated straight into Rich markup strings, so a path like `src/[id].tsx` had its `[id]` token swallowed as an unknown markup tag and dropped. The same hazard applied to error/tip messages carrying user-supplied hunk IDs, skill names, and subcommand names.

## Summary
- Wrap every user-controlled value rendered through a Rich markup string with `rich.markup.escape`: tracked and untracked file listings, the `show` file header, and `print_error` msg/tip.
- Trusted markup constants (the `USAGE_*` strings, section headers) are deliberately left unescaped. `Text.append`/`Text(...)` sites (hunk diff bodies, the applied message) were already markup-safe and are untouched.

## Test plan
- [x] e2e: `list` and `show` render `src/[id].tsx` verbatim (tracked and untracked), and an error referencing `[bogus]` prints it literally: `tests/e2e/markup_test.py`
- [x] unit: `print_error` escapes brackets in both message and tip: `tests/unit/_ui/print_error_test.py`
- [x] `make lint` and `uv run pytest` (101 passed)
