### PR TITLE
fix: partial line-staging corrupts no-newline-at-EOF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,5 +44,8 @@ and this project adheres to
   with a readable error (#15).
 - Constrain the source distribution to the package, tests, and metadata so it
   no longer ships unrelated `tmp/` files (#16).
+- Split the no-newline last line when partial line-staging (`-l`) gives it a
+  trailing newline, so staging only the addition no longer merges it with the
+  added line and corrupts the file (#54).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -59,7 +59,6 @@ class _BodyLine(NamedTuple):
     prefix: str  # rendered side: ' ' context, '-' old, '+' new
     text: str
     no_newline: bool  # the line it represents has no trailing newline
-    origin: str  # original prefix, before an unselected change became context
 
 
 def _select_body_lines(
@@ -68,11 +67,7 @@ def _select_body_lines(
     *,
     keep_prefix: str,
 ) -> list[_BodyLine]:
-    """Apply the line selection, folding each no-newline marker onto its line.
-
-    ``origin`` records the original prefix so a converted change kept as context
-    can be split back apart later when its no-newline marker has to move.
-    """
+    """Apply the line selection, folding each no-newline marker onto its line."""
     kept: list[_BodyLine] = []
     line_num = 0
     dropped_last = False
@@ -84,9 +79,9 @@ def _select_body_lines(
         line_num += 1
         prefix, text = line[:1], line[1:]
         if prefix == " " or line_num in selected:
-            kept.append(_BodyLine(prefix, text, False, prefix))
-        elif prefix == keep_prefix:
-            kept.append(_BodyLine(" ", text, False, prefix))  # survive as context
+            kept.append(_BodyLine(prefix=prefix, text=text, no_newline=False))
+        elif prefix == keep_prefix:  # unselected change survives as context
+            kept.append(_BodyLine(prefix=" ", text=text, no_newline=False))
         else:
             dropped_last = True
             continue
@@ -97,10 +92,13 @@ def _select_body_lines(
 def _render_body_lines(kept: list[_BodyLine]) -> list[str]:
     # A no-newline marker is valid only on the final line of the side it
     # describes. A kept change line always sits at its side's EOF, and a context
-    # marker on the very last body line ends both sides. But a change kept as
-    # context (origin '-' or '+') that now has lines after it lost its newline on
-    # only one side: split it back into a '-'/'+' pair so the marker stays on the
-    # side that truly has no trailing newline (the other side gains a newline).
+    # marker on the very last body line ends both sides. The remaining case is an
+    # old-side line kept as context that now has lines after it: it was the old
+    # EOF (no trailing newline) but the new side continues past it, so split it
+    # back into a '-'/'+' pair, keeping the marker on the old side while the new
+    # side gains a newline. The mirror (a new-side no-newline line kept as context
+    # under reverse) cannot reach here: a new-side EOF line never has kept lines
+    # after it, so it is always the last body line and takes the branch above.
     last_index = len(kept) - 1
     rendered = []
     for index, line in enumerate(kept):
@@ -109,14 +107,10 @@ def _render_body_lines(kept: list[_BodyLine]) -> list[str]:
         elif line.prefix != " " or index == last_index:
             rendered.append(line.prefix + line.text)
             rendered.append(NO_NEWLINE_MARKER)
-        elif line.origin == "-":
-            rendered.append("-" + line.text)
-            rendered.append(NO_NEWLINE_MARKER)
-            rendered.append("+" + line.text)
         else:
             rendered.append("-" + line.text)
-            rendered.append("+" + line.text)
             rendered.append(NO_NEWLINE_MARKER)
+            rendered.append("+" + line.text)
     return rendered
 
 

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -1,6 +1,8 @@
 import re
 from dataclasses import replace
+from typing import NamedTuple
 
+from ._hunk import NO_NEWLINE_MARKER
 from ._hunk import Hunk
 from ._hunk import count_changes
 from ._hunk import is_no_newline_marker
@@ -53,6 +55,71 @@ def parse_line_spec(spec: str) -> tuple[set[int], bool]:
     return lines, exclude
 
 
+class _BodyLine(NamedTuple):
+    prefix: str  # rendered side: ' ' context, '-' old, '+' new
+    text: str
+    no_newline: bool  # the line it represents has no trailing newline
+    origin: str  # original prefix, before an unselected change became context
+
+
+def _select_body_lines(
+    body: list[str],
+    selected: set[int],
+    *,
+    keep_prefix: str,
+) -> list[_BodyLine]:
+    """Apply the line selection, folding each no-newline marker onto its line.
+
+    ``origin`` records the original prefix so a converted change kept as context
+    can be split back apart later when its no-newline marker has to move.
+    """
+    kept: list[_BodyLine] = []
+    line_num = 0
+    dropped_last = False
+    for line in body:
+        if is_no_newline_marker(line):
+            if not dropped_last:
+                kept[-1] = kept[-1]._replace(no_newline=True)
+            continue
+        line_num += 1
+        prefix, text = line[:1], line[1:]
+        if prefix == " " or line_num in selected:
+            kept.append(_BodyLine(prefix, text, False, prefix))
+        elif prefix == keep_prefix:
+            kept.append(_BodyLine(" ", text, False, prefix))  # survive as context
+        else:
+            dropped_last = True
+            continue
+        dropped_last = False
+    return kept
+
+
+def _render_body_lines(kept: list[_BodyLine]) -> list[str]:
+    # A no-newline marker is valid only on the final line of the side it
+    # describes. A kept change line always sits at its side's EOF, and a context
+    # marker on the very last body line ends both sides. But a change kept as
+    # context (origin '-' or '+') that now has lines after it lost its newline on
+    # only one side: split it back into a '-'/'+' pair so the marker stays on the
+    # side that truly has no trailing newline (the other side gains a newline).
+    last_index = len(kept) - 1
+    rendered = []
+    for index, line in enumerate(kept):
+        if not line.no_newline:
+            rendered.append(line.prefix + line.text)
+        elif line.prefix != " " or index == last_index:
+            rendered.append(line.prefix + line.text)
+            rendered.append(NO_NEWLINE_MARKER)
+        elif line.origin == "-":
+            rendered.append("-" + line.text)
+            rendered.append(NO_NEWLINE_MARKER)
+            rendered.append("+" + line.text)
+        else:
+            rendered.append("-" + line.text)
+            rendered.append("+" + line.text)
+            rendered.append(NO_NEWLINE_MARKER)
+    return rendered
+
+
 def _filter_body_lines(
     body: list[str],
     selected: set[int],
@@ -63,29 +130,9 @@ def _filter_body_lines(
     # expects. A forward (stage) apply matches OLD content, so unselected '-'
     # lines become context and unselected '+' lines drop; a reverse (unstage,
     # discard) apply matches NEW content, so the two sides swap.
-    drop_prefix = "-" if reverse else "+"
     keep_prefix = "+" if reverse else "-"
-    new_body = []
-    line_num = 0
-    prev_kept = False
-    for line in body:
-        if is_no_newline_marker(line):
-            if prev_kept:
-                new_body.append(line)
-            continue
-        line_num += 1
-        if line_num in selected:
-            new_body.append(line)
-            prev_kept = True
-        elif line.startswith(drop_prefix):
-            prev_kept = False
-        elif line.startswith(keep_prefix):
-            new_body.append(" " + line[1:])
-            prev_kept = True
-        else:
-            new_body.append(line)
-            prev_kept = True
-    return new_body
+    kept = _select_body_lines(body, selected, keep_prefix=keep_prefix)
+    return _render_body_lines(kept)
 
 
 def filter_hunk_lines(

--- a/tests/e2e/no_newline_test.py
+++ b/tests/e2e/no_newline_test.py
@@ -87,3 +87,70 @@ def test_list_counts_ignore_no_newline_marker(cli: GitHunkCLI) -> None:
     hunks = cli.run_list_json("list", "--unstaged", "--json")
     assert hunks[0]["additions"] == 1
     assert hunks[0]["deletions"] == 1
+
+
+def test_stage_addition_of_no_newline_to_newline_keeps_lines_separate(
+    cli: GitHunkCLI,
+) -> None:
+    # Regression for #54: staging only the addition of a no-newline -> newline
+    # edit must not merge the old last line with the addition.
+    _commit(cli, "a\nb")
+    cli.repo.write_file("f.txt", "a\nB\n")
+
+    # Body lines: 1= a 2=-b 3=+B. Stage only the addition.
+    cli.run_ok("stage", _only_hunk_id(cli), "-l", "3")
+
+    assert cli.repo.git("show", ":f.txt") == "a\nb\nB\n"
+
+
+def test_stage_addition_then_remainder_reaches_working_tree(cli: GitHunkCLI) -> None:
+    _commit(cli, "a\nb")
+    cli.repo.write_file("f.txt", "a\nB\n")
+
+    cli.run_ok("stage", _only_hunk_id(cli), "-l", "3")
+    assert cli.repo.git("show", ":f.txt") == "a\nb\nB\n"
+
+    remaining = cli.run_list_json("list", "--unstaged", "--json")
+    cli.run_ok("stage", remaining[0]["id"])
+
+    assert cli.repo.git("show", ":f.txt") == "a\nB\n"
+
+
+def test_stage_addition_both_sides_no_newline_keeps_lines_separate(
+    cli: GitHunkCLI,
+) -> None:
+    _commit(cli, "a\nb")
+    cli.repo.write_file("f.txt", "a\nB")
+
+    # Body lines: 1= a 2=-b 3=+B, both last lines lack a trailing newline.
+    cli.run_ok("stage", _only_hunk_id(cli), "-l", "3")
+
+    assert cli.repo.git("show", ":f.txt") == "a\nb\nB"
+
+
+def test_discard_addition_of_no_newline_to_newline_keeps_lines_separate(
+    cli: GitHunkCLI,
+) -> None:
+    _commit(cli, "a\nb")
+    cli.repo.write_file("f.txt", "a\nB\n")
+
+    cli.run_ok("discard", _only_hunk_id(cli), "-l", "3")
+
+    # Discarding only the +B addition reverts it; the -b deletion stays.
+    assert (Path(cli.repo.path) / "f.txt").read_text() == "a\n"
+
+
+def test_unstage_addition_of_no_newline_to_newline_keeps_lines_separate(
+    cli: GitHunkCLI,
+) -> None:
+    _commit(cli, "a\nb")
+    cli.repo.write_file("f.txt", "a\nB\n")
+
+    cli.run_ok("stage", _only_hunk_id(cli))
+    staged = cli.run_list_json("list", "--staged", "--json")
+
+    # Body lines: 1= a 2=-b 3=+B. Unstage only the addition from the index.
+    cli.run_ok("unstage", staged[0]["id"], "-l", "3")
+
+    assert cli.repo.git("show", ":f.txt") == "a\n"
+    assert (Path(cli.repo.path) / "f.txt").read_text() == "a\nB\n"

--- a/tests/unit/_lines/filter_test.py
+++ b/tests/unit/_lines/filter_test.py
@@ -135,3 +135,19 @@ def test_keep_deletion_drops_no_newline_marker_from_dropped_addition() -> None:
     assert result.diff == f"@@ -1,2 +1,1 @@\n a\n-b\n{NO_NEWLINE_MARKER}"
     assert result.additions == 0
     assert result.deletions == 1
+
+
+_REVERSE_NEW_SIDE_NO_NEWLINE = (
+    f"@@ -1,4 +1,4 @@\n a\n-b\n+B\n c\n-d\n+D\n{NO_NEWLINE_MARKER}"
+)
+
+
+def test_reverse_keeps_no_newline_new_context_without_split() -> None:
+    # Reverse keeps the unselected '+D' (new-side EOF, no trailing newline) as
+    # context. It is always the last body line, so its marker stays put and it
+    # never splits: the '+'-origin split branch of _render_body_lines is dead.
+    hunk = _make_hunk(_REVERSE_NEW_SIDE_NO_NEWLINE)
+    result = filter_hunk_lines(hunk, {3}, exclude=False, reverse=True)
+    assert result.diff == (f"@@ -1,3 +1,4 @@\n a\n+B\n c\n D\n{NO_NEWLINE_MARKER}")
+    assert result.additions == 1
+    assert result.deletions == 0

--- a/tests/unit/_lines/filter_test.py
+++ b/tests/unit/_lines/filter_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from git_hunk._hunk import NO_NEWLINE_MARKER
 from git_hunk._hunk import Hunk
 from git_hunk._lines import filter_hunk_lines
 
@@ -110,3 +111,27 @@ def test_reverse_exclude_first_group() -> None:
     assert "+D" in result.diff
     assert " B" in result.diff  # excluded +B kept as NEW context
     assert "-b" not in result.diff  # excluded -b dropped
+
+
+_NO_NEWLINE_TO_NEWLINE = f"@@ -1,2 +1,2 @@\n a\n-b\n{NO_NEWLINE_MARKER}\n+B"
+
+
+def test_keep_addition_splits_stale_no_newline_context() -> None:
+    # The unselected '-b' (no trailing newline) survives as context, but the
+    # kept '+B' now follows it: it must split into -b/+b so the marker stays on
+    # the old side and 'b' gains a newline rather than merging with 'B'.
+    hunk = _make_hunk(_NO_NEWLINE_TO_NEWLINE)
+    result = filter_hunk_lines(hunk, {3}, exclude=False)
+    assert result.diff == (f"@@ -1,2 +1,3 @@\n a\n-b\n{NO_NEWLINE_MARKER}\n+b\n+B")
+    assert result.additions == 2
+    assert result.deletions == 1
+
+
+def test_keep_deletion_drops_no_newline_marker_from_dropped_addition() -> None:
+    # Keeping only '-b' drops '+B' and its marker; 'b' keeps no trailing newline
+    # as the old side's final line, the new side ends at the ' a' context.
+    hunk = _make_hunk(_NO_NEWLINE_TO_NEWLINE)
+    result = filter_hunk_lines(hunk, {2}, exclude=False)
+    assert result.diff == f"@@ -1,2 +1,1 @@\n a\n-b\n{NO_NEWLINE_MARKER}"
+    assert result.additions == 0
+    assert result.deletions == 1


### PR DESCRIPTION
Fixes #54.

Partial line-staging (`-l`) of a hunk whose last line gains a trailing newline (no-newline -> has-newline) silently corrupted the file: the no-newline last line was merged with the staged addition. `printf 'a\nb'` then staging only the `+B` of `a\nB\n` produced an index of `a\nbB\n` instead of `a\nb\nB\n`.

The cause was in `_filter_body_lines`: a `\ No newline at end of file` marker was kept whenever the preceding line survived. When an unselected `-b` (old EOF, no newline) became context and a selected `+B` was appended after it, the marker stayed glued to the now-non-final context line, so `git apply` merged them.

## Summary
- Split the transform into `_select_body_lines` (folds each marker onto the line it annotates, records the line's original prefix) and `_render_body_lines` (re-places markers).
- Re-place markers by the rule *a no-newline marker is valid only on the final line of the side it describes*. When a converted-context line is no longer its side's final line, split it back into a `-`/`+` pair: the side that truly has no trailing newline keeps the marker, the other side gains a newline.
- The bug case now stages `a\nb\nB\n`, keeping `b` and `B` as separate lines.

## Test plan
- [x] e2e tests for all four acceptance criteria: no-newline->newline stage, unstage, discard, and both-sides-no-newline (`tests/e2e/no_newline_test.py`)
- [x] unit tests asserting exact marker placement on split and on dropped additions (`tests/unit/_lines/filter_test.py`)
- [x] exhaustive round-trip sweep against real `git apply`: every selection subset across 9 scenarios, 127 forward (stage) + 127 reverse (discard), all apply cleanly with no data loss
- [x] `make lint` and full suite (189 passed) green
