### PR TITLE
feat: add --dry-run to stage, unstage, and discard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 - Examples section in `--help` for every subcommand.
 - Accept a file path as shorthand for all hunks in a file, so
   `git-hunk stage src/foo.py` stages every hunk in that file (#21).
+- `--dry-run` for `stage`, `unstage`, and `discard`, previewing what would
+  change without touching the index or working tree (#25).
 
 ### Changed
 

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -171,6 +171,7 @@ def _run_patch_command(
     cached: bool,
     reverse: bool,
     verb: str,
+    dry_run: bool,
 ) -> None:
     if not args:
         raise CliError(
@@ -188,8 +189,8 @@ def _run_patch_command(
     try:
         if text:
             patch = build_patch(text, diff_output)
-            apply_patch(patch, cached=cached, reverse=reverse)
-        if whole_file:
+            apply_patch(patch, cached=cached, reverse=reverse, dry_run=dry_run)
+        if whole_file and not dry_run:
             paths = [h.file for h in whole_file]
             if reverse and not cached:
                 discard_files(paths)
@@ -200,7 +201,7 @@ def _run_patch_command(
     except RuntimeError as exc:
         raise CliError(str(exc)) from exc
 
-    print_applied(selected, verb=verb)
+    print_applied(selected, verb=f"would {command_name}" if dry_run else verb)
 
 
 @click.group(cls=CliGroup, invoke_without_command=True, add_help_option=False)
@@ -370,9 +371,12 @@ def cmd_skills(args: tuple[str, ...], force_json: bool, show_help: bool) -> None
 
 @cli.command("stage", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
+@click.option("--dry-run", "dry_run", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("targets", nargs=-1)
-def cmd_stage(targets: tuple[str, ...], line_spec: str | None, show_help: bool) -> None:
+def cmd_stage(
+    targets: tuple[str, ...], line_spec: str | None, dry_run: bool, show_help: bool
+) -> None:
     if show_help:
         print_help(HELP_STAGE)
         return
@@ -385,15 +389,17 @@ def cmd_stage(targets: tuple[str, ...], line_spec: str | None, show_help: bool) 
         cached=True,
         reverse=False,
         verb="staged",
+        dry_run=dry_run,
     )
 
 
 @cli.command("unstage", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
+@click.option("--dry-run", "dry_run", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("targets", nargs=-1)
 def cmd_unstage(
-    targets: tuple[str, ...], line_spec: str | None, show_help: bool
+    targets: tuple[str, ...], line_spec: str | None, dry_run: bool, show_help: bool
 ) -> None:
     if show_help:
         print_help(HELP_UNSTAGE)
@@ -407,15 +413,17 @@ def cmd_unstage(
         cached=True,
         reverse=True,
         verb="unstaged",
+        dry_run=dry_run,
     )
 
 
 @cli.command("discard", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
+@click.option("--dry-run", "dry_run", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("targets", nargs=-1)
 def cmd_discard(
-    targets: tuple[str, ...], line_spec: str | None, show_help: bool
+    targets: tuple[str, ...], line_spec: str | None, dry_run: bool, show_help: bool
 ) -> None:
     if show_help:
         print_help(HELP_DISCARD)
@@ -429,4 +437,5 @@ def cmd_discard(
         cached=False,
         reverse=True,
         verb="discarded",
+        dry_run=dry_run,
     )

--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -35,12 +35,20 @@ def get_untracked_files() -> list[str]:
     return [f for f in output.split("\0") if f]
 
 
-def apply_patch(patch: str, *, cached: bool = False, reverse: bool = False) -> None:
+def apply_patch(
+    patch: str,
+    *,
+    cached: bool = False,
+    reverse: bool = False,
+    dry_run: bool = False,
+) -> None:
     args = ["apply", "--whitespace=nowarn"]
     if cached:
         args.append("--cached")
     if reverse:
         args.append("--reverse")
+    if dry_run:
+        args.append("--check")
     run_git(*args, input=patch)
 
 

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -197,7 +197,8 @@ def print_version(version: str) -> None:
 _LINE_OPTS = """\
 [bold green]Options:[/bold green]
   [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk (requires exactly one hunk)
-             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""  # noqa: E501
+             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)
+  [bold cyan]--dry-run[/bold cyan]   Report what would change without touching the index or working tree"""  # noqa: E501
 
 USAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk[/bold cyan] [cyan]<COMMAND>[/cyan]"  # noqa: E501
 USAGE_SHOW = "[bold green]Usage:[/bold green] [bold cyan]git-hunk show[/bold cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
@@ -234,16 +235,19 @@ _EXAMPLES_STAGE: Final = [
     ("git-hunk stage d161935 a3f82c1", "Stage multiple hunks"),
     ("git-hunk stage src/foo.py", "Stage every hunk in a file"),
     ("git-hunk stage d161935 -l 3,5-7", "Stage specific lines only"),
+    ("git-hunk stage d161935 --dry-run", "Preview without changing anything"),
 ]
 _EXAMPLES_UNSTAGE: Final = [
     ("git-hunk unstage d161935", "Move a hunk back to working tree"),
     ("git-hunk unstage src/foo.py", "Unstage every hunk in a file"),
     ("git-hunk unstage d161935 -l 3,5-7", "Unstage specific lines only"),
+    ("git-hunk unstage d161935 --dry-run", "Preview without changing anything"),
 ]
 _EXAMPLES_DISCARD: Final = [
     ("git-hunk discard d161935", "Restore a hunk from HEAD"),
     ("git-hunk discard src/foo.py", "Discard every hunk in a file"),
     ("git-hunk discard d161935 -l ^3,^5-7", "Discard excluding specific lines"),
+    ("git-hunk discard d161935 --dry-run", "Preview without changing anything"),
 ]
 _EXAMPLES_SKILLS: Final = [
     ("git-hunk skills", "List available skills"),

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -151,7 +151,12 @@ git-hunk discard <id> <id> ...   # permanently restore unstaged hunks from HEAD
 
 Both take `-l <lines>` for partial ranges, like `stage`. `discard` is
 destructive: it throws away changes. Confirm with the user before discarding
-work you didn't create.
+work you didn't create. `stage`, `unstage`, and `discard` all take `--dry-run`
+to report what they would change without touching the index or working tree:
+
+```bash
+git-hunk discard d161935 --dry-run   # preview the restore, change nothing
+```
 
 ## Reading the output
 

--- a/tests/e2e/dry_run_test.py
+++ b/tests/e2e/dry_run_test.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+from .conftest import GitHunkCLI
+
+
+def _setup_modified(cli: GitHunkCLI) -> str:
+    cli.repo.write_file("f.txt", "a\nb\nc\n")
+    cli.repo.git("add", "f.txt")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "aX\nb\ncX\n")
+    hunks = cli.run_json("list", "--unstaged", "--json")
+    assert len(hunks) == 1
+    return hunks[0]["id"]
+
+
+def test_stage_dry_run_changes_nothing(cli: GitHunkCLI) -> None:
+    hunk_id = _setup_modified(cli)
+
+    r = cli.run("stage", hunk_id, "--dry-run")
+    assert r.returncode == 0
+    assert "would stage" in r.stderr
+
+    assert cli.repo.git("diff", "--cached").strip() == ""
+    assert cli.run_json("list", "--unstaged", "--json")[0]["id"] == hunk_id
+
+
+def test_discard_dry_run_keeps_working_tree(cli: GitHunkCLI) -> None:
+    hunk_id = _setup_modified(cli)
+
+    r = cli.run("discard", hunk_id, "--dry-run")
+    assert r.returncode == 0
+    assert "would discard" in r.stderr
+
+    assert cli.repo.git("diff").strip() != ""
+    assert cli.run_json("list", "--unstaged", "--json")[0]["id"] == hunk_id
+
+
+def test_unstage_dry_run_keeps_index(cli: GitHunkCLI) -> None:
+    hunk_id = _setup_modified(cli)
+    cli.run_ok("stage", hunk_id)
+    staged_id = cli.run_json("list", "--staged", "--json")[0]["id"]
+
+    r = cli.run("unstage", staged_id, "--dry-run")
+    assert r.returncode == 0
+    assert "would unstage" in r.stderr
+
+    assert cli.repo.git("diff", "--cached").strip() != ""
+
+
+def test_dry_run_line_selection_changes_nothing(cli: GitHunkCLI) -> None:
+    hunk_id = _setup_modified(cli)
+
+    # Body: 1=-a 2=+aX 3= b 4=-c 5=+cX. Preview staging just the first change.
+    r = cli.run("stage", hunk_id, "-l", "1,2", "--dry-run")
+    assert r.returncode == 0
+
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+def test_stage_dry_run_leaves_binary_unstaged(cli: GitHunkCLI) -> None:
+    path = Path(cli.repo.path) / "a.bin"
+    path.write_bytes(b"\x00\x01bin\xff")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    path.write_bytes(b"\x00\x02BIN\xfe")
+
+    hunk_id = cli.run_json("list", "--unstaged", "--json")[0]["id"]
+    r = cli.run("stage", hunk_id, "--dry-run")
+    assert r.returncode == 0
+    assert "would stage" in r.stderr
+
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+def test_dry_run_unknown_id_exits_nonzero(cli: GitHunkCLI) -> None:
+    _setup_modified(cli)
+
+    r = cli.run("stage", "deadbee", "--dry-run")
+    assert r.returncode != 0
+    assert "deadbee" in r.stderr
+    assert cli.repo.git("diff", "--cached").strip() == ""


### PR DESCRIPTION
## Summary
- Add a `--dry-run` flag to `stage`, `unstage`, and `discard` that reports what would change without modifying the index or working tree.
- Text hunks are validated with `git apply --check`, so the exit code reflects whether the operation would actually have succeeded.
- Whole-file (binary / mode-only) selections are reported but left untouched.
- Output uses a `would stage / unstage / discard` verb to distinguish a preview from a real apply.

A safety net before the destructive `discard` in particular, and it lets agents preview an operation before committing to it.

## Test plan
- [x] tests added: `tests/e2e/dry_run_test.py` (stage/unstage/discard change nothing, `-l` preview, binary preview, unknown id exits non-zero)
- [x] `uv run pytest` (164 passed)
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check`

Closes #25
