### PR TITLE
feat: add a commit subcommand to stage and commit in one step

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ git-hunk discard d161935               # restore from HEAD
 git-hunk discard d161935 -l ^3,^5-7    # discard excluding specific lines
 ```
 
+### Commit
+
+```bash
+git-hunk commit d161935 -m "fix: ..."      # stage a hunk and commit it in one step
+git-hunk commit d161935 -l 3,5-7 -m "..."  # stage specific lines and commit
+```
+
+`commit` aborts if anything is already staged, so the commit contains exactly
+the selected hunks.
+
 ### JSON output
 
 ```bash

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -7,6 +7,7 @@ import click
 
 from . import __version__
 from ._git import apply_patch
+from ._git import commit
 from ._git import discard_files
 from ._git import get_diff
 from ._git import get_untracked_files
@@ -22,6 +23,7 @@ from ._skills import Skill
 from ._skills import load_skills
 from ._skills import skills_root
 from ._ui import HELP
+from ._ui import HELP_COMMIT
 from ._ui import HELP_DISCARD
 from ._ui import HELP_LIST
 from ._ui import HELP_SHOW
@@ -29,11 +31,13 @@ from ._ui import HELP_SKILLS
 from ._ui import HELP_STAGE
 from ._ui import HELP_UNSTAGE
 from ._ui import USAGE
+from ._ui import USAGE_COMMIT
 from ._ui import USAGE_DISCARD
 from ._ui import USAGE_SKILLS
 from ._ui import USAGE_STAGE
 from ._ui import USAGE_UNSTAGE
 from ._ui import print_applied
+from ._ui import print_committed
 from ._ui import print_error
 from ._ui import print_help
 from ._ui import print_hunk_diffs
@@ -161,7 +165,7 @@ def _is_whole_file_hunk(hunk: Hunk) -> bool:
     return not hunk.diff
 
 
