### PR TITLE
ci: gate PyPI publish on tests and use a full clone for versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,28 @@ on:
   push:
     tags: [v*]
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
   publish:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
       - run: uv build
+      - name: Verify built version matches tag
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          ls -1 dist/
+          test -f "dist/git_hunk-${version}-py3-none-any.whl" || {
+            echo "::error::no wheel for tag ${GITHUB_REF_NAME} (expected version" \
+              "${version}); check fetch-depth and that the tag is a canonical" \
+              "PEP 440 version"
+            exit 1
+          }
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fixes #17.

The publish workflow triggered on a `v*` tag with **no test gate** and a **shallow checkout** — so a tag with red tests could ship, and `hatch-vcs` fell back to `0.0.0.dev0` instead of deriving the version from the tag.

## Summary
- Make `test.yml` reusable via `workflow_call`, and add a `test` job to `publish.yml` that calls it; `publish` is `needs: test`, so publishing cannot run unless the full matrix passes (no test-matrix duplication).
- Check out the publish job with `fetch-depth: 0` so `hatch-vcs` sees the tags and derives the real version.
- Add a step that lists `dist/` and fails (before upload) if the built wheel does not match the tag version.

## Verification
- [x] Gating: `publish` `needs: test` → a red cell blocks publish (standard GHA semantics).
- [x] `fetch-depth: 0` on the publish checkout.
- [x] Simulated a tag build in a full clone at `v0.2.0` → version `0.2.0`, wheel `git_hunk-0.2.0-py3-none-any.whl`, and the verify step passes.
- [x] `make lint` (yamlfix) clean.

## Out of scope (follow-up: #37)
Further supply-chain hardening — SHA-pinning actions, `environment: pypi` protection, splitting build/publish jobs — is tracked in #37 (some needs repo-settings config; pinning needs the real current SHAs, not guesses).
