### PR TITLE
fix: make the skills loader robust to malformed SKILL.md

### DIFF
--- a/git_hunk/_skills.py
+++ b/git_hunk/_skills.py
@@ -6,6 +6,7 @@ the content an agent loads always matches the installed git-hunk version.
 
 import os
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -34,7 +35,11 @@ def load_skills() -> list[Skill]:
         skill_md = child / "SKILL.md"
         if not skill_md.is_file():
             continue
-        content = skill_md.read_text(encoding="utf-8")
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"warning: could not read skill {skill_md}: {exc}", file=sys.stderr)
+            continue
         meta = _parse_frontmatter(content)
         skills.append(
             Skill(
@@ -52,10 +57,15 @@ def _parse_frontmatter(text: str) -> dict[str, str]:
     if not lines or lines[0].strip() != "---":
         return {}
     meta: dict[str, str] = {}
+    closed = False
     for line in lines[1:]:
         if line.strip() == "---":
+            closed = True
             break
         match = re.match(r"^([A-Za-z0-9_-]+):[ \t]*(.*)$", line)
         if match is not None:
             meta[match.group(1)] = match.group(2).strip()
+    if not closed:
+        # Frontmatter must be terminated; otherwise the body is not metadata.
+        return {}
     return meta

--- a/tests/unit/_skills/load_skills_test.py
+++ b/tests/unit/_skills/load_skills_test.py
@@ -1,0 +1,60 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from git_hunk._skills import load_skills
+
+_VALID = b"---\nname: good\ndescription: ok\n---\nbody\n"
+
+
+def _write_skill(root: Path, name: str, content: bytes) -> None:
+    (root / name).mkdir()
+    (root / name / "SKILL.md").write_bytes(content)
+
+
+def test_non_utf8_skill_is_skipped_with_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_skill(tmp_path, "good", _VALID)
+    _write_skill(tmp_path, "bad", b"---\nname: bad\xff\n---\n")
+    monkeypatch.setenv("GIT_HUNK_SKILLS_DIR", str(tmp_path))
+
+    assert [s.name for s in load_skills()] == ["good"]
+    assert "could not read skill" in capsys.readouterr().err
+
+
+def test_unclosed_frontmatter_loads_with_directory_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No closing ---: the skill still loads, but with no metadata.
+    _write_skill(tmp_path, "core", b"---\nname: real\ndescription: d\n\nbody\n")
+    monkeypatch.setenv("GIT_HUNK_SKILLS_DIR", str(tmp_path))
+
+    (skill,) = load_skills()
+    assert skill.name == "core"
+    assert skill.description == ""
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="permission bits are not enforced on Windows"
+)
+@pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0, reason="root bypasses permissions"
+)
+def test_unreadable_skill_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_skill(tmp_path, "good", _VALID)
+    _write_skill(tmp_path, "noperm", b"---\nname: noperm\n---\n")
+    unreadable = tmp_path / "noperm" / "SKILL.md"
+    os.chmod(unreadable, 0o000)
+    monkeypatch.setenv("GIT_HUNK_SKILLS_DIR", str(tmp_path))
+
+    try:
+        assert [s.name for s in load_skills()] == ["good"]
+    finally:
+        os.chmod(unreadable, 0o644)

--- a/tests/unit/_skills/parse_frontmatter_test.py
+++ b/tests/unit/_skills/parse_frontmatter_test.py
@@ -19,3 +19,9 @@ def test_only_top_level_keys_are_parsed() -> None:
 
 def test_missing_frontmatter_returns_empty() -> None:
     assert _parse_frontmatter("# just markdown\n") == {}
+
+
+def test_missing_closing_delimiter_returns_empty() -> None:
+    # Without a terminating ---, the body must not be absorbed as metadata.
+    text = "---\nname: core\nfoo: from_body\n\n# Heading\n"
+    assert _parse_frontmatter(text) == {}


### PR DESCRIPTION
Fixes #20.

The skills loader crashed with an uncaught traceback when a `SKILL.md` was unreadable (permissions) or non-UTF-8, and frontmatter with no closing `---` was parsed as if the entire file body were metadata (body keys leaked into `name`/`description`).

## Summary
- `load_skills` skips a `SKILL.md` it cannot read or UTF-8-decode (`OSError`/`UnicodeDecodeError`), printing a one-line warning to stderr and continuing instead of crashing. (Uses plain `sys.stderr` — `_ui` imports `_skills`, so routing through the Rich console would be a circular import.)
- `_parse_frontmatter` requires a terminating `---`; without it, it returns `{}` so body lines are never absorbed as keys (the skill still loads, falling back to its directory name).

## Test plan
- [x] unit: missing-closing-delimiter returns `{}`; an unclosed-frontmatter skill loads with the directory name; a non-UTF-8 file is skipped with a warning; an unreadable (chmod 000) file is skipped (skipif Windows/root): `tests/unit/_skills/`
- [x] verified end-to-end: `GIT_HUNK_SKILLS_DIR` pointing at a non-UTF-8 `SKILL.md` makes `git-hunk skills list` warn and print `No skills.` instead of a traceback
- [x] `make lint` and `uv run pytest` (99 passed)
