### PR TITLE
fix: byte-safe JSON for non-UTF-8 paths and content in list --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to
 - **Breaking:** `list --json` now wraps its output in a versioned envelope,
   `{"schema_version": 1, "hunks": [...]}`, instead of a bare array, so consumers
   can depend on a documented, versioned shape (#23).
+- **Breaking:** `list --json` emits the git-derived string fields (`file`,
+  `header`, `context_before`, `diff`) as byte-safe objects (`{"text": "..."}`
+  for UTF-8, `{"bytes": "<base64>"}` otherwise) instead of bare strings, and
+  bumps `schema_version` to 2. This keeps the output valid for strict JSON
+  parsers (Go, Rust) when a path or diff line carries non-UTF-8 bytes (#44).
 - README image paths are rewritten to absolute URLs so they render on PyPI.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -126,34 +126,42 @@ shape:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "hunks": [
     {
       "id": "d161935",
-      "file": "src/main.py",
+      "file": { "text": "src/main.py" },
       "status": "unstaged",
-      "header": "@@ -10,3 +10,5 @@ def main():",
-      "context_before": "def main():",
+      "header": { "text": "@@ -10,3 +10,5 @@ def main():" },
+      "context_before": { "text": "def main():" },
       "additions": 2,
       "deletions": 0,
-      "diff": "..."
+      "diff": { "text": "..." }
     }
   ]
 }
 ```
 
-| Field            | Type   | Description                                                                                        |
-| ---------------- | ------ | -------------------------------------------------------------------------------------------------- |
-| `schema_version` | int    | Envelope version; bumped on any incompatible change to the shape below.                            |
-| `hunks`          | array  | The hunks (empty array when there are no changes).                                                 |
-| `id`             | string | Stable, content-based hunk id (7-char SHA-256 prefix); accepts prefixes.                           |
-| `file`           | string | Path of the changed file.                                                                          |
-| `status`         | string | One of `staged`, `unstaged`, `untracked`.                                                          |
-| `header`         | string | The hunk's `@@ ... @@` header, or a `Binary file (...)` / `Mode ...` label for whole-file changes. |
-| `context_before` | string | The function/section git names after the `@@` header; empty when git provides no context.          |
-| `additions`      | int    | Number of added lines.                                                                             |
-| `deletions`      | int    | Number of removed lines.                                                                           |
-| `diff`           | string | The unified diff for the hunk (empty for whole-file changes).                                      |
+| Field            | Type   | Description                                                                                       |
+| ---------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| `schema_version` | int    | Envelope version; bumped on any incompatible change to the shape below.                           |
+| `hunks`          | array  | The hunks (empty array when there are no changes).                                                |
+| `id`             | string | Stable, content-based hunk id (7-char SHA-256 prefix); accepts prefixes.                          |
+| `file`           | object | Path of the changed file, as a byte-safe value (see below).                                       |
+| `status`         | string | One of `staged`, `unstaged`, `untracked`.                                                         |
+| `header`         | object | The hunk's `@@ ... @@` header, or a `Binary file (...)` / `Mode ...` label, as a byte-safe value. |
+| `context_before` | object | The function/section git names after the `@@` header, as a byte-safe value; empty when none.      |
+| `additions`      | int    | Number of added lines.                                                                            |
+| `deletions`      | int    | Number of removed lines.                                                                          |
+| `diff`           | object | The unified diff for the hunk, as a byte-safe value (empty for whole-file changes).               |
+
+Fields carrying git-derived text (`file`, `header`, `context_before`, `diff`)
+are byte-safe values: always an object with exactly one key, never a bare
+string. UTF-8 content is `{"text": "<string>"}`; non-UTF-8 content (a path or
+diff line with bytes that aren't valid UTF-8) is `{"bytes": "<base64>"}`, the
+standard base64 of the raw bytes, so the original is recoverable losslessly and
+the document stays valid for strict JSON parsers. (Plain string output would
+emit lone surrogates that `jq` corrupts and Go/Rust parsers reject.)
 
 Adding a new field is backward-compatible and does not change `schema_version`;
 renaming, removing, or changing the type of an existing field bumps it. (Before

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -47,7 +47,7 @@ from ._ui import print_skill_list
 from ._ui import print_version
 
 # Bump when the `list --json` shape changes incompatibly (see README JSON output).
-JSON_SCHEMA_VERSION: Final = 1
+JSON_SCHEMA_VERSION: Final = 2
 
 
 class CliError(Exception):

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import re
 from collections import Counter
@@ -11,6 +12,22 @@ NO_NEWLINE_MARKER: Final = "\\ No newline at end of file"
 
 def is_no_newline_marker(line: str) -> bool:
     return line == NO_NEWLINE_MARKER
+
+
+def _encode_arbitrary(s: str) -> dict[str, str]:
+    """Byte-safe JSON encoding for git-derived text that may not be UTF-8.
+
+    run_git decodes with surrogateescape, so a non-UTF-8 byte lands as a lone
+    surrogate that ensure_ascii serializes as a `\\udcXX` escape strict parsers
+    reject. Emit a ripgrep-style discriminated union instead: always an object,
+    never a bare string, so consumers have one code path.
+    """
+    try:
+        s.encode("utf-8")  # probe: raises on the lone surrogates surrogateescape left
+    except UnicodeEncodeError:
+        raw = s.encode(errors="surrogateescape")
+        return {"bytes": base64.b64encode(raw).decode("ascii")}
+    return {"text": s}
 
 
 @dataclass(frozen=True)
@@ -27,13 +44,13 @@ class Hunk:
     def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
-            "file": self.file,
+            "file": _encode_arbitrary(self.file),
             "status": self.status,
-            "header": self.header,
-            "context_before": self.context_before,
+            "header": _encode_arbitrary(self.header),
+            "context_before": _encode_arbitrary(self.context_before),
             "additions": self.additions,
             "deletions": self.deletions,
-            "diff": self.diff,
+            "diff": _encode_arbitrary(self.diff),
         }
 
 

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -182,8 +182,12 @@ git-hunk list --json      # machine-readable; plain output is usually enough
 ```
 
 `list` and `show` search both staged and unstaged by default. `list --json`
-returns a versioned envelope, `{"schema_version": 1, "hunks": [...]}`; read the
-hunks from the `hunks` array.
+returns a versioned envelope, `{"schema_version": 2, "hunks": [...]}`; read the
+hunks from the `hunks` array. In each hunk the git-derived text fields (`file`,
+`header`, `context_before`, `diff`) are byte-safe objects with exactly one key:
+`{"text": "<string>"}` for UTF-8, or `{"bytes": "<base64>"}` when the bytes
+aren't valid UTF-8. `id` and `status` stay plain strings; `additions` and
+`deletions` stay ints.
 
 ## Working safely
 

--- a/tests/e2e/binary_test.py
+++ b/tests/e2e/binary_test.py
@@ -9,7 +9,7 @@ from .conftest import GitHunkCLI
 
 def _id_for(cli: GitHunkCLI, path: str, *flags: str) -> str:
     hunks = cli.run_list_json("list", *flags, "--json")
-    return next(h["id"] for h in hunks if h["file"] == path)
+    return next(h["id"] for h in hunks if h["file"]["text"] == path)
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ def test_list_distinguishes_modified_and_deleted_binary(cli: GitHunkCLI) -> None
     (root / "d.bin").unlink()
 
     headers = {
-        h["file"]: h["header"]
+        h["file"]["text"]: h["header"]["text"]
         for h in cli.run_list_json("list", "--unstaged", "--json")
     }
     assert headers["a.bin"] == "Binary file (modified)"
@@ -89,7 +89,8 @@ def test_stage_added_binary(cli: GitHunkCLI) -> None:
 
     cli.repo.git("add", "n.bin")
     staged = {
-        h["file"]: h["header"] for h in cli.run_list_json("list", "--staged", "--json")
+        h["file"]["text"]: h["header"]["text"]
+        for h in cli.run_list_json("list", "--staged", "--json")
     }
     assert staged["n.bin"] == "Binary file (added)"
 
@@ -109,7 +110,7 @@ def test_stage_and_discard_mode_only_change(cli: GitHunkCLI) -> None:
     os.chmod(path, 0o755)
 
     headers = {
-        h["file"]: h["header"]
+        h["file"]["text"]: h["header"]["text"]
         for h in cli.run_list_json("list", "--unstaged", "--json")
     }
     assert headers["m.sh"].startswith("Mode ")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from typing import Any
 from typing import cast
 
 import pytest
@@ -46,10 +47,11 @@ class GitHunkCLI:
     def run_list_envelope(self, *args: str) -> dict[str, object]:
         return cast("dict[str, object]", json.loads(self.run_ok(*args)))
 
-    def run_list_json(self, *args: str) -> list[dict[str, str]]:
+    def run_list_json(self, *args: str) -> list[dict[str, Any]]:
         # `list --json` wraps the hunks in a versioned envelope; tests that only
-        # need the hunks call this to unwrap it.
-        return cast("list[dict[str, str]]", self.run_list_envelope(*args)["hunks"])
+        # need the hunks call this to unwrap it. Hunk values are heterogeneous
+        # (str/int scalars and `{"text"|"bytes": ...}` byte-safe objects).
+        return cast("list[dict[str, Any]]", self.run_list_envelope(*args)["hunks"])
 
 
 @pytest.fixture

--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import cast
 
 from git_hunk._cli import JSON_SCHEMA_VERSION
@@ -14,6 +15,7 @@ _REQUIRED_HUNK_KEYS = {
     "diff",
 }
 _STATUSES = {"staged", "unstaged", "untracked"}
+_BYTE_SAFE_FIELDS = {"file", "header", "context_before", "diff"}
 
 
 def test_json_envelope_contract(cli: GitHunkCLI) -> None:
@@ -24,11 +26,15 @@ def test_json_envelope_contract(cli: GitHunkCLI) -> None:
 
     envelope = cli.run_list_envelope("list", "--json")
     assert envelope["schema_version"] == JSON_SCHEMA_VERSION
-    hunks = cast("list[dict[str, str]]", envelope["hunks"])
+    hunks = cast("list[dict[str, Any]]", envelope["hunks"])
     assert hunks
     for hunk in hunks:
         assert _REQUIRED_HUNK_KEYS <= hunk.keys()
         assert hunk["status"] in _STATUSES
+        # The byte-safe fields are objects with exactly one of text/bytes, never
+        # bare strings; this locks the schema v2 shape against a regression.
+        for field in _BYTE_SAFE_FIELDS:
+            assert set(hunk[field]) in ({"text"}, {"bytes"})
 
 
 def test_json_envelope_present_when_empty(cli: GitHunkCLI) -> None:
@@ -58,7 +64,7 @@ def test_single_file_single_hunk(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
-    assert hunks[0]["file"] == "f.py"
+    assert hunks[0]["file"]["text"] == "f.py"
     assert hunks[0]["additions"] == 1
     assert hunks[0]["deletions"] == 1
     assert "id" in hunks[0]
@@ -76,7 +82,7 @@ def test_single_file_multiple_hunks(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
-    assert all(h["file"] == "f.py" for h in hunks)
+    assert all(h["file"]["text"] == "f.py" for h in hunks)
 
 
 def test_multi_file_changes(cli: GitHunkCLI) -> None:
@@ -90,7 +96,7 @@ def test_multi_file_changes(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
-    files = {h["file"] for h in hunks}
+    files = {h["file"]["text"] for h in hunks}
     assert files == {"a.py", "b.py"}
 
 
@@ -103,7 +109,7 @@ def test_list_staged(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--staged", "--json")
     assert len(hunks) == 1
-    assert hunks[0]["file"] == "f.py"
+    assert hunks[0]["file"]["text"] == "f.py"
 
 
 def test_list_file_filter(cli: GitHunkCLI) -> None:
@@ -117,7 +123,7 @@ def test_list_file_filter(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json", "a.py")
     assert len(hunks) == 1
-    assert hunks[0]["file"] == "a.py"
+    assert hunks[0]["file"]["text"] == "a.py"
 
 
 def test_list_new_file(cli: GitHunkCLI) -> None:
@@ -130,7 +136,7 @@ def test_list_new_file(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--staged", "--json")
     assert len(hunks) == 1
-    assert hunks[0]["file"] == "new.py"
+    assert hunks[0]["file"]["text"] == "new.py"
     assert int(hunks[0]["additions"]) >= 1
     assert hunks[0]["deletions"] == 0
 
@@ -159,7 +165,7 @@ def test_list_default_shows_untracked(cli: GitHunkCLI) -> None:
     hunks = cli.run_list_json("list", "--json")
     untracked = [h for h in hunks if h["status"] == "untracked"]
     assert len(untracked) == 1
-    assert untracked[0]["file"] == "untracked.py"
+    assert untracked[0]["file"]["text"] == "untracked.py"
 
 
 def test_list_unstaged_filter(cli: GitHunkCLI) -> None:
@@ -204,6 +210,6 @@ def test_list_context_before_field_in_json_matches_display(cli: GitHunkCLI) -> N
 
     hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
-    assert hunks[0]["context_before"] == "def foo():"
+    assert hunks[0]["context_before"]["text"] == "def foo():"
     # Parity: the field equals the function context shown in the human display.
     assert "def foo():" in cli.run_ok("list")

--- a/tests/e2e/no_newline_test.py
+++ b/tests/e2e/no_newline_test.py
@@ -77,7 +77,7 @@ def test_stage_line_selection_on_no_newline_hunk(cli: GitHunkCLI) -> None:
 
     # The dropped change still carries its no-newline marker in the remainder.
     remaining = cli.run_list_json("list", "--unstaged", "--json")
-    assert NO_NEWLINE_MARKER in remaining[0]["diff"]
+    assert NO_NEWLINE_MARKER in remaining[0]["diff"]["text"]
 
 
 def test_list_counts_ignore_no_newline_marker(cli: GitHunkCLI) -> None:

--- a/tests/e2e/non_utf8_test.py
+++ b/tests/e2e/non_utf8_test.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import subprocess
 from pathlib import Path
 
@@ -22,9 +24,32 @@ def latin1_repo(cli: GitHunkCLI) -> GitHunkCLI:
 
 def test_list_does_not_crash_on_non_utf8_content(latin1_repo: GitHunkCLI) -> None:
     hunks = latin1_repo.run_list_json("list", "--unstaged", "--json")
-    assert [h["file"] for h in hunks] == ["latin1.txt"]
+    assert [h["file"]["text"] for h in hunks] == ["latin1.txt"]
 
     latin1_repo.run_ok("list", "--unstaged")
+
+
+def test_list_json_is_accepted_by_strict_parsers(latin1_repo: GitHunkCLI) -> None:
+    raw = latin1_repo.run_ok("list", "--unstaged", "--json")
+    parsed = json.loads(raw)
+
+    # Python's json.loads is lenient about lone surrogates; a strict parser
+    # (Go encoding/json, Rust serde_json) rejects them. Re-encoding the parsed
+    # document to UTF-8 reproduces that rejection without an external parser:
+    # it raises on a lone surrogate, and the bytes re-parse to the same object.
+    reencoded = json.dumps(parsed, ensure_ascii=False).encode("utf-8")
+    assert json.loads(reencoded) == parsed
+
+
+def test_list_json_encodes_non_utf8_diff_as_lossless_bytes(
+    latin1_repo: GitHunkCLI,
+) -> None:
+    hunk = latin1_repo.run_list_json("list", "--unstaged", "--json")[0]
+
+    # The path is ASCII, so it stays text; the diff carries the 0xe9 byte.
+    assert hunk["file"] == {"text": "latin1.txt"}
+    assert set(hunk["diff"]) == {"bytes"}
+    assert b"pass\xe9" in base64.b64decode(hunk["diff"]["bytes"])
 
 
 def test_show_does_not_crash_on_non_utf8_content(latin1_repo: GitHunkCLI) -> None:

--- a/tests/e2e/path_shorthand_test.py
+++ b/tests/e2e/path_shorthand_test.py
@@ -20,7 +20,7 @@ def multi_hunk_repo(cli: GitHunkCLI) -> GitHunkCLI:
 def test_stage_whole_file_by_path(multi_hunk_repo: GitHunkCLI) -> None:
     cli = multi_hunk_repo
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    assert len([h for h in hunks if h["file"] == "big.py"]) == 2
+    assert len([h for h in hunks if h["file"]["text"] == "big.py"]) == 2
 
     cli.run_ok("stage", "big.py")
     assert cli.repo.git("diff", "--cached", "--name-only").split() == ["big.py"]
@@ -51,7 +51,7 @@ def test_dot_slash_prefixed_path(multi_hunk_repo: GitHunkCLI) -> None:
 def test_mixing_path_and_id(multi_hunk_repo: GitHunkCLI) -> None:
     cli = multi_hunk_repo
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    b_id = next(h["id"] for h in hunks if h["file"] == "b.py")
+    b_id = next(h["id"] for h in hunks if h["file"]["text"] == "b.py")
 
     cli.run_ok("stage", "big.py", b_id)
     staged = sorted(cli.repo.git("diff", "--cached", "--name-only").split())

--- a/tests/e2e/quoted_paths_test.py
+++ b/tests/e2e/quoted_paths_test.py
@@ -3,7 +3,7 @@ from .conftest import GitHunkCLI
 
 def _hunk_id_for(cli: GitHunkCLI, path: str) -> str:
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    return next(h["id"] for h in hunks if h["file"] == path)
+    return next(h["id"] for h in hunks if h["file"]["text"] == path)
 
 
 def test_non_ascii_modified_file_round_trips(cli: GitHunkCLI) -> None:
@@ -31,7 +31,7 @@ def test_non_ascii_untracked_shows_real_path(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json")
     untracked = [h for h in hunks if h["status"] == "untracked"]
-    assert [h["file"] for h in untracked] == ["untrack𝟙.txt"]
+    assert [h["file"]["text"] for h in untracked] == ["untrack𝟙.txt"]
 
 
 def test_filename_with_b_slash_substring_stages(cli: GitHunkCLI) -> None:
@@ -41,7 +41,7 @@ def test_filename_with_b_slash_substring_stages(cli: GitHunkCLI) -> None:
     cli.repo.write_file("a b/c.txt", "x\nY\n")
 
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    assert [h["file"] for h in hunks] == ["a b/c.txt"]
+    assert [h["file"]["text"] for h in hunks] == ["a b/c.txt"]
 
     cli.run_ok("stage", _hunk_id_for(cli, "a b/c.txt"))
     assert cli.repo.git("show", ":a b/c.txt") == "x\nY\n"

--- a/tests/e2e/stage_test.py
+++ b/tests/e2e/stage_test.py
@@ -55,7 +55,7 @@ def test_stage_from_different_files(cli: GitHunkCLI) -> None:
     cli.repo.write_file("b.py", "BBB\n")
 
     hunks = cli.run_list_json("list", "--json")
-    a_hunk = next(h for h in hunks if h["file"] == "a.py")
+    a_hunk = next(h for h in hunks if h["file"]["text"] == "a.py")
 
     cli.run_ok("stage", a_hunk["id"])
 

--- a/tests/unit/_hunk/to_dict_test.py
+++ b/tests/unit/_hunk/to_dict_test.py
@@ -1,3 +1,5 @@
+import base64
+
 from git_hunk._hunk import Hunk
 
 
@@ -11,7 +13,7 @@ def test_to_dict_includes_context_before() -> None:
         context_before="def foo():",
         diff="@@ -1,3 +1,3 @@ def foo():\n-a\n+b",
     )
-    assert hunk.to_dict()["context_before"] == "def foo():"
+    assert hunk.to_dict()["context_before"] == {"text": "def foo():"}
 
 
 def test_to_dict_context_before_empty_when_no_context() -> None:
@@ -26,4 +28,43 @@ def test_to_dict_context_before_empty_when_no_context() -> None:
     )
     serialized = hunk.to_dict()
     assert "context_before" in serialized
-    assert serialized["context_before"] == ""
+    assert serialized["context_before"] == {"text": ""}
+
+
+def test_to_dict_wraps_text_fields_and_keeps_scalars_plain() -> None:
+    # Multi-byte UTF-8 (héllo) must stay {"text": ...}, not get base64'd.
+    hunk = Hunk(
+        id="abc1234",
+        file="f.py",
+        header="@@ -1,3 +1,4 @@ def héllo():",
+        additions=2,
+        deletions=1,
+        context_before="def héllo():",
+        diff="@@ -1,3 +1,4 @@ def héllo():\n-a\n+b\n+c",
+    )
+    serialized = hunk.to_dict()
+    assert serialized["file"] == {"text": "f.py"}
+    assert serialized["header"] == {"text": "@@ -1,3 +1,4 @@ def héllo():"}
+    assert serialized["diff"] == {"text": "@@ -1,3 +1,4 @@ def héllo():\n-a\n+b\n+c"}
+    assert serialized["id"] == "abc1234"
+    assert serialized["status"] == "unstaged"
+    assert serialized["additions"] == 2
+    assert serialized["deletions"] == 1
+
+
+def test_to_dict_encodes_non_utf8_file_as_bytes() -> None:
+    # A non-UTF-8 byte in a path reaches to_dict as a lone surrogate (run_git
+    # decodes with surrogateescape). The filesystem rejects such names on macOS,
+    # so the path-bytes case is only reachable at this level, not via e2e.
+    hunk = Hunk(
+        id="abc1234",
+        file=b"pass\xe9.txt".decode(errors="surrogateescape"),
+        header="@@ -1,2 +1,2 @@",
+        additions=1,
+        deletions=1,
+        context_before="",
+        diff="@@ -1,2 +1,2 @@\n-a\n+b",
+    )
+    file_field = hunk.to_dict()["file"]
+    assert set(file_field) == {"bytes"}
+    assert base64.b64decode(file_field["bytes"]) == b"pass\xe9.txt"


### PR DESCRIPTION
> *This was generated by AI during implementation.*

Closes #44.

`git-hunk` decodes git output with `surrogateescape`, so a non-UTF-8 byte in a
path or diff line becomes a lone surrogate in the Python `str`. `list --json`
serialized those with the default `ensure_ascii=True`, emitting a `\udcXX`
escape: `jq` silently rewrites it to U+FFFD (lossy) and strict parsers (Go
`encoding/json`, Rust `serde_json`) reject the whole document.

## Summary
- The git-derived hunk fields (`file`, `header`, `context_before`, `diff`) are
  now byte-safe objects following ripgrep's discriminated union: `{"text": "..."}`
  for valid UTF-8, `{"bytes": "<base64>"}` otherwise. Always an object, never a
  bare string, so consumers have one code path.
- `id`, `status`, `additions`, `deletions` stay plain (never git-derived).
- `schema_version` bumps to `2` (breaking shape change); README, the bundled
  `skills/core/SKILL.md`, and CHANGELOG document the new shape.

## Test plan
- [x] new tests: strict-parser acceptance + lossless base64 round-trip for a
  non-UTF-8 diff line, the `{"bytes"}` path for a non-UTF-8 filename (unit-level,
  since macOS rejects such names on disk), multi-byte UTF-8 staying `{"text"}`,
  and an envelope-contract assertion locking the v2 field shape
- [x] `make lint` (ruff format/check, ty, taplo, mdformat, yamlfix, typos)
- [x] `uv run pytest` (195 passed)
- [x] manual smoke: `git-hunk list --json` on a repo with a `0xe9` byte in a
  diff line yields `{"bytes": ...}` that strict-parses and round-trips
