### PR TITLE
refactor: extract split_file_diffs helper for per-file diff splitting

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -77,6 +77,10 @@ def _with_stable_ids(hunks: list[Hunk]) -> list[Hunk]:
     ]
 
 
+def split_file_diffs(diff_output: str) -> list[str]:
+    return re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE)
+
+
 def extract_file_path(file_diff: str) -> str | None:
     first_line = file_diff.split("\n", 1)[0]
     # For non-renames git emits `diff --git a/<path> b/<path>` with both halves
@@ -127,7 +131,7 @@ def parse_diff(diff_output: str) -> list[Hunk]:
         return []
 
     hunks = []
-    file_diffs = re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE)
+    file_diffs = split_file_diffs(diff_output)
 
     for file_diff in file_diffs:
         if not file_diff.strip():

--- a/git_hunk/_patch.py
+++ b/git_hunk/_patch.py
@@ -2,11 +2,12 @@ import re
 
 from ._hunk import Hunk
 from ._hunk import extract_file_path
+from ._hunk import split_file_diffs
 
 
 def _extract_file_headers(diff_output: str) -> dict[str, str]:
     headers: dict[str, str] = {}
-    for file_diff in re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE):
+    for file_diff in split_file_diffs(diff_output):
         filepath = extract_file_path(file_diff)
         if filepath is None:
             continue


### PR DESCRIPTION
The `re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE)` idiom for
splitting a combined diff into per-file chunks was written verbatim in two
places: `parse_diff` (`_hunk.py`) and `_extract_file_headers` (`_patch.py`).
This extracts it into a `split_file_diffs` helper in `_hunk.py` so the
non-obvious lookahead regex is spelled once and both call sites share it.

Pure refactor, no behavior change. Follows the same dedup pattern as the
recent `strip_trailing_empty_lines` extraction, and matches the existing
non-prefixed cross-module helpers (`extract_file_path`, `strip_trailing_empty_lines`).

## Test plan
- [x] `make test` (191 passed)
- [x] `make lint`
