### PR TITLE
build: constrain sdist to the package, tests, and metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ replacement = '![\1](https://raw.githubusercontent.com/wkentaro/git-hunk/main/\2
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build.targets.sdist]
+# pyproject.toml and LICENSE are auto-included; README.md is not, because the
+# readme is dynamic (hatch-fancy-pypi-readme) and the wheel build needs it.
+include = ["/README.md", "/git_hunk"]
+
 [dependency-groups]
 dev = [
   "mdformat-frontmatter>=2.0.10",


### PR DESCRIPTION
Fixes #16.

`uv build` produced an sdist containing `tmp/` plus every other repo-root file (`docs/`, `assets/`, `Makefile`, `uv.lock`, `.github/`, …) — hatchling includes all non-gitignored files, and `tmp/` is untracked but not ignored, so it (and, historically, a ~345-file nested `tmp/agent-browser/` repo) would be published to PyPI.

## Summary
- Add a `[tool.hatch.build.targets.sdist]` `include` whitelist so the sdist ships only `git_hunk/`, `tests/`, and `README.md`. `pyproject.toml` and `LICENSE` are auto-included by hatchling; `README.md` is **not**, because the readme is dynamic (`hatch-fancy-pypi-readme`) and the sdist→wheel build re-runs that hook — verified empirically.
- The wheel target is untouched, so it still ships `git_hunk/skills/core/SKILL.md`.

## Verification
- [x] `tar tzf dist/*.tar.gz` → zero `tmp/` entries; nothing outside `git_hunk/`, `tests/`, `README.md`, `LICENSE`, `pyproject.toml` (+ hatchling's standard `PKG-INFO`/`.gitignore`)
- [x] wheel still contains `git_hunk/skills/core/SKILL.md`
- [x] clean `pip install` from the built sdist → `git-hunk skills get core` works
- [x] `make lint` and `uv run pytest` (95 passed)

No automated test: the fix is a declarative whitelist (self-guarding — it can only ship what's listed), and a build-shelling test would be slow/flaky; build verification belongs in the publish CI (tracked separately in #17).
