### PR TITLE
refactor: extract strip_trailing_empty_lines helper

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -43,6 +43,12 @@ def count_changes(lines: list[str]) -> tuple[int, int]:
     return additions, deletions
 
 
+def strip_trailing_empty_lines(lines: list[str]) -> list[str]:
+    while lines and lines[-1] == "":
+        lines = lines[:-1]
+    return lines
+
+
 def _body_id(filepath: str, diff_content: str) -> str:
     """Stable across partial staging: ignores @@ headers that shift."""
     body = "\n".join(
@@ -150,9 +156,7 @@ def parse_diff(diff_output: str) -> list[Hunk]:
         # section, so there is nothing finer to split here (use -l for that).
         for part in parts[1:]:
             header_line, *body_lines = part.split("\n")
-
-            while body_lines and body_lines[-1] == "":
-                body_lines = body_lines[:-1]
+            body_lines = strip_trailing_empty_lines(body_lines)
 
             additions, deletions = count_changes(body_lines)
             hunks.append(

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -6,6 +6,7 @@ from ._hunk import NO_NEWLINE_MARKER
 from ._hunk import Hunk
 from ._hunk import count_changes
 from ._hunk import is_no_newline_marker
+from ._hunk import strip_trailing_empty_lines
 
 
 def _parse_line_number(token: str) -> int:
@@ -141,10 +142,7 @@ def filter_hunk_lines(
     """
     diff_lines = hunk.diff.split("\n")
     header = diff_lines[0]
-    body = diff_lines[1:]
-
-    while body and body[-1] == "":
-        body = body[:-1]
+    body = strip_trailing_empty_lines(diff_lines[1:])
 
     total = sum(1 for line in body if not is_no_newline_marker(line))
 


### PR DESCRIPTION
`parse_diff` and `filter_hunk_lines` each stripped trailing empty lines
from a diff body with the same `while lines and lines[-1] == "": lines =
lines[:-1]` loop. Extract it into one `strip_trailing_empty_lines` helper
in `_hunk.py` (alongside `count_changes`, the existing cross-module diff-body
utility) so the handling lives in a single place. Behavior is unchanged.

## Test plan
- [x] `make test` (190 passed)
- [x] `make lint` (ruff format/check, ty, taplo, mdformat, yamlfix, typos)
- [x] manual smoke: `git_hunk list` and `stage <id> -l 2` parse and partial-stage correctly
