### PR TITLE
feat: accept a file path as shorthand for all hunks in a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
 - `skills` subcommand (`git-hunk skills list|get|path`) serving the bundled,
   version-matched core usage guide for AI agents.
 - Examples section in `--help` for every subcommand.
+- Accept a file path as shorthand for all hunks in a file, so
+  `git-hunk stage src/foo.py` stages every hunk in that file (#21).
 
 ### Changed
 

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -1,4 +1,6 @@
 import json
+import os
+import re
 from dataclasses import replace
 
 import click
@@ -109,13 +111,39 @@ def _find_hunks_by_ids(hunks: list[Hunk], ids: list[str]) -> list[Hunk]:
     return found
 
 
+def _select_hunks(hunks: list[Hunk], args: list[str]) -> list[Hunk]:
+    files = {h.file for h in hunks}
+    selected: list[Hunk] = []
+    seen: set[str] = set()
+    for arg in args:
+        if not arg.strip():
+            raise CliError("hunk id or file path must not be empty or whitespace")
+        # A path that matches a changed file wins; otherwise hunk ids are hex,
+        # so a non-hex argument can only have been meant as a (missing) path.
+        path = os.path.normpath(arg)
+        if path in files:
+            matches = [h for h in hunks if h.file == path]
+        elif re.fullmatch(r"[0-9a-f]+", arg):
+            matches = _find_hunks_by_ids(hunks, [arg])
+        else:
+            raise CliError(
+                f"no changed file matches '{arg}'",
+                tip="run 'git-hunk list' to see changed files and hunk ids",
+            )
+        for hunk in matches:
+            if hunk.id not in seen:
+                seen.add(hunk.id)
+                selected.append(hunk)
+    return selected
+
+
 def _apply_line_filter(
     hunks: list[Hunk], line_spec: str | None, *, reverse: bool
 ) -> list[Hunk]:
     if line_spec is None:
         return hunks
     if len(hunks) != 1:
-        raise CliError("line selection (-l) requires exactly one hunk id")
+        raise CliError("line selection (-l) requires exactly one hunk")
     if _is_whole_file_hunk(hunks[0]):
         raise CliError(
             "line selection (-l) is not supported for binary or mode-only changes"
@@ -134,7 +162,7 @@ def _is_whole_file_hunk(hunk: Hunk) -> bool:
 
 
 def _run_patch_command(
-    ids: list[str],
+    args: list[str],
     line_spec: str | None,
     *,
     usage: str,
@@ -144,14 +172,14 @@ def _run_patch_command(
     reverse: bool,
     verb: str,
 ) -> None:
-    if not ids:
+    if not args:
         raise CliError(
-            f"{command_name} requires at least one hunk id",
+            f"{command_name} requires at least one hunk id or file path",
             usage=usage,
         )
 
     hunks, diff_output = _get_hunks(staged=staged)
-    selected = _find_hunks_by_ids(hunks, ids)
+    selected = _select_hunks(hunks, args)
     selected = _apply_line_filter(selected, line_spec, reverse=reverse)
 
     whole_file = [h for h in selected if _is_whole_file_hunk(h)]
@@ -343,13 +371,13 @@ def cmd_skills(args: tuple[str, ...], force_json: bool, show_help: bool) -> None
 @cli.command("stage", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
 @click.option("-h", "--help", "show_help", is_flag=True)
-@click.argument("ids", nargs=-1)
-def cmd_stage(ids: tuple[str, ...], line_spec: str | None, show_help: bool) -> None:
+@click.argument("targets", nargs=-1)
+def cmd_stage(targets: tuple[str, ...], line_spec: str | None, show_help: bool) -> None:
     if show_help:
         print_help(HELP_STAGE)
         return
     _run_patch_command(
-        list(ids),
+        list(targets),
         line_spec,
         usage=USAGE_STAGE,
         command_name="stage",
@@ -363,13 +391,15 @@ def cmd_stage(ids: tuple[str, ...], line_spec: str | None, show_help: bool) -> N
 @cli.command("unstage", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
 @click.option("-h", "--help", "show_help", is_flag=True)
-@click.argument("ids", nargs=-1)
-def cmd_unstage(ids: tuple[str, ...], line_spec: str | None, show_help: bool) -> None:
+@click.argument("targets", nargs=-1)
+def cmd_unstage(
+    targets: tuple[str, ...], line_spec: str | None, show_help: bool
+) -> None:
     if show_help:
         print_help(HELP_UNSTAGE)
         return
     _run_patch_command(
-        list(ids),
+        list(targets),
         line_spec,
         usage=USAGE_UNSTAGE,
         command_name="unstage",
@@ -383,13 +413,15 @@ def cmd_unstage(ids: tuple[str, ...], line_spec: str | None, show_help: bool) ->
 @cli.command("discard", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
 @click.option("-h", "--help", "show_help", is_flag=True)
-@click.argument("ids", nargs=-1)
-def cmd_discard(ids: tuple[str, ...], line_spec: str | None, show_help: bool) -> None:
+@click.argument("targets", nargs=-1)
+def cmd_discard(
+    targets: tuple[str, ...], line_spec: str | None, show_help: bool
+) -> None:
     if show_help:
         print_help(HELP_DISCARD)
         return
     _run_patch_command(
-        list(ids),
+        list(targets),
         line_spec,
         usage=USAGE_DISCARD,
         command_name="discard",

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -196,14 +196,14 @@ def print_version(version: str) -> None:
 
 _LINE_OPTS = """\
 [bold green]Options:[/bold green]
-  [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk (requires single id)
+  [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk (requires exactly one hunk)
              e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""  # noqa: E501
 
 USAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk[/bold cyan] [cyan]<COMMAND>[/cyan]"  # noqa: E501
 USAGE_SHOW = "[bold green]Usage:[/bold green] [bold cyan]git-hunk show[/bold cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
-USAGE_STAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk stage[/bold cyan] [cyan]<id>[/cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
-USAGE_UNSTAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk unstage[/bold cyan] [cyan]<id>[/cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
-USAGE_DISCARD = "[bold green]Usage:[/bold green] [bold cyan]git-hunk discard[/bold cyan] [cyan]<id>[/cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
+USAGE_STAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk stage[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
+USAGE_UNSTAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk unstage[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
+USAGE_DISCARD = "[bold green]Usage:[/bold green] [bold cyan]git-hunk discard[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_SKILLS = "[bold green]Usage:[/bold green] [bold cyan]git-hunk skills[/bold cyan] [cyan][SUBCOMMAND][/cyan] [cyan][<name>...][/cyan]"  # noqa: E501
 
 
@@ -232,14 +232,17 @@ _EXAMPLES_SHOW: Final = [
 _EXAMPLES_STAGE: Final = [
     ("git-hunk stage d161935", "Stage a hunk"),
     ("git-hunk stage d161935 a3f82c1", "Stage multiple hunks"),
+    ("git-hunk stage src/foo.py", "Stage every hunk in a file"),
     ("git-hunk stage d161935 -l 3,5-7", "Stage specific lines only"),
 ]
 _EXAMPLES_UNSTAGE: Final = [
     ("git-hunk unstage d161935", "Move a hunk back to working tree"),
+    ("git-hunk unstage src/foo.py", "Unstage every hunk in a file"),
     ("git-hunk unstage d161935 -l 3,5-7", "Unstage specific lines only"),
 ]
 _EXAMPLES_DISCARD: Final = [
     ("git-hunk discard d161935", "Restore a hunk from HEAD"),
+    ("git-hunk discard src/foo.py", "Discard every hunk in a file"),
     ("git-hunk discard d161935 -l ^3,^5-7", "Discard excluding specific lines"),
 ]
 _EXAMPLES_SKILLS: Final = [

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -27,6 +27,17 @@ git-hunk list                 # 5. repeat until nothing is left behind
 IDs are content-based hashes. They're stable across partial staging and support
 prefix matching, so a 7-char prefix like `d161935` is enough.
 
+`stage`, `unstage`, and `discard` also accept a file path as shorthand for every
+hunk in that file, so you don't have to enumerate IDs:
+
+```bash
+git-hunk stage src/foo.py     # stage all of src/foo.py's hunks
+```
+
+An argument that exactly matches a changed file's path operates on that whole
+file; otherwise it's treated as a hunk ID. A path takes precedence if an
+argument could be both.
+
 ## Quickstart
 
 A working tree with three unrelated changes, committed as three commits:

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -51,7 +51,7 @@ def test_stage_nonexistent_hunk(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "new\n")
 
-    r = cli.run("stage", "nonexistent")
+    r = cli.run("stage", "deadbee")
     assert r.returncode != 0
     assert "not found" in r.stderr
 

--- a/tests/e2e/markup_test.py
+++ b/tests/e2e/markup_test.py
@@ -41,4 +41,4 @@ def test_error_renders_bracketed_value_verbatim(cli: GitHunkCLI) -> None:
 
     r = cli.run("stage", "[bogus]")
     assert r.returncode != 0
-    assert "hunk '[bogus]' not found" in r.stderr
+    assert "no changed file matches '[bogus]'" in r.stderr

--- a/tests/e2e/path_shorthand_test.py
+++ b/tests/e2e/path_shorthand_test.py
@@ -1,0 +1,96 @@
+import pytest
+
+from .conftest import GitHunkCLI
+
+
+@pytest.fixture
+def multi_hunk_repo(cli: GitHunkCLI) -> GitHunkCLI:
+    cli.repo.write_file("big.py", "\n".join(f"l{i}" for i in range(1, 11)) + "\n")
+    cli.repo.write_file("b.py", "other\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    lines = [f"l{i}" for i in range(1, 11)]
+    lines[0] = "L1"
+    lines[9] = "L10"  # two change groups far enough apart to be two hunks
+    cli.repo.write_file("big.py", "\n".join(lines) + "\n")
+    cli.repo.write_file("b.py", "OTHER\n")
+    return cli
+
+
+def test_stage_whole_file_by_path(multi_hunk_repo: GitHunkCLI) -> None:
+    cli = multi_hunk_repo
+    hunks = cli.run_json("list", "--unstaged", "--json")
+    assert len([h for h in hunks if h["file"] == "big.py"]) == 2
+
+    cli.run_ok("stage", "big.py")
+    assert cli.repo.git("diff", "--cached", "--name-only").split() == ["big.py"]
+    assert cli.repo.git("diff", "--name-only").split() == ["b.py"]
+
+
+def test_unstage_whole_file_by_path(multi_hunk_repo: GitHunkCLI) -> None:
+    cli = multi_hunk_repo
+    cli.run_ok("stage", "big.py")
+
+    cli.run_ok("unstage", "big.py")
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+def test_discard_whole_file_by_path(multi_hunk_repo: GitHunkCLI) -> None:
+    cli = multi_hunk_repo
+    cli.run_ok("discard", "big.py")
+    assert "big.py" not in cli.repo.git("diff", "--name-only")
+    assert "b.py" in cli.repo.git("diff", "--name-only")
+
+
+def test_dot_slash_prefixed_path(multi_hunk_repo: GitHunkCLI) -> None:
+    multi_hunk_repo.run_ok("stage", "./big.py")
+    staged = multi_hunk_repo.repo.git("diff", "--cached", "--name-only").split()
+    assert staged == ["big.py"]
+
+
+def test_mixing_path_and_id(multi_hunk_repo: GitHunkCLI) -> None:
+    cli = multi_hunk_repo
+    hunks = cli.run_json("list", "--unstaged", "--json")
+    b_id = next(h["id"] for h in hunks if h["file"] == "b.py")
+
+    cli.run_ok("stage", "big.py", b_id)
+    staged = sorted(cli.repo.git("diff", "--cached", "--name-only").split())
+    assert staged == ["b.py", "big.py"]
+
+
+def test_path_and_id_of_same_hunk_dedup(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "x\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "X\n")
+
+    hunk_id = cli.run_json("list", "--unstaged", "--json")[0]["id"]
+    # Same hunk named twice (by path and by id) must apply once, not error.
+    cli.run_ok("stage", "f.py", hunk_id)
+    assert cli.repo.git("diff", "--cached", "--name-only").split() == ["f.py"]
+
+
+def test_path_takes_precedence_over_id_lookalike(cli: GitHunkCLI) -> None:
+    # A changed file whose name looks like a hunk id is treated as a path.
+    cli.repo.write_file("a1b2c3d", "x\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("a1b2c3d", "X\n")
+
+    cli.run_ok("stage", "a1b2c3d")
+    assert "a1b2c3d" in cli.repo.git("diff", "--cached", "--name-only")
+
+
+def test_line_selection_rejected_for_multi_hunk_path(
+    multi_hunk_repo: GitHunkCLI,
+) -> None:
+    r = multi_hunk_repo.run("stage", "big.py", "-l", "1")
+    assert r.returncode != 0
+    assert "exactly one hunk" in r.stderr
+
+
+def test_unknown_path_errors_clearly(multi_hunk_repo: GitHunkCLI) -> None:
+    # A non-hex argument can only be a path, so the error names the file.
+    r = multi_hunk_repo.run("stage", "does-not-exist.py")
+    assert r.returncode != 0
+    assert "no changed file matches 'does-not-exist.py'" in r.stderr


### PR DESCRIPTION
Fixes #21.

`stage`, `unstage`, and `discard` now accept a **file path** as shorthand for every hunk in that file, so agents and users don't have to enumerate hunk IDs (real usage has hit 51 IDs in one command).

## Summary
- New `_select_hunks` resolves each argument: an argument that matches a changed file's path selects all of that file's hunks; otherwise it's a hunk ID (prefix match). Results are deduped by hunk ID, order preserved.
- **Disambiguation (documented in SKILL.md + `--help`):** a path takes precedence when an argument could be both. Because hunk IDs are lowercase hex, a non-hex argument can only be a path — so a typo like `stage src/typo.py` reports `no changed file matches 'src/typo.py'` instead of a misleading "hunk not found". Arguments are normalized (`./src/foo.py` matches `src/foo.py`).

## Test plan
- [x] e2e: stage/unstage/discard a whole file by path; mixing path + ID; dedup (path + an ID it contains); path precedence over an ID-lookalike filename; `./`-prefixed path; `-l` rejected on a multi-hunk path; clear errors for a missing path vs a missing hunk ID: `tests/e2e/path_shorthand_test.py`
- [x] dogfooded: this PR's own change was staged with `git-hunk stage <paths>`
- [x] `make lint` and `uv run pytest` (104 passed)

## Scope notes
Kept the documented path-precedence rule (the issue allows "error OR documented precedence") rather than adding a `git`-style `--` escape hatch — the only "ambiguous" case is a changed file named exactly like a current hex hunk ID, which is vanishingly rare and still stageable via the file. `show` remains ID-only (out of scope).
