### PR TITLE
refactor: split diff into per-file headers once in build_patch

### DIFF
--- a/git_hunk/_patch.py
+++ b/git_hunk/_patch.py
@@ -4,25 +4,30 @@ from ._hunk import Hunk
 from ._hunk import extract_file_path
 
 
-def _get_file_header(diff_output: str, filepath: str) -> str:
-    file_diffs = re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE)
-    for file_diff in file_diffs:
-        if extract_file_path(file_diff) == filepath:
-            # Return everything up to the first @@ line
-            parts = re.split(r"(?=^@@)", file_diff, flags=re.MULTILINE)
-            return parts[0]
-    raise ValueError(f"File header not found for {filepath}")
+def _extract_file_headers(diff_output: str) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for file_diff in re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE):
+        filepath = extract_file_path(file_diff)
+        if filepath is None:
+            continue
+        headers[filepath] = re.split(
+            r"(?=^@@)", file_diff, maxsplit=1, flags=re.MULTILINE
+        )[0]
+    return headers
 
 
 def build_patch(hunks: list[Hunk], diff_output: str) -> str:
-    files = {}
+    files: dict[str, list[Hunk]] = {}
     for hunk in hunks:
         files.setdefault(hunk.file, []).append(hunk)
 
+    headers = _extract_file_headers(diff_output)
+
     patches = []
     for filepath, file_hunks in files.items():
-        header = _get_file_header(diff_output, filepath)
+        if filepath not in headers:
+            raise ValueError(f"File header not found for {filepath}")
         hunk_diffs = "\n".join(h.diff for h in file_hunks)
-        patches.append(header + hunk_diffs + "\n")
+        patches.append(headers[filepath] + hunk_diffs + "\n")
 
     return "".join(patches)

--- a/tests/unit/_patch_test.py
+++ b/tests/unit/_patch_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from git_hunk._hunk import Hunk
-from git_hunk._patch import _get_file_header
+from git_hunk._patch import _extract_file_headers
 from git_hunk._patch import build_patch
 
 DIFF_SINGLE = (
@@ -48,16 +48,22 @@ def _make_hunk(*, file: str, diff: str) -> Hunk:
     )
 
 
-def test_get_file_header_extracts_up_to_hunk() -> None:
-    header = _get_file_header(DIFF_SINGLE, "f.py")
+def test_extract_file_headers_stops_before_hunk() -> None:
+    header = _extract_file_headers(DIFF_SINGLE)["f.py"]
     assert header.startswith("diff --git a/f.py b/f.py\n")
     assert "+++ b/f.py\n" in header
     assert "@@" not in header
 
 
-def test_get_file_header_missing_file_raises() -> None:
+def test_extract_file_headers_keys_every_file() -> None:
+    headers = _extract_file_headers(DIFF_TWO_FILES)
+    assert set(headers) == {"a.py", "b.py"}
+
+
+def test_build_patch_missing_file_raises() -> None:
+    hunk = _make_hunk(file="nonexistent.py", diff="")
     with pytest.raises(ValueError, match="not found"):
-        _get_file_header(DIFF_SINGLE, "nonexistent.py")
+        build_patch([hunk], DIFF_SINGLE)
 
 
 def test_build_patch_single_hunk() -> None:


### PR DESCRIPTION
`build_patch` called `_get_file_header` once per changed file, and each call
re-split the entire `diff_output` with `re.split(r"(?=^diff --git )")` and scanned
it linearly, making header lookup O(files^2). Replace it with
`_extract_file_headers`, which splits the diff once into a `{path: header}` map
that `build_patch` indexes. Behavior is unchanged; the missing-file `ValueError`
now raises from `build_patch` instead of the helper.

## Test plan
- [x] `make test` (191 passed)
- [x] `make lint` (ruff format/check, ty, taplo, mdformat, yamlfix, typos)
- [x] CLI smoke: `git-hunk stage <id>` partial-stages one of two changed files correctly
