### PR TITLE
fix: harden binary and special-file handling

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -116,6 +116,10 @@ def _apply_line_filter(
         return hunks
     if len(hunks) != 1:
         raise CliError("line selection (-l) requires exactly one hunk id")
+    if _is_whole_file_hunk(hunks[0]):
+        raise CliError(
+            "line selection (-l) is not supported for binary or mode-only changes"
+        )
     try:
         lines, exclude = parse_line_spec(line_spec)
         return [filter_hunk_lines(hunks[0], lines, exclude=exclude, reverse=reverse)]
@@ -123,8 +127,10 @@ def _apply_line_filter(
         raise CliError(str(exc)) from exc
 
 
-def _is_binary_hunk(hunk: Hunk) -> bool:
-    return hunk.header == "Binary file"
+def _is_whole_file_hunk(hunk: Hunk) -> bool:
+    # Binary and mode-only changes carry no text diff and are applied by staging
+    # the whole file rather than by a patch.
+    return not hunk.diff
 
 
 def _run_patch_command(
@@ -148,21 +154,21 @@ def _run_patch_command(
     selected = _find_hunks_by_ids(hunks, ids)
     selected = _apply_line_filter(selected, line_spec, reverse=reverse)
 
-    binary = [h for h in selected if _is_binary_hunk(h)]
-    text = [h for h in selected if not _is_binary_hunk(h)]
+    whole_file = [h for h in selected if _is_whole_file_hunk(h)]
+    text = [h for h in selected if not _is_whole_file_hunk(h)]
 
     try:
         if text:
             patch = build_patch(text, diff_output)
             apply_patch(patch, cached=cached, reverse=reverse)
-        if binary:
-            binary_files = [h.file for h in binary]
+        if whole_file:
+            paths = [h.file for h in whole_file]
             if reverse and not cached:
-                discard_files(binary_files)
+                discard_files(paths)
             elif reverse:
-                unstage_files(binary_files)
+                unstage_files(paths)
             else:
-                stage_files(binary_files)
+                stage_files(paths)
     except RuntimeError as exc:
         raise CliError(str(exc)) from exc
 

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -214,6 +214,35 @@ def _extract_context_before(header: str) -> str:
     return match.group(1).strip() if match and match.group(1).strip() else ""
 
 
+def _whole_file_hunk(filepath: str, header: str) -> Hunk:
+    """A change applied by staging the whole file (binary or mode-only)."""
+    return Hunk(
+        id="",
+        file=filepath,
+        header=header,
+        additions=0,
+        deletions=0,
+        context_before="",
+        diff="",
+    )
+
+
+def _binary_file_header(file_diff: str) -> str:
+    if re.search(r"^deleted file mode ", file_diff, flags=re.MULTILINE):
+        return "Binary file (deleted)"
+    if re.search(r"^new file mode ", file_diff, flags=re.MULTILINE):
+        return "Binary file (added)"
+    return "Binary file (modified)"
+
+
+def _mode_change_header(file_diff: str) -> str | None:
+    old = re.search(r"^old mode (\d+)$", file_diff, flags=re.MULTILINE)
+    new = re.search(r"^new mode (\d+)$", file_diff, flags=re.MULTILINE)
+    if not (old and new):
+        return None
+    return f"Mode {old.group(1)} -> {new.group(1)}"
+
+
 def parse_diff(diff_output: str) -> list[Hunk]:
     if not diff_output.strip():
         return []
@@ -230,20 +259,18 @@ def parse_diff(diff_output: str) -> list[Hunk]:
             continue
 
         if re.search(r"^Binary files .* differ$", file_diff, flags=re.MULTILINE):
-            hunks.append(
-                Hunk(
-                    id="",
-                    file=filepath,
-                    header="Binary file",
-                    additions=0,
-                    deletions=0,
-                    context_before="",
-                    diff="",
-                )
-            )
+            hunks.append(_whole_file_hunk(filepath, _binary_file_header(file_diff)))
             continue
 
         parts = re.split(r"(?=^@@)", file_diff, flags=re.MULTILINE)
+
+        if len(parts) == 1:
+            # No text hunks: surface a pure mode change (chmod) that would
+            # otherwise be dropped silently.
+            mode_header = _mode_change_header(file_diff)
+            if mode_header is not None:
+                hunks.append(_whole_file_hunk(filepath, mode_header))
+            continue
 
         for part in parts[1:]:
             lines = part.split("\n")

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -117,6 +117,9 @@ def print_hunk_list(hunks: list[Hunk]) -> None:
 
 def _print_hunk_diff(out: Console, hunk: Hunk) -> None:
     out.print(f"[bold]{escape(_safe(hunk.file))}[/bold]  [dim]{escape(hunk.id)}[/dim]")
+    if not hunk.diff:
+        out.print(Text(_safe(hunk.header), style="dim"))
+        return
     line_num = 0
     for line in hunk.diff.split("\n"):
         if line.startswith("@@"):

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -146,8 +146,9 @@ work you didn't create.
 
 In `list` (see Quickstart), hunks group under `staged`, `unstaged`, and
 `untracked` (new files git isn't tracking yet). Each hunk line is `id`, the `@@`
-header with its enclosing context, then `+N -N`. A binary hunk shows
-`Binary file` as its header; stage it whole (no `-l`).
+header with its enclosing context, then `+N -N`. A binary or mode-only change
+has no `@@` line; it shows a `Binary file (modified|added|deleted)` or
+`Mode <old> -> <new>` header instead and is staged whole (no `-l`).
 
 ## Useful flags
 

--- a/tests/e2e/binary_test.py
+++ b/tests/e2e/binary_test.py
@@ -1,0 +1,120 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from .conftest import GitHunkCLI
+
+
+def _id_for(cli: GitHunkCLI, path: str, *flags: str) -> str:
+    hunks = cli.run_json("list", *flags, "--json")
+    return next(h["id"] for h in hunks if h["file"] == path)
+
+
+@pytest.fixture
+def modified_binary(cli: GitHunkCLI) -> GitHunkCLI:
+    path = Path(cli.repo.path) / "a.bin"
+    path.write_bytes(b"\x00\x01bin\xff")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    path.write_bytes(b"\x00\x02BIN\xfe")
+    return cli
+
+
+def test_list_distinguishes_modified_and_deleted_binary(cli: GitHunkCLI) -> None:
+    root = Path(cli.repo.path)
+    (root / "a.bin").write_bytes(b"\x00\x01a\xff")
+    (root / "d.bin").write_bytes(b"\x00\x01d\xff")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    (root / "a.bin").write_bytes(b"\x00\x02A\xfe")
+    (root / "d.bin").unlink()
+
+    headers = {
+        h["file"]: h["header"] for h in cli.run_json("list", "--unstaged", "--json")
+    }
+    assert headers["a.bin"] == "Binary file (modified)"
+    assert headers["d.bin"] == "Binary file (deleted)"
+
+
+def test_show_binary_has_no_blank_numbered_line(modified_binary: GitHunkCLI) -> None:
+    out = modified_binary.run_ok(
+        "show", _id_for(modified_binary, "a.bin", "--unstaged")
+    )
+    assert "Binary file (modified)" in out
+    assert "  1 " not in out  # no numbered line from an empty diff body
+
+
+def test_stage_unstage_discard_modified_binary(modified_binary: GitHunkCLI) -> None:
+    cli = modified_binary
+    cli.run_ok("stage", _id_for(cli, "a.bin", "--unstaged"))
+    assert "a.bin" in cli.repo.git("diff", "--cached", "--name-only")
+
+    cli.run_ok("unstage", _id_for(cli, "a.bin", "--staged"))
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+    cli.run_ok("discard", _id_for(cli, "a.bin", "--unstaged"))
+    assert cli.repo.git("diff").strip() == ""
+
+
+def test_line_selection_rejected_on_binary(modified_binary: GitHunkCLI) -> None:
+    cli = modified_binary
+    r = cli.run("stage", _id_for(cli, "a.bin", "--unstaged"), "-l", "1")
+    assert r.returncode != 0
+    assert "not supported for binary or mode-only" in r.stderr
+
+
+def test_stage_deleted_binary(cli: GitHunkCLI) -> None:
+    path = Path(cli.repo.path) / "d.bin"
+    path.write_bytes(b"\x00\x01del\xff")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    path.unlink()
+
+    cli.run_ok("stage", _id_for(cli, "d.bin", "--unstaged"))
+    assert "D\td.bin" in cli.repo.git("diff", "--cached", "--name-status")
+
+    cli.run_ok("unstage", _id_for(cli, "d.bin", "--staged"))
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+def test_stage_added_binary(cli: GitHunkCLI) -> None:
+    # A new binary is untracked; stage it, then it shows as an added binary.
+    (Path(cli.repo.path) / "keep.txt").write_text("x\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    (Path(cli.repo.path) / "n.bin").write_bytes(b"\x00new\xff")
+
+    cli.repo.git("add", "n.bin")
+    staged = {
+        h["file"]: h["header"] for h in cli.run_json("list", "--staged", "--json")
+    }
+    assert staged["n.bin"] == "Binary file (added)"
+
+    cli.run_ok("unstage", _id_for(cli, "n.bin", "--staged"))
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="git does not track unix file modes on Windows"
+)
+def test_stage_and_discard_mode_only_change(cli: GitHunkCLI) -> None:
+    cli.repo.git("config", "core.fileMode", "true")
+    path = Path(cli.repo.path) / "m.sh"
+    path.write_text("plain\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    os.chmod(path, 0o755)
+
+    headers = {
+        h["file"]: h["header"] for h in cli.run_json("list", "--unstaged", "--json")
+    }
+    assert headers["m.sh"].startswith("Mode ")
+
+    cli.run_ok("stage", _id_for(cli, "m.sh", "--unstaged"))
+    assert "m.sh" in cli.repo.git("diff", "--cached", "--name-only")
+
+    cli.run_ok("unstage", _id_for(cli, "m.sh", "--staged"))
+    cli.run_ok("discard", _id_for(cli, "m.sh", "--unstaged"))
+    assert cli.repo.git("diff").strip() == ""

--- a/tests/unit/_hunk/parse_diff_test.py
+++ b/tests/unit/_hunk/parse_diff_test.py
@@ -37,7 +37,7 @@ def test_binary_file() -> None:
     hunks = parse_diff(diff)
     assert len(hunks) == 1
     assert hunks[0].file == "foo.qm"
-    assert hunks[0].header == "Binary file"
+    assert hunks[0].header == "Binary file (modified)"
     assert hunks[0].additions == 0
     assert hunks[0].deletions == 0
     assert hunks[0].diff == ""
@@ -61,9 +61,45 @@ def test_binary_file_mixed_with_text() -> None:
     hunks = parse_diff(diff)
     assert len(hunks) == 2
     assert hunks[0].file == "foo.qm"
-    assert hunks[0].header == "Binary file"
+    assert hunks[0].header == "Binary file (modified)"
     assert hunks[1].file == "bar.py"
     assert hunks[1].additions == 1
+
+
+def test_deleted_binary_distinguished() -> None:
+    diff = (
+        "diff --git a/d.bin b/d.bin\n"
+        "deleted file mode 100644\n"
+        "index 885b32b..0000000\n"
+        "Binary files a/d.bin and /dev/null differ\n"
+    )
+    hunks = parse_diff(diff)
+    assert len(hunks) == 1
+    assert hunks[0].header == "Binary file (deleted)"
+    assert hunks[0].diff == ""
+
+
+def test_added_binary_distinguished() -> None:
+    diff = (
+        "diff --git a/n.bin b/n.bin\n"
+        "new file mode 100644\n"
+        "index 0000000..abc1234\n"
+        "Binary files /dev/null and b/n.bin differ\n"
+    )
+    hunks = parse_diff(diff)
+    assert len(hunks) == 1
+    assert hunks[0].header == "Binary file (added)"
+
+
+def test_mode_only_change_surfaced() -> None:
+    diff = "diff --git a/m.sh b/m.sh\nold mode 100644\nnew mode 100755\n"
+    hunks = parse_diff(diff)
+    assert len(hunks) == 1
+    assert hunks[0].file == "m.sh"
+    assert hunks[0].header == "Mode 100644 -> 100755"
+    assert hunks[0].additions == 0
+    assert hunks[0].deletions == 0
+    assert hunks[0].diff == ""
 
 
 def test_no_split_when_close() -> None:


### PR DESCRIPTION
Fixes #19.

Hardens handling of binary and special-status files and adds the missing e2e coverage for the binary staging path.

## Summary
- **`list` distinguishes binary state**: `Binary file (modified|added|deleted)` instead of one identical `Binary file` header (derived from the `deleted file mode` / `new file mode` extended-diff headers).
- **Mode-only changes surfaced**: a `chmod` that produces no `@@` hunk now appears as a `Mode <old> -> <new>` hunk instead of being silently dropped, and can be staged/unstaged/discarded.
- **Clean `show`**: binary/mode hunks print their header and return, fixing the spurious blank `  1 ` numbered line from splitting an empty diff body.
- **`-l` rejected** on binary/mode hunks with a clear message (was a misleading "hunk has 0 lines").
- Routing keys on the empty diff (`_is_whole_file_hunk`) so binary and mode-only changes share one whole-file `git add` path; updated SKILL.md.

## Test plan
- [x] unit: parse of modified/added/deleted binary headers and mode-only change: `tests/unit/_hunk/parse_diff_test.py`
- [x] e2e: stage/unstage/discard a modified binary; stage a deleted binary; added-binary header + unstage; mode-only stage/discard (skipped on Windows where git ignores unix modes); clean `show`; `-l` rejection: `tests/e2e/binary_test.py`
- [x] `make lint` and `uv run pytest` (105 passed)

## Follow-up: #40
The change-kind/mode is carried in the free-text `header` string; modeling it as structured `Hunk` fields (and exposing it in `--json`) is tracked in #40, coordinated with the JSON-schema work in #23/#27.
