### PR TITLE
feat!: version the --json output schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to
 
 ### Changed
 
+- **Breaking:** `list --json` now wraps its output in a versioned envelope,
+  `{"schema_version": 1, "hunks": [...]}`, instead of a bare array, so consumers
+  can depend on a documented, versioned shape (#23).
 - README image paths are rewritten to absolute URLs so they render on PyPI.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -121,23 +121,43 @@ the selected hunks.
 git-hunk list --json
 ```
 
+`list --json` emits a versioned envelope so consumers can depend on a stable
+shape:
+
 ```json
-[
-  {
-    "id": "d161935",
-    "file": "src/main.py",
-    "status": "unstaged",
-    "header": "@@ -10,3 +10,5 @@ def main():",
-    "context_before": "def main():",
-    "additions": 2,
-    "deletions": 0,
-    "diff": "..."
-  }
-]
+{
+  "schema_version": 1,
+  "hunks": [
+    {
+      "id": "d161935",
+      "file": "src/main.py",
+      "status": "unstaged",
+      "header": "@@ -10,3 +10,5 @@ def main():",
+      "context_before": "def main():",
+      "additions": 2,
+      "deletions": 0,
+      "diff": "..."
+    }
+  ]
+}
 ```
 
-`context_before` is the function/section git names after the `@@` header; it is
-an empty string when git provides no context (e.g. plain text or binary hunks).
+| Field            | Type   | Description                                                                                        |
+| ---------------- | ------ | -------------------------------------------------------------------------------------------------- |
+| `schema_version` | int    | Envelope version; bumped on any incompatible change to the shape below.                            |
+| `hunks`          | array  | The hunks (empty array when there are no changes).                                                 |
+| `id`             | string | Stable, content-based hunk id (7-char SHA-256 prefix); accepts prefixes.                           |
+| `file`           | string | Path of the changed file.                                                                          |
+| `status`         | string | One of `staged`, `unstaged`, `untracked`.                                                          |
+| `header`         | string | The hunk's `@@ ... @@` header, or a `Binary file (...)` / `Mode ...` label for whole-file changes. |
+| `context_before` | string | The function/section git names after the `@@` header; empty when git provides no context.          |
+| `additions`      | int    | Number of added lines.                                                                             |
+| `deletions`      | int    | Number of removed lines.                                                                           |
+| `diff`           | string | The unified diff for the hunk (empty for whole-file changes).                                      |
+
+Adding a new field is backward-compatible and does not change `schema_version`;
+renaming, removing, or changing the type of an existing field bumps it. (Before
+`schema_version` existed, `list --json` returned a bare array.)
 
 ## Comparison
 

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from dataclasses import replace
+from typing import Final
 
 import click
 
@@ -44,6 +45,9 @@ from ._ui import print_hunk_diffs
 from ._ui import print_hunk_list
 from ._ui import print_skill_list
 from ._ui import print_version
+
+# Bump when the `list --json` shape changes incompatibly (see README JSON output).
+JSON_SCHEMA_VERSION: Final = 1
 
 
 class CliError(Exception):
@@ -296,7 +300,11 @@ def cmd_list(
         hunks = hunks_staged + hunks_unstaged + _get_untracked_entries(files=file_list)
 
     if force_json:
-        click.echo(json.dumps([h.to_dict() for h in hunks], indent=2))
+        envelope = {
+            "schema_version": JSON_SCHEMA_VERSION,
+            "hunks": [h.to_dict() for h in hunks],
+        }
+        click.echo(json.dumps(envelope, indent=2))
     else:
         print_hunk_list(hunks)
 

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -181,7 +181,9 @@ git-hunk show             # show every hunk's diff (no args)
 git-hunk list --json      # machine-readable; plain output is usually enough
 ```
 
-`list` and `show` search both staged and unstaged by default.
+`list` and `show` search both staged and unstaged by default. `list --json`
+returns a versioned envelope, `{"schema_version": 1, "hunks": [...]}`; read the
+hunks from the `hunks` array.
 
 ## Working safely
 

--- a/tests/e2e/binary_test.py
+++ b/tests/e2e/binary_test.py
@@ -8,7 +8,7 @@ from .conftest import GitHunkCLI
 
 
 def _id_for(cli: GitHunkCLI, path: str, *flags: str) -> str:
-    hunks = cli.run_json("list", *flags, "--json")
+    hunks = cli.run_list_json("list", *flags, "--json")
     return next(h["id"] for h in hunks if h["file"] == path)
 
 
@@ -32,7 +32,8 @@ def test_list_distinguishes_modified_and_deleted_binary(cli: GitHunkCLI) -> None
     (root / "d.bin").unlink()
 
     headers = {
-        h["file"]: h["header"] for h in cli.run_json("list", "--unstaged", "--json")
+        h["file"]: h["header"]
+        for h in cli.run_list_json("list", "--unstaged", "--json")
     }
     assert headers["a.bin"] == "Binary file (modified)"
     assert headers["d.bin"] == "Binary file (deleted)"
@@ -88,7 +89,7 @@ def test_stage_added_binary(cli: GitHunkCLI) -> None:
 
     cli.repo.git("add", "n.bin")
     staged = {
-        h["file"]: h["header"] for h in cli.run_json("list", "--staged", "--json")
+        h["file"]: h["header"] for h in cli.run_list_json("list", "--staged", "--json")
     }
     assert staged["n.bin"] == "Binary file (added)"
 
@@ -108,7 +109,8 @@ def test_stage_and_discard_mode_only_change(cli: GitHunkCLI) -> None:
     os.chmod(path, 0o755)
 
     headers = {
-        h["file"]: h["header"] for h in cli.run_json("list", "--unstaged", "--json")
+        h["file"]: h["header"]
+        for h in cli.run_list_json("list", "--unstaged", "--json")
     }
     assert headers["m.sh"].startswith("Mode ")
 

--- a/tests/e2e/commit_test.py
+++ b/tests/e2e/commit_test.py
@@ -15,7 +15,7 @@ def _commit_count(cli: GitHunkCLI) -> int:
 
 
 def _unstaged_ids(cli: GitHunkCLI) -> list[str]:
-    return [h["id"] for h in cli.run_json("list", "--unstaged", "--json")]
+    return [h["id"] for h in cli.run_list_json("list", "--unstaged", "--json")]
 
 
 def test_commit_single_hunk(cli: GitHunkCLI) -> None:
@@ -118,7 +118,7 @@ def test_commit_aborts_when_index_already_has_staged_changes(cli: GitHunkCLI) ->
     cli.repo.git("add", "a.txt")  # pre-stage an unrelated change
 
     before = _commit_count(cli)
-    b_id = next(h["id"] for h in cli.run_json("list", "--unstaged", "--json"))
+    b_id = next(h["id"] for h in cli.run_list_json("list", "--unstaged", "--json"))
     r = cli.run("commit", b_id, "-m", "feat: only b")
     assert r.returncode != 0
     assert "already staged" in r.stderr

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from typing import cast
 
 import pytest
 from click.testing import CliRunner
@@ -38,7 +39,17 @@ class GitHunkCLI:
         return r.stdout
 
     def run_json(self, *args: str) -> list[dict[str, str]]:
-        return json.loads(self.run_ok(*args))  # type: ignore[no-any-return]
+        # For commands whose --json output is a bare array (e.g. `skills`).
+        # `list --json` returns an envelope; use run_list_json for that.
+        return cast("list[dict[str, str]]", json.loads(self.run_ok(*args)))
+
+    def run_list_envelope(self, *args: str) -> dict[str, object]:
+        return cast("dict[str, object]", json.loads(self.run_ok(*args)))
+
+    def run_list_json(self, *args: str) -> list[dict[str, str]]:
+        # `list --json` wraps the hunks in a versioned envelope; tests that only
+        # need the hunks call this to unwrap it.
+        return cast("list[dict[str, str]]", self.run_list_envelope(*args)["hunks"])
 
 
 @pytest.fixture

--- a/tests/e2e/discard_test.py
+++ b/tests/e2e/discard_test.py
@@ -7,12 +7,12 @@ def test_discard_hunk(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "new\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
 
     cli.run_ok("discard", hunks[0]["id"])
 
-    after = cli.run_json("list", "--json")
+    after = cli.run_list_json("list", "--json")
     assert len(after) == 0
 
     content = cli.repo.run("cat", "f.py").stdout
@@ -29,12 +29,12 @@ def test_discard_one_of_multiple(cli: GitHunkCLI) -> None:
     lines[17] = "CHANGED18"
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
 
     cli.run_ok("discard", hunks[0]["id"])
 
-    after = cli.run_json("list", "--json")
+    after = cli.run_list_json("list", "--json")
     assert len(after) == 1
 
     content = cli.repo.run("cat", "f.py").stdout

--- a/tests/e2e/dry_run_test.py
+++ b/tests/e2e/dry_run_test.py
@@ -8,7 +8,7 @@ def _setup_modified(cli: GitHunkCLI) -> str:
     cli.repo.git("add", "f.txt")
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.txt", "aX\nb\ncX\n")
-    hunks = cli.run_json("list", "--unstaged", "--json")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
     assert len(hunks) == 1
     return hunks[0]["id"]
 
@@ -21,7 +21,7 @@ def test_stage_dry_run_changes_nothing(cli: GitHunkCLI) -> None:
     assert "would stage" in r.stderr
 
     assert cli.repo.git("diff", "--cached").strip() == ""
-    assert cli.run_json("list", "--unstaged", "--json")[0]["id"] == hunk_id
+    assert cli.run_list_json("list", "--unstaged", "--json")[0]["id"] == hunk_id
 
 
 def test_discard_dry_run_keeps_working_tree(cli: GitHunkCLI) -> None:
@@ -32,13 +32,13 @@ def test_discard_dry_run_keeps_working_tree(cli: GitHunkCLI) -> None:
     assert "would discard" in r.stderr
 
     assert cli.repo.git("diff").strip() != ""
-    assert cli.run_json("list", "--unstaged", "--json")[0]["id"] == hunk_id
+    assert cli.run_list_json("list", "--unstaged", "--json")[0]["id"] == hunk_id
 
 
 def test_unstage_dry_run_keeps_index(cli: GitHunkCLI) -> None:
     hunk_id = _setup_modified(cli)
     cli.run_ok("stage", hunk_id)
-    staged_id = cli.run_json("list", "--staged", "--json")[0]["id"]
+    staged_id = cli.run_list_json("list", "--staged", "--json")[0]["id"]
 
     r = cli.run("unstage", staged_id, "--dry-run")
     assert r.returncode == 0
@@ -64,7 +64,7 @@ def test_stage_dry_run_leaves_binary_unstaged(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     path.write_bytes(b"\x00\x02BIN\xfe")
 
-    hunk_id = cli.run_json("list", "--unstaged", "--json")[0]["id"]
+    hunk_id = cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
     r = cli.run("stage", hunk_id, "--dry-run")
     assert r.returncode == 0
     assert "would stage" in r.stderr

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -86,7 +86,7 @@ def test_malformed_line_spec_rejected(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "A\nb\nC\n")
 
-    hunk_id = cli.run_json("list", "--unstaged", "--json")[0]["id"]
+    hunk_id = cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
     r = cli.run("stage", hunk_id, "-l", "1-2-3")
     assert r.returncode != 0
     assert "1-2-3" in r.stderr
@@ -103,7 +103,7 @@ def test_line_spec_with_multiple_hunks_fails(cli: GitHunkCLI) -> None:
     lines[17] = "CHANGED18"
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
 
     r = cli.run("stage", hunks[0]["id"], hunks[1]["id"], "-l", "1")

--- a/tests/e2e/line_selection_test.py
+++ b/tests/e2e/line_selection_test.py
@@ -19,7 +19,7 @@ def two_group(cli: GitHunkCLI) -> GitHunkCLI:
 
 
 def _only_id(cli: GitHunkCLI, *flags: str) -> str:
-    hunks = cli.run_json("list", *flags, "--json")
+    hunks = cli.run_list_json("list", *flags, "--json")
     assert len(hunks) == 1
     return hunks[0]["id"]
 

--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -1,4 +1,44 @@
+from typing import cast
+
+from git_hunk._cli import JSON_SCHEMA_VERSION
+
 from .conftest import GitHunkCLI
+
+_REQUIRED_HUNK_KEYS = {
+    "id",
+    "file",
+    "status",
+    "header",
+    "additions",
+    "deletions",
+    "diff",
+}
+_STATUSES = {"staged", "unstaged", "untracked"}
+
+
+def test_json_envelope_contract(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "new\n")
+
+    envelope = cli.run_list_envelope("list", "--json")
+    assert envelope["schema_version"] == JSON_SCHEMA_VERSION
+    hunks = cast("list[dict[str, str]]", envelope["hunks"])
+    assert hunks
+    for hunk in hunks:
+        assert _REQUIRED_HUNK_KEYS <= hunk.keys()
+        assert hunk["status"] in _STATUSES
+
+
+def test_json_envelope_present_when_empty(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "x\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    envelope = cli.run_list_envelope("list", "--json")
+    assert envelope["schema_version"] == JSON_SCHEMA_VERSION
+    assert envelope["hunks"] == []
 
 
 def test_no_changes_returns_empty_list(cli: GitHunkCLI) -> None:
@@ -6,7 +46,7 @@ def test_no_changes_returns_empty_list(cli: GitHunkCLI) -> None:
     cli.repo.git("add", ".")
     cli.repo.git("commit", "-m", "init")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert hunks == []
 
 
@@ -16,7 +56,7 @@ def test_single_file_single_hunk(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "LINE1\nline2\nline3\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
     assert hunks[0]["file"] == "f.py"
     assert hunks[0]["additions"] == 1
@@ -34,7 +74,7 @@ def test_single_file_multiple_hunks(cli: GitHunkCLI) -> None:
     lines[17] = "CHANGED18"
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
     assert all(h["file"] == "f.py" for h in hunks)
 
@@ -48,7 +88,7 @@ def test_multi_file_changes(cli: GitHunkCLI) -> None:
     cli.repo.write_file("a.py", "AAA\n")
     cli.repo.write_file("b.py", "BBB\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
     files = {h["file"] for h in hunks}
     assert files == {"a.py", "b.py"}
@@ -61,7 +101,7 @@ def test_list_staged(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "new\n")
     cli.repo.git("add", "f.py")
 
-    hunks = cli.run_json("list", "--staged", "--json")
+    hunks = cli.run_list_json("list", "--staged", "--json")
     assert len(hunks) == 1
     assert hunks[0]["file"] == "f.py"
 
@@ -75,7 +115,7 @@ def test_list_file_filter(cli: GitHunkCLI) -> None:
     cli.repo.write_file("a.py", "AAA\n")
     cli.repo.write_file("b.py", "BBB\n")
 
-    hunks = cli.run_json("list", "--json", "a.py")
+    hunks = cli.run_list_json("list", "--json", "a.py")
     assert len(hunks) == 1
     assert hunks[0]["file"] == "a.py"
 
@@ -88,7 +128,7 @@ def test_list_new_file(cli: GitHunkCLI) -> None:
     cli.repo.write_file("new.py", "brand new\n")
     cli.repo.git("add", "new.py")
 
-    hunks = cli.run_json("list", "--staged", "--json")
+    hunks = cli.run_list_json("list", "--staged", "--json")
     assert len(hunks) == 1
     assert hunks[0]["file"] == "new.py"
     assert int(hunks[0]["additions"]) >= 1
@@ -104,7 +144,7 @@ def test_list_default_shows_staged_and_unstaged(cli: GitHunkCLI) -> None:
     cli.repo.git("add", "f.py")
     cli.repo.write_file("f.py", "unstaged\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     statuses = {h["status"] for h in hunks}
     assert statuses == {"staged", "unstaged"}
 
@@ -116,7 +156,7 @@ def test_list_default_shows_untracked(cli: GitHunkCLI) -> None:
 
     cli.repo.write_file("untracked.py", "new\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     untracked = [h for h in hunks if h["status"] == "untracked"]
     assert len(untracked) == 1
     assert untracked[0]["file"] == "untracked.py"
@@ -131,7 +171,7 @@ def test_list_unstaged_filter(cli: GitHunkCLI) -> None:
     cli.repo.git("add", "f.py")
     cli.repo.write_file("f.py", "unstaged\n")
 
-    hunks = cli.run_json("list", "--unstaged", "--json")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
     assert all(h["status"] == "unstaged" for h in hunks)
     assert len(hunks) == 1
 
@@ -148,7 +188,7 @@ def test_list_status_field_in_json(cli: GitHunkCLI) -> None:
 
     cli.repo.write_file("f.py", "new\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert all("status" in h for h in hunks)
     assert hunks[0]["status"] == "unstaged"
 
@@ -162,7 +202,7 @@ def test_list_context_before_field_in_json_matches_display(cli: GitHunkCLI) -> N
     body[4] = "    x3 = 99"
     cli.repo.write_file("f.py", "\n".join(body) + "\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
     assert hunks[0]["context_before"] == "def foo():"
     # Parity: the field equals the function context shown in the human display.

--- a/tests/e2e/no_newline_test.py
+++ b/tests/e2e/no_newline_test.py
@@ -12,7 +12,7 @@ def _commit(cli: GitHunkCLI, content: str) -> None:
 
 
 def _only_hunk_id(cli: GitHunkCLI) -> str:
-    hunks = cli.run_json("list", "--unstaged", "--json")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
     assert len(hunks) == 1
     return hunks[0]["id"]
 
@@ -49,7 +49,7 @@ def test_unstage_round_trips_no_newline(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.txt", "a\nb\ncX")
 
     cli.run_ok("stage", _only_hunk_id(cli))
-    staged = cli.run_json("list", "--staged", "--json")
+    staged = cli.run_list_json("list", "--staged", "--json")
     cli.run_ok("unstage", staged[0]["id"])
 
     assert cli.repo.git("diff", "--cached").strip() == ""
@@ -76,7 +76,7 @@ def test_stage_line_selection_on_no_newline_hunk(cli: GitHunkCLI) -> None:
     assert cli.repo.git("show", ":f.txt") == "aX\nb\nc"
 
     # The dropped change still carries its no-newline marker in the remainder.
-    remaining = cli.run_json("list", "--unstaged", "--json")
+    remaining = cli.run_list_json("list", "--unstaged", "--json")
     assert NO_NEWLINE_MARKER in remaining[0]["diff"]
 
 
@@ -84,6 +84,6 @@ def test_list_counts_ignore_no_newline_marker(cli: GitHunkCLI) -> None:
     _commit(cli, "a\nb\nc")
     cli.repo.write_file("f.txt", "a\nb\ncX")
 
-    hunks = cli.run_json("list", "--unstaged", "--json")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
     assert hunks[0]["additions"] == 1
     assert hunks[0]["deletions"] == 1

--- a/tests/e2e/non_utf8_test.py
+++ b/tests/e2e/non_utf8_test.py
@@ -21,7 +21,7 @@ def latin1_repo(cli: GitHunkCLI) -> GitHunkCLI:
 
 
 def test_list_does_not_crash_on_non_utf8_content(latin1_repo: GitHunkCLI) -> None:
-    hunks = latin1_repo.run_json("list", "--unstaged", "--json")
+    hunks = latin1_repo.run_list_json("list", "--unstaged", "--json")
     assert [h["file"] for h in hunks] == ["latin1.txt"]
 
     latin1_repo.run_ok("list", "--unstaged")
@@ -32,7 +32,7 @@ def test_show_does_not_crash_on_non_utf8_content(latin1_repo: GitHunkCLI) -> Non
 
 
 def test_stage_preserves_non_utf8_bytes(latin1_repo: GitHunkCLI) -> None:
-    hunk_id = latin1_repo.run_json("list", "--unstaged", "--json")[0]["id"]
+    hunk_id = latin1_repo.run_list_json("list", "--unstaged", "--json")[0]["id"]
     latin1_repo.run_ok("stage", hunk_id)
 
     staged = subprocess.run(

--- a/tests/e2e/path_shorthand_test.py
+++ b/tests/e2e/path_shorthand_test.py
@@ -19,7 +19,7 @@ def multi_hunk_repo(cli: GitHunkCLI) -> GitHunkCLI:
 
 def test_stage_whole_file_by_path(multi_hunk_repo: GitHunkCLI) -> None:
     cli = multi_hunk_repo
-    hunks = cli.run_json("list", "--unstaged", "--json")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
     assert len([h for h in hunks if h["file"] == "big.py"]) == 2
 
     cli.run_ok("stage", "big.py")
@@ -50,7 +50,7 @@ def test_dot_slash_prefixed_path(multi_hunk_repo: GitHunkCLI) -> None:
 
 def test_mixing_path_and_id(multi_hunk_repo: GitHunkCLI) -> None:
     cli = multi_hunk_repo
-    hunks = cli.run_json("list", "--unstaged", "--json")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
     b_id = next(h["id"] for h in hunks if h["file"] == "b.py")
 
     cli.run_ok("stage", "big.py", b_id)
@@ -64,7 +64,7 @@ def test_path_and_id_of_same_hunk_dedup(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "X\n")
 
-    hunk_id = cli.run_json("list", "--unstaged", "--json")[0]["id"]
+    hunk_id = cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
     # Same hunk named twice (by path and by id) must apply once, not error.
     cli.run_ok("stage", "f.py", hunk_id)
     assert cli.repo.git("diff", "--cached", "--name-only").split() == ["f.py"]

--- a/tests/e2e/quoted_paths_test.py
+++ b/tests/e2e/quoted_paths_test.py
@@ -2,7 +2,7 @@ from .conftest import GitHunkCLI
 
 
 def _hunk_id_for(cli: GitHunkCLI, path: str) -> str:
-    hunks = cli.run_json("list", "--unstaged", "--json")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
     return next(h["id"] for h in hunks if h["file"] == path)
 
 
@@ -15,7 +15,7 @@ def test_non_ascii_modified_file_round_trips(cli: GitHunkCLI) -> None:
     cli.run_ok("stage", _hunk_id_for(cli, "файл.txt"))
     assert cli.repo.git("show", ":файл.txt") == "a\nB\n"
 
-    staged = cli.run_json("list", "--staged", "--json")
+    staged = cli.run_list_json("list", "--staged", "--json")
     cli.run_ok("unstage", staged[0]["id"])
     assert cli.repo.git("diff", "--cached").strip() == ""
 
@@ -29,7 +29,7 @@ def test_non_ascii_untracked_shows_real_path(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("untrack𝟙.txt", "new\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     untracked = [h for h in hunks if h["status"] == "untracked"]
     assert [h["file"] for h in untracked] == ["untrack𝟙.txt"]
 
@@ -40,13 +40,13 @@ def test_filename_with_b_slash_substring_stages(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("a b/c.txt", "x\nY\n")
 
-    hunks = cli.run_json("list", "--unstaged", "--json")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
     assert [h["file"] for h in hunks] == ["a b/c.txt"]
 
     cli.run_ok("stage", _hunk_id_for(cli, "a b/c.txt"))
     assert cli.repo.git("show", ":a b/c.txt") == "x\nY\n"
 
-    staged = cli.run_json("list", "--staged", "--json")
+    staged = cli.run_list_json("list", "--staged", "--json")
     cli.run_ok("unstage", staged[0]["id"])
     assert cli.repo.git("diff", "--cached").strip() == ""
 

--- a/tests/e2e/show_test.py
+++ b/tests/e2e/show_test.py
@@ -7,7 +7,7 @@ def test_show_hunk_by_full_id(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "new\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     hunk_id = hunks[0]["id"]
 
     r = cli.run("show", hunk_id)
@@ -22,7 +22,7 @@ def test_show_hunk_by_prefix(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "new\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     prefix = hunks[0]["id"][:4]
 
     r = cli.run("show", prefix)
@@ -37,7 +37,7 @@ def test_show_staged_hunk(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "new\n")
     cli.repo.git("add", "f.py")
 
-    hunks = cli.run_json("list", "--staged", "--json")
+    hunks = cli.run_list_json("list", "--staged", "--json")
     hunk_id = hunks[0]["id"]
 
     r = cli.run("show", hunk_id, "--staged")
@@ -52,7 +52,7 @@ def test_show_finds_staged_hunk_without_flag(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "new\n")
     cli.repo.git("add", "f.py")
 
-    hunks = cli.run_json("list", "--staged", "--json")
+    hunks = cli.run_list_json("list", "--staged", "--json")
     hunk_id = hunks[0]["id"]
 
     r = cli.run("show", hunk_id)

--- a/tests/e2e/stage_test.py
+++ b/tests/e2e/stage_test.py
@@ -11,7 +11,7 @@ def test_stage_single_hunk(cli: GitHunkCLI) -> None:
     lines[17] = "CHANGED18"
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
 
     cli.run_ok("stage", hunks[0]["id"])
@@ -34,7 +34,7 @@ def test_stage_multiple_hunks(cli: GitHunkCLI) -> None:
     lines[17] = "CHANGED18"
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     cli.run_ok("stage", hunks[0]["id"], hunks[1]["id"])
 
     staged = cli.repo.git("diff", "--cached")
@@ -54,7 +54,7 @@ def test_stage_from_different_files(cli: GitHunkCLI) -> None:
     cli.repo.write_file("a.py", "AAA\n")
     cli.repo.write_file("b.py", "BBB\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     a_hunk = next(h for h in hunks if h["file"] == "a.py")
 
     cli.run_ok("stage", a_hunk["id"])
@@ -70,7 +70,7 @@ def test_stage_with_line_include(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "LINE1\nLINE2\nLINE3\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
 
     # Diff body: 1=-line1, 2=-line2, 3=-line3, 4=+LINE1, 5=+LINE2, 6=+LINE3
@@ -92,7 +92,7 @@ def test_stage_with_line_exclude(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     cli.repo.write_file("f.py", "LINE1\nLINE2\nLINE3\n")
 
-    hunks = cli.run_json("list", "--json")
+    hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
 
     # Diff body: 1=-line1, 2=-line2, 3=-line3, 4=+LINE1, 5=+LINE2, 6=+LINE3

--- a/tests/e2e/unstage_test.py
+++ b/tests/e2e/unstage_test.py
@@ -8,15 +8,15 @@ def test_unstage_hunk(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "new\n")
     cli.repo.git("add", "f.py")
 
-    staged = cli.run_json("list", "--staged", "--json")
+    staged = cli.run_list_json("list", "--staged", "--json")
     assert len(staged) == 1
 
     cli.run_ok("unstage", staged[0]["id"])
 
-    after_staged = cli.run_json("list", "--staged", "--json")
+    after_staged = cli.run_list_json("list", "--staged", "--json")
     assert len(after_staged) == 0
 
-    unstaged = cli.run_json("list", "--json")
+    unstaged = cli.run_list_json("list", "--json")
     assert len(unstaged) == 1
 
 
@@ -31,10 +31,10 @@ def test_unstage_one_of_multiple(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")
     cli.repo.git("add", "f.py")
 
-    staged = cli.run_json("list", "--staged", "--json")
+    staged = cli.run_list_json("list", "--staged", "--json")
     assert len(staged) == 2
 
     cli.run_ok("unstage", staged[0]["id"])
 
-    after = cli.run_json("list", "--staged", "--json")
+    after = cli.run_list_json("list", "--staged", "--json")
     assert len(after) == 1


### PR DESCRIPTION
## Summary
- Wrap `list --json` in a versioned envelope, `{"schema_version": 1, "hunks": [...]}`, so downstream agents/tools can depend on a documented, versioned shape instead of guessing at a bare array.
- Add a `JSON_SCHEMA_VERSION` constant (single source of truth, imported by the contract test).
- Document the full schema in the README (envelope + field table with types and `status` values) and note the compatibility rule (additive = non-breaking; rename/remove/retype = version bump).
- Add a contract test that pins the envelope and the required hunk keys (subset check, so it tolerates additive fields) and fails on any breaking shape change.
- Tests read hunks through a `run_list_json` helper that unwraps the envelope; ~57 call sites migrated.

**Breaking:** the bare-array output is gone (noted in CHANGELOG).

## Test plan
- [x] contract test: envelope shape + `schema_version` + required hunk keys (`tests/e2e/list_test.py`), incl. the empty case
- [x] `uv run pytest` (173 passed) · `ruff check` / `ruff format --check` / `ty check`
- [x] manual: `list --json` emits the envelope for both empty and non-empty trees

## Notes for the maintainer
- The envelope shape (`schema_version` + `hunks`) is a one-way-door public-API decision; flagging it explicitly in case you'd prefer a different key/layout — easy to adjust.
- Scoped to `list --json` per the acceptance criteria; `skills --json` keeps its own (simpler, bare-array) shape.
- Sequences cleanly with #27 (PR #48, adds `context_before` to each hunk): the contract test uses a required-keys *subset* check, so that additive field won't break it, and adding it won't need a `schema_version` bump.

Closes #23