-def _run_patch_command(
+def _apply_selection(
     args: list[str],
     line_spec: str | None,
     *,
@@ -170,9 +174,8 @@ def _run_patch_command(
     staged: bool,
     cached: bool,
     reverse: bool,
-    verb: str,
     dry_run: bool,
-) -> None:
+) -> list[Hunk]:
     if not args:
         raise CliError(
             f"{command_name} requires at least one hunk id or file path",
@@ -201,6 +204,31 @@ def _run_patch_command(
     except RuntimeError as exc:
         raise CliError(str(exc)) from exc
 
+    return selected
+
+
+def _run_patch_command(
+    args: list[str],
+    line_spec: str | None,
+    *,
+    usage: str,
+    command_name: str,
+    staged: bool,
+    cached: bool,
+    reverse: bool,
+    verb: str,
+    dry_run: bool,
+) -> None:
+    selected = _apply_selection(
+        args,
+        line_spec,
+        usage=usage,
+        command_name=command_name,
+        staged=staged,
+        cached=cached,
+        reverse=reverse,
+        dry_run=dry_run,
+    )
     print_applied(selected, verb=f"would {command_name}" if dry_run else verb)
 
 
@@ -439,3 +467,45 @@ def cmd_discard(
         verb="discarded",
         dry_run=dry_run,
     )
+
+
+@cli.command("commit", add_help_option=False)
+@click.option("-m", "message", default=None)
+@click.option("-l", "line_spec", default=None)
+@click.option("-h", "--help", "show_help", is_flag=True)
+@click.argument("targets", nargs=-1)
+def cmd_commit(
+    targets: tuple[str, ...],
+    message: str | None,
+    line_spec: str | None,
+    show_help: bool,
+) -> None:
+    if show_help:
+        print_help(HELP_COMMIT)
+        return
+    if message is None or not message.strip():
+        raise CliError("commit requires a message (-m)", usage=USAGE_COMMIT)
+
+    _require_git_repo()
+    if get_diff(staged=True).strip():
+        raise CliError(
+            "cannot commit: changes are already staged",
+            tip="commit them with 'git commit', or unstage with 'git-hunk unstage'",
+        )
+
+    selected = _apply_selection(
+        list(targets),
+        line_spec,
+        usage=USAGE_COMMIT,
+        command_name="commit",
+        staged=False,
+        cached=True,
+        reverse=False,
+        dry_run=False,
+    )
+    try:
+        commit(message)
+    except RuntimeError as exc:
+        raise CliError(str(exc)) from exc
+
+    print_committed(selected, message=message)

--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -62,3 +62,7 @@ def unstage_files(files: list[str]) -> None:
 
 def discard_files(files: list[str]) -> None:
     run_git("restore", "--", *files)
+
+
+def commit(message: str) -> None:
+    run_git("commit", "-m", message)

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -175,6 +175,16 @@ def print_applied(hunks: list[Hunk], *, verb: str) -> None:
         err.print(line)
 
 
+def print_committed(hunks: list[Hunk], *, message: str) -> None:
+    summary = message.strip().splitlines()[0]
+    count = len(hunks)
+    line = Text()
+    line.append("  committed ", style="bold green")
+    line.append(f"{count} hunk{'s' if count != 1 else ''}", style="bold")
+    line.append(f"  {_safe(summary)}", style="dim")
+    _err().print(line)
+
+
 def print_error(
     msg: str,
     *,
@@ -194,10 +204,13 @@ def print_version(version: str) -> None:
     _err().print(f"git-hunk [dim]{version}[/dim]")
 
 
-_LINE_OPTS = """\
-[bold green]Options:[/bold green]
+_LINE_OPT_ROW = """\
   [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk (requires exactly one hunk)
-             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)
+             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""  # noqa: E501
+
+_LINE_OPTS = f"""\
+[bold green]Options:[/bold green]
+{_LINE_OPT_ROW}
   [bold cyan]--dry-run[/bold cyan]   Report what would change without touching the index or working tree"""  # noqa: E501
 
 USAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk[/bold cyan] [cyan]<COMMAND>[/cyan]"  # noqa: E501
@@ -205,6 +218,7 @@ USAGE_SHOW = "[bold green]Usage:[/bold green] [bold cyan]git-hunk show[/bold cya
 USAGE_STAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk stage[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_UNSTAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk unstage[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_DISCARD = "[bold green]Usage:[/bold green] [bold cyan]git-hunk discard[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
+USAGE_COMMIT = "[bold green]Usage:[/bold green] [bold cyan]git-hunk commit[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [bold cyan]-m[/bold cyan] [cyan]<msg>[/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_SKILLS = "[bold green]Usage:[/bold green] [bold cyan]git-hunk skills[/bold cyan] [cyan][SUBCOMMAND][/cyan] [cyan][<name>...][/cyan]"  # noqa: E501
 
 
@@ -249,6 +263,10 @@ _EXAMPLES_DISCARD: Final = [
     ("git-hunk discard d161935 -l ^3,^5-7", "Discard excluding specific lines"),
     ("git-hunk discard d161935 --dry-run", "Preview without changing anything"),
 ]
+_EXAMPLES_COMMIT: Final = [
+    ('git-hunk commit d161935 -m "fix: ..."', "Stage a hunk and commit it"),
+    ('git-hunk commit src/foo.py -m "..."', "Stage a whole file and commit"),
+]
 _EXAMPLES_SKILLS: Final = [
     ("git-hunk skills", "List available skills"),
     ("git-hunk skills get core", "Load the core usage guide"),
@@ -260,6 +278,7 @@ _EXAMPLES_ALL: Final = (
     + _EXAMPLES_STAGE
     + _EXAMPLES_UNSTAGE
     + _EXAMPLES_DISCARD
+    + _EXAMPLES_COMMIT
 )
 
 HELP = f"""\
@@ -280,6 +299,7 @@ Non-interactive git hunk staging for AI agents.
   [bold cyan]stage[/bold cyan]    Stage specific hunks
   [bold cyan]unstage[/bold cyan]  Unstage specific hunks
   [bold cyan]discard[/bold cyan]  Discard specific hunks (restore from HEAD)
+  [bold cyan]commit[/bold cyan]   Stage specific hunks and commit them in one step
   [bold cyan]skills[/bold cyan]   Load bundled skill content for AI agents
 
 [bold green]Options:[/bold green]
@@ -340,6 +360,20 @@ IDs support prefix matching.
 {_LINE_OPTS}
 
 {_format_examples(_EXAMPLES_UNSTAGE)}"""
+
+HELP_COMMIT = f"""\
+Stage one or more specific hunks and commit them in one step. IDs support
+prefix matching. Aborts if anything is already staged, so the commit contains
+exactly the selected hunks. If the commit is rejected (e.g. by a pre-commit
+hook) the hunks are left staged so you can retry with [bold cyan]git commit[/bold cyan].
+
+{USAGE_COMMIT}
+
+[bold green]Options:[/bold green]
+  [bold cyan]-m[/bold cyan] [cyan]<msg>[/cyan]    Commit message (required)
+{_LINE_OPT_ROW}
+
+{_format_examples(_EXAMPLES_COMMIT)}"""  # noqa: E501
 
 HELP_SKILLS = f"""\
 List and retrieve bundled skill content. Skills always match the installed

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -38,6 +38,12 @@ An argument that exactly matches a changed file's path operates on that whole
 file; otherwise it's treated as a hunk ID. A path takes precedence if an
 argument could be both.
 
+`git-hunk commit <id|file> ... -m "type: msg"` collapses steps 3-4 (stage one
+group, then commit it) into a single call. It aborts if anything is already
+staged, so the commit holds exactly the selected hunks; use the separate `stage`
+
+- `git commit` when you want to inspect the staged diff in between.
+
 ## Quickstart
 
 A working tree with three unrelated changes, committed as three commits:

--- a/tests/e2e/commit_test.py
+++ b/tests/e2e/commit_test.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+
+from .conftest import GitHunkCLI
+
+
+def _init(cli: GitHunkCLI, files: dict[str, str]) -> None:
+    for name, content in files.items():
+        cli.repo.write_file(name, content)
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+
+def _commit_count(cli: GitHunkCLI) -> int:
+    return int(cli.repo.git("rev-list", "--count", "HEAD").strip())
+
+
+def _unstaged_ids(cli: GitHunkCLI) -> list[str]:
+    return [h["id"] for h in cli.run_json("list", "--unstaged", "--json")]
+
+
+def test_commit_single_hunk(cli: GitHunkCLI) -> None:
+    _init(cli, {"f.txt": "a\nb\nc\n"})
+    cli.repo.write_file("f.txt", "aX\nb\nc\n")
+
+    before = _commit_count(cli)
+    cli.run_ok("commit", _unstaged_ids(cli)[0], "-m", "fix: change a")
+
+    assert _commit_count(cli) == before + 1
+    assert cli.repo.git("log", "-1", "--format=%s").strip() == "fix: change a"
+    assert "aX" in cli.repo.git("show", "HEAD:f.txt")
+    assert cli.repo.git("status", "--porcelain").strip() == ""
+
+
+def test_commit_multiple_hunks(cli: GitHunkCLI) -> None:
+    _init(cli, {"a.txt": "a\n", "b.txt": "b\n"})
+    cli.repo.write_file("a.txt", "AAA\n")
+    cli.repo.write_file("b.txt", "BBB\n")
+
+    ids = _unstaged_ids(cli)
+    assert len(ids) == 2
+    cli.run_ok("commit", ids[0], ids[1], "-m", "chore: update both")
+
+    head = cli.repo.git("show", "HEAD")
+    assert "AAA" in head
+    assert "BBB" in head
+    assert cli.repo.git("status", "--porcelain").strip() == ""
+
+
+def test_commit_partial_lines_leaves_remainder_unstaged(cli: GitHunkCLI) -> None:
+    _init(cli, {"f.txt": "a\nb\nc\n"})
+    cli.repo.write_file("f.txt", "aX\nb\ncX\n")
+
+    # Body: 1=-a 2=+aX 3= b 4=-c 5=+cX. Commit only the a->aX change.
+    cli.run_ok("commit", _unstaged_ids(cli)[0], "-l", "1,2", "-m", "fix: only a")
+
+    assert "aX" in cli.repo.git("show", "HEAD:f.txt")
+    assert "cX" not in cli.repo.git("show", "HEAD:f.txt")
+    # The c->cX change is still in the working tree, unstaged.
+    assert "cX" in cli.repo.git("diff")
+
+
+def test_commit_by_file_path(cli: GitHunkCLI) -> None:
+    _init(cli, {"a.txt": "a\n", "b.txt": "b\n"})
+    cli.repo.write_file("a.txt", "A1\nA2\nA3\n")
+    cli.repo.write_file("b.txt", "BBB\n")
+
+    cli.run_ok("commit", "a.txt", "-m", "feat: rewrite a")
+
+    assert "A1" in cli.repo.git("show", "HEAD:a.txt")
+    # b.txt was not named, so it stays out of the commit and in the working tree.
+    assert cli.repo.git("show", "HEAD:b.txt").strip() == "b"
+    assert "BBB" in cli.repo.git("diff")
+
+
+def test_commit_requires_message(cli: GitHunkCLI) -> None:
+    _init(cli, {"f.txt": "a\n"})
+    cli.repo.write_file("f.txt", "AAA\n")
+
+    before = _commit_count(cli)
+    r = cli.run("commit", _unstaged_ids(cli)[0])
+    assert r.returncode != 0
+    assert "message" in r.stderr
+    assert _commit_count(cli) == before
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+def test_commit_unknown_id_makes_no_commit(cli: GitHunkCLI) -> None:
+    _init(cli, {"f.txt": "a\n"})
+    cli.repo.write_file("f.txt", "AAA\n")
+
+    before = _commit_count(cli)
+    r = cli.run("commit", "deadbee", "-m", "nope")
+    assert r.returncode != 0
+    assert _commit_count(cli) == before
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+def test_commit_failure_leaves_hunk_staged(cli: GitHunkCLI) -> None:
+    _init(cli, {"f.txt": "a\n"})
+    cli.repo.write_file("f.txt", "AAA\n")
+
+    hook = Path(cli.repo.path) / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
+
+    before = _commit_count(cli)
+    r = cli.run("commit", _unstaged_ids(cli)[0], "-m", "fix: blocked by hook")
+    assert r.returncode != 0
+    assert _commit_count(cli) == before
+    # The hunk is left staged so the user can retry, not silently lost.
+    assert "AAA" in cli.repo.git("diff", "--cached")
+
+
+def test_commit_aborts_when_index_already_has_staged_changes(cli: GitHunkCLI) -> None:
+    _init(cli, {"a.txt": "a\n", "b.txt": "b\n"})
+    cli.repo.write_file("a.txt", "AAA\n")
+    cli.repo.write_file("b.txt", "BBB\n")
+    cli.repo.git("add", "a.txt")  # pre-stage an unrelated change
+
+    before = _commit_count(cli)
+    b_id = next(h["id"] for h in cli.run_json("list", "--unstaged", "--json"))
+    r = cli.run("commit", b_id, "-m", "feat: only b")
+    assert r.returncode != 0
+    assert "already staged" in r.stderr
+    assert _commit_count(cli) == before
+    # The pre-staged change is untouched; nothing new was committed or staged.
+    assert cli.repo.git("diff", "--cached", "--name-only").strip() == "a.txt"


### PR DESCRIPTION
## Summary
- Add a `commit` subcommand: `git-hunk commit <ids|files> -m "msg"` stages the selected hunks and commits them in one step, collapsing the common `git-hunk stage <ids> && git commit -m "..."` flow.
- Same selection semantics as `stage`: id prefixes, file-path shorthand, and `-l` line selection.
- Aborts if anything is already staged, so the commit holds exactly the selected hunks (no silent inclusion of unrelated pre-staged changes).
- If the commit is rejected (e.g. by a pre-commit hook), the hunks are left staged so you can retry with `git commit`.
- The staging core is factored out of `_run_patch_command` into a shared `_apply_selection`, so stage/unstage/discard and commit share one implementation.

## Test plan
- [x] tests added: `tests/e2e/commit_test.py` (single/multiple/by-file/partial-line commits, message required, unknown id, dirty-index abort, pre-commit-hook failure leaves hunks staged)
- [x] `uv run pytest` (181 passed)
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check`

Closes #26
