### PR TITLE
fix: keep full context_before when section heading contains @@

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -83,8 +83,8 @@ def extract_file_path(file_diff: str) -> str | None:
 
 
 def _extract_context_before(header: str) -> str:
-    match = re.search(r"@@.*@@\s*(.*)", header)
-    return match.group(1).strip() if match and match.group(1).strip() else ""
+    match = re.search(r"@@.*?@@\s*(.*)", header)
+    return match.group(1).strip() if match else ""
 
 
 def _whole_file_hunk(filepath: str, header: str) -> Hunk:

--- a/tests/unit/_hunk/extract_context_before_test.py
+++ b/tests/unit/_hunk/extract_context_before_test.py
@@ -1,0 +1,26 @@
+from git_hunk._hunk import _extract_context_before
+
+
+def test_returns_trailing_context() -> None:
+    assert _extract_context_before("@@ -1,3 +1,4 @@ def foo():") == "def foo():"
+
+
+def test_strips_surrounding_whitespace() -> None:
+    assert _extract_context_before("@@ -1,3 +1,4 @@   def foo():  ") == "def foo():"
+
+
+def test_anchors_to_first_at_at_pair() -> None:
+    header = "@@ -1,3 +1,4 @@ class Foo:  # @@ tag"
+    assert _extract_context_before(header) == "class Foo:  # @@ tag"
+
+
+def test_empty_when_no_trailing_context() -> None:
+    assert _extract_context_before("@@ -1,3 +1,4 @@") == ""
+
+
+def test_empty_when_trailing_context_is_whitespace_only() -> None:
+    assert _extract_context_before("@@ -1,3 +1,4 @@   ") == ""
+
+
+def test_empty_when_header_does_not_match() -> None:
+    assert _extract_context_before("diff --git a/f.py b/f.py") == ""


### PR DESCRIPTION
The hunk-header parser pulls the section heading after the `@@ … @@` range with
a greedy regex (`@@.*@@`). When that heading itself contains `@@` — a Ruby class
variable like `@@count`, or a trailing `# @@` comment — the match ran to the
*last* `@@` on the line and truncated the heading, so `context_before` (shown in
the human listing and emitted in `--json`) lost everything up to the embedded
`@@`.

Anchoring to the first closing `@@` pair with a lazy quantifier (`@@.*?@@`) fixes
it: the range between the delimiters never contains `@@`, so the first pair is
always the structural one. Also drops a redundant double `strip()` in the same
return.

## Test plan
- [x] tests added: `tests/unit/_hunk/extract_context_before_test.py` — `test_anchors_to_first_at_at_pair` fails on the old greedy regex, passes on the fix
- [x] `make test` (182 passed) and `make lint` clean
