### PR TITLE
docs: add context_before --json field to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   `git-hunk stage src/foo.py` stages every hunk in that file (#21).
 - `--dry-run` for `stage`, `unstage`, and `discard`, previewing what would
   change without touching the index or working tree (#25).
+- `context_before` field in `list --json`, exposing the function/section heading
+  git names after the `@@` header (#27).
 
 ### Changed
 


### PR DESCRIPTION
The `context_before` field was added to `list --json` in #48 (closing #27) but never recorded in the changelog's `Added` section, so the `[Unreleased]` list is missing a user-facing field for v0.3.0. This adds the entry.

## Test plan
- [x] `make lint` (mdformat) clean on `CHANGELOG.md`