### PR TITLE
docs: add CHANGELOG.md seeded with the v0.3.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `skills` subcommand (`git-hunk skills list|get|path`) serving the bundled,
+  version-matched core usage guide for AI agents.
+- Examples section in `--help` for every subcommand.
+
+### Changed
+
+- README image paths are rewritten to absolute URLs so they render on PyPI.
+
+### Fixed
+
+- Preserve `\ No newline at end of file` markers so staging the last line of a
+  file without a trailing newline no longer fails or silently stages nothing
+  (#9).
+- Parse git's quoted and octal-escaped paths, so files with non-ASCII names or
+  names containing ` b/` appear and stage correctly (#10).
+- Decode git output with `surrogateescape`, so a diff containing non-UTF-8 bytes
+  no longer crashes with `UnicodeDecodeError` (#11).
+- Apply partial line selection (`-l`) correctly for `unstage` and `discard` on
+  hunks with more than one change group (#12).
+- Escape user-controlled text in Rich output, so a path like `src/[id].tsx`
+  renders verbatim instead of being swallowed as markup (#14).
+- Reject empty or whitespace-only hunk ids, and report malformed `-l` ranges
+  with a readable error (#15).
+- Constrain the source distribution to the package, tests, and metadata so it
+  no longer ships unrelated `tmp/` files (#16).
+
+[unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD


### PR DESCRIPTION
Closes #18.

Adds a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-style `CHANGELOG.md` seeded with the upcoming v0.3.0 changes.

The release-in-progress lives under `## [Unreleased]` (the canonical spec form — `[X.Y.Z] - Unreleased` is a non-standard hybrid some changelog tooling misparses). At tag time it gets stamped `## [0.3.0] - <date>` with a fresh `## [Unreleased]` above it.

- **Added / Changed** items are verified present in `main` since v0.2.0 (skills subcommand #8, `--help` examples #7, PyPI README URLs #5).
- **Fixed** items are the v0.3.0 blocker fixes currently in review (#9–#12, #14–#16), referenced per the issue's "reference them as they merge". CI-only #17 and the human-design #13 are intentionally excluded from a user-facing changelog.

## Note
When #16 (sdist whitelist) merges, it does not include `CHANGELOG.md` in the sdist. The changelog lives on GitHub; if shipping it in the sdist is desired, add it to that whitelist — flagging here rather than coupling the two PRs.

## Test plan
- [x] `make lint` (mdformat + typos) clean
- [x] Every Added/Changed/Fixed claim verified against `git log v0.2.0..main` and the referenced issues
