### PR TITLE
fix: harden CLI input validation for empty ids and bad -l specs

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -92,6 +92,8 @@ def _get_hunks(staged: bool, files: list[str] | None = None) -> tuple[list[Hunk]
 def _find_hunks_by_ids(hunks: list[Hunk], ids: list[str]) -> list[Hunk]:
     found = []
     for hunk_id in ids:
+        if not hunk_id.strip():
+            raise CliError("hunk id must not be empty or whitespace")
         matches = [h for h in hunks if h.id.startswith(hunk_id)]
         if len(matches) == 0:
             available = [h.id for h in hunks]

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -5,6 +5,16 @@ from ._hunk import Hunk
 from ._hunk import count_changes
 
 
+def _parse_line_number(token: str) -> int:
+    token = token.strip()
+    if not re.fullmatch(r"[0-9]+", token):
+        raise ValueError(f"invalid line number: '{token}'")
+    n = int(token)
+    if n < 1:
+        raise ValueError(f"line numbers must be positive: '{token}'")
+    return n
+
+
 def parse_line_spec(spec: str) -> tuple[set[int], bool]:
     """Parse "-l" value into (line_numbers, exclude_mode).
 
@@ -25,19 +35,19 @@ def parse_line_spec(spec: str) -> tuple[set[int], bool]:
 
     for part in parts:
         raw = part.lstrip("^")
+        if not raw:
+            raise ValueError(f"invalid token in -l spec: '{part}'")
         if "-" in raw:
-            lo_s, hi_s = raw.split("-", 1)
-            lo, hi = int(lo_s), int(hi_s)
-            if lo < 1 or hi < 1:
-                raise ValueError(f"line numbers must be positive: {part}")
+            bounds = raw.split("-")
+            if len(bounds) != 2 or not all(b.strip() for b in bounds):
+                raise ValueError(f"invalid range: '{part}' (expected start-end)")
+            lo = _parse_line_number(bounds[0])
+            hi = _parse_line_number(bounds[1])
             if lo > hi:
                 raise ValueError(f"invalid range (start > end): {part}")
             lines.update(range(lo, hi + 1))
         else:
-            n = int(raw)
-            if n < 1:
-                raise ValueError(f"line numbers must be positive: {part}")
-            lines.add(n)
+            lines.add(_parse_line_number(raw))
 
     return lines, exclude
 

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -56,6 +56,43 @@ def test_stage_nonexistent_hunk(cli: GitHunkCLI) -> None:
     assert "not found" in r.stderr
 
 
+def test_empty_hunk_id_rejected(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "new\n")
+
+    r = cli.run("discard", "")
+    assert r.returncode != 0
+    assert "must not be empty" in r.stderr
+    # The empty id must never match a hunk: the change is left untouched.
+    assert cli.repo.git("diff").strip() != ""
+
+
+def test_empty_hunk_id_rejected_on_show(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "new\n")
+
+    r = cli.run("show", "")
+    assert r.returncode != 0
+    assert "must not be empty" in r.stderr
+
+
+def test_malformed_line_spec_rejected(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "a\nb\nc\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "A\nb\nC\n")
+
+    hunk_id = cli.run_json("list", "--unstaged", "--json")[0]["id"]
+    r = cli.run("stage", hunk_id, "-l", "1-2-3")
+    assert r.returncode != 0
+    assert "1-2-3" in r.stderr
+    assert "expected start-end" in r.stderr  # readable message, not raw int() error
+
+
 def test_line_spec_with_multiple_hunks_fails(cli: GitHunkCLI) -> None:
     lines = [f"line{i}" for i in range(1, 21)]
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")

--- a/tests/unit/_lines/parse_spec_test.py
+++ b/tests/unit/_lines/parse_spec_test.py
@@ -57,3 +57,34 @@ def test_non_positive_errors() -> None:
 def test_reversed_range_errors() -> None:
     with pytest.raises(ValueError, match="start > end"):
         parse_line_spec("5-3")
+
+
+def test_range_with_too_many_parts_errors() -> None:
+    with pytest.raises(ValueError, match="expected start-end"):
+        parse_line_spec("1-2-3")
+
+
+def test_non_numeric_token_errors() -> None:
+    with pytest.raises(ValueError, match="invalid line number"):
+        parse_line_spec("abc")
+
+
+def test_open_ended_range_errors() -> None:
+    with pytest.raises(ValueError, match="expected start-end"):
+        parse_line_spec("1-")
+
+
+def test_bare_caret_errors() -> None:
+    with pytest.raises(ValueError, match="invalid token"):
+        parse_line_spec("^")
+
+
+def test_plus_prefixed_token_errors() -> None:
+    with pytest.raises(ValueError, match="invalid line number"):
+        parse_line_spec("+5")
+
+
+def test_spaces_around_range_hyphen_allowed() -> None:
+    lines, exclude = parse_line_spec("2 - 4")
+    assert lines == {2, 3, 4}
+    assert exclude is False


### PR DESCRIPTION
Fixes #15.

Two CLI argument footguns:

1. An empty-string hunk id matched **every** hunk, because prefix matching uses `startswith("")` which is always true — so `git-hunk discard ""` (e.g. from an unset shell variable) silently operated on a hunk the user never named.
2. A malformed `-l` range like `1-2-3` surfaced a raw Python `invalid literal for int()` message.

## Summary
- Reject empty/whitespace-only hunk ids in `_find_hunks_by_ids` before the prefix match runs (covers stage/unstage/discard/show).
- Validate `-l` tokens through a `_parse_line_number` helper (strict positive decimal) and require a range to have exactly two non-empty bounds, so malformed specs produce a readable error naming the offending token. Spaces around a hyphen (`2 - 4`) are still accepted.

## Test plan
- [x] unit: malformed `-l` specs (`1-2-3`, `abc`, `1-`, `+5`, bare `^`) error readably; `2 - 4` still parses: `tests/unit/_lines/parse_spec_test.py`
- [x] e2e: `discard ""` and `show ""` are rejected and never match a hunk; `-l 1-2-3` gives a readable error (not a raw `int()` message): `tests/e2e/error_test.py`
- [x] `make lint` and `uv run pytest` (104 passed)
