### PR TITLE
chore: pipe git ls-files into xargs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,17 @@ lint:  # Lint code
 	$(call exec,uv run ruff format --check)
 	$(call exec,uv run ruff check)
 	$(call exec,uv run ty check --no-progress)
-	$(call exec,uv run taplo fmt --check $(shell git ls-files "*.toml"))
-	$(call exec,uv run mdformat --check $(shell git ls-files "*.md"))
-	$(call exec,uv run yamlfix --check $(shell git ls-files "*.yml" "*.yaml"))
+	$(call exec,git ls-files "*.toml" | xargs uv run taplo fmt --check)
+	$(call exec,git ls-files "*.md" | xargs uv run mdformat --check)
+	$(call exec,git ls-files "*.yml" "*.yaml" | xargs uv run yamlfix --check)
 	$(call exec,uv run typos)
 
 format:  # Format code
 	$(call exec,uv run ruff format)
 	$(call exec,uv run ruff check --fix)
-	$(call exec,uv run taplo fmt $(shell git ls-files "*.toml"))
-	$(call exec,uv run mdformat $(shell git ls-files "*.md"))
-	$(call exec,uv run yamlfix $(shell git ls-files "*.yml" "*.yaml"))
+	$(call exec,git ls-files "*.toml" | xargs uv run taplo fmt)
+	$(call exec,git ls-files "*.md" | xargs uv run mdformat)
+	$(call exec,git ls-files "*.yml" "*.yaml" | xargs uv run yamlfix)
 
 test:  # Run tests
 	$(call exec,uv run pytest -v tests/ $(PYTEST_ARGS))


### PR DESCRIPTION
Adopt labelme's xargs style in the `lint` and `format` targets: pipe `git ls-files` into `xargs` instead of expanding it inline with `$(shell ...)`. This keeps the file-globbed tool invocations consistent with labelme's Makefile and makes the printed command line show the pipeline rather than the full expanded file list.

## Test plan
- [x] `make lint`