### PR TITLE
feat: include context_before in --json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,17 @@ git-hunk list --json
     "id": "d161935",
     "file": "src/main.py",
     "status": "unstaged",
-    "header": "@@ -10,3 +10,5 @@",
+    "header": "@@ -10,3 +10,5 @@ def main():",
+    "context_before": "def main():",
     "additions": 2,
     "deletions": 0,
     "diff": "..."
   }
 ]
 ```
+
+`context_before` is the function/section git names after the `@@` header; it is
+an empty string when git provides no context (e.g. plain text or binary hunks).
 
 ## Comparison
 

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -30,6 +30,7 @@ class Hunk:
             "file": self.file,
             "status": self.status,
             "header": self.header,
+            "context_before": self.context_before,
             "additions": self.additions,
             "deletions": self.deletions,
             "diff": self.diff,

--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -151,3 +151,19 @@ def test_list_status_field_in_json(cli: GitHunkCLI) -> None:
     hunks = cli.run_json("list", "--json")
     assert all("status" in h for h in hunks)
     assert hunks[0]["status"] == "unstaged"
+
+
+def test_list_context_before_field_in_json_matches_display(cli: GitHunkCLI) -> None:
+    body = ["def foo():"] + [f"    x{i} = {i}" for i in range(8)]
+    cli.repo.write_file("f.py", "\n".join(body) + "\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    body[4] = "    x3 = 99"
+    cli.repo.write_file("f.py", "\n".join(body) + "\n")
+
+    hunks = cli.run_json("list", "--json")
+    assert len(hunks) == 1
+    assert hunks[0]["context_before"] == "def foo():"
+    # Parity: the field equals the function context shown in the human display.
+    assert "def foo():" in cli.run_ok("list")

--- a/tests/unit/_hunk/to_dict_test.py
+++ b/tests/unit/_hunk/to_dict_test.py
@@ -1,0 +1,29 @@
+from git_hunk._hunk import Hunk
+
+
+def test_to_dict_includes_context_before() -> None:
+    hunk = Hunk(
+        id="abc1234",
+        file="f.py",
+        header="@@ -1,3 +1,3 @@ def foo():",
+        additions=1,
+        deletions=1,
+        context_before="def foo():",
+        diff="@@ -1,3 +1,3 @@ def foo():\n-a\n+b",
+    )
+    assert hunk.to_dict()["context_before"] == "def foo():"
+
+
+def test_to_dict_context_before_empty_when_no_context() -> None:
+    hunk = Hunk(
+        id="abc1234",
+        file="f.txt",
+        header="@@ -1,3 +1,3 @@",
+        additions=1,
+        deletions=1,
+        context_before="",
+        diff="@@ -1,3 +1,3 @@\n-a\n+b",
+    )
+    serialized = hunk.to_dict()
+    assert "context_before" in serialized
+    assert serialized["context_before"] == ""


### PR DESCRIPTION
## Summary
- Add `context_before` to `Hunk.to_dict()` so `git-hunk list --json` carries the function/section annotation (the text git puts after the `@@` header) that the human `list` display already shows.
- git-hunk targets AI agents, which read `--json` rather than the rich display; without this they couldn't tell which function a hunk belonged to without re-parsing the header.
- The field is always present and is an empty string when git provides no context (plain text / binary / mode-only hunks). README `--json` example and a note updated to match.

## Test plan
- [x] unit: `to_dict` includes `context_before` (named-context and empty-string cases)
- [x] e2e: `list --json` exposes `context_before` matching the function context shown in the display
- [x] `uv run pytest` (176 passed) · `ruff check` / `ruff format --check` / `ty check`

## Note for the maintainer (out of scope here)
While testing I noticed the **human `list`/applied display shows the function context twice** for hunks that have it — once inside `header` (git emits `@@ … @@ def foo():`) and once via the separate `context_before` column, e.g. `@@ -2,7 +2,7 @@ def foo():  def foo():`. This PR deliberately does not touch it, since #27's acceptance criteria require no change to the human-readable output. Happy to file a follow-up to render the bare `@@` header (or drop the duplicate column) if you'd like.

Relatedly, #23 (version the `--json` schema) will document this field as part of the versioned contract; this change is additive and safe for current consumers.

Closes #27
