### PR TITLE
fix: parse git's quoted, C-escaped diff headers

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -81,8 +81,43 @@ def split_file_diffs(diff_output: str) -> list[str]:
     return re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE)
 
 
+def _unquote_c_path(path: str) -> str:
+    C_ESCAPES: Final = {
+        "a": "\a",
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        "v": "\v",
+        "\\": "\\",
+        '"': '"',
+    }
+    chars = []
+    i = 0
+    while i < len(path):
+        if path[i] != "\\":
+            chars.append(path[i])
+            i += 1
+            continue
+        escape = path[i + 1]
+        if escape in C_ESCAPES:
+            chars.append(C_ESCAPES[escape])
+            i += 2
+        else:
+            chars.append(chr(int(path[i + 1 : i + 4], 8)))
+            i += 4
+    return "".join(chars)
+
+
 def extract_file_path(file_diff: str) -> str | None:
     first_line = file_diff.split("\n", 1)[0]
+    # git double-quotes and C-escapes the header when a path contains a tab,
+    # newline, backslash, or double-quote (regardless of core.quotePath). Both
+    # halves are identical for non-renames; decode the logical path.
+    m = re.match(r'diff --git "a/(.+)" "b/\1"$', first_line)
+    if m:
+        return _unquote_c_path(m.group(1))
     # For non-renames git emits `diff --git a/<path> b/<path>` with both halves
     # identical; the backreference resolves paths that contain " b/".
     m = re.match(r"diff --git a/(.+) b/\1$", first_line)

--- a/tests/e2e/quoted_paths_test.py
+++ b/tests/e2e/quoted_paths_test.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest
+
 from .conftest import GitHunkCLI
 
 
@@ -51,4 +55,33 @@ def test_filename_with_b_slash_substring_stages(cli: GitHunkCLI) -> None:
     assert cli.repo.git("diff", "--cached").strip() == ""
 
     cli.run_ok("discard", _hunk_id_for(cli, "a b/c.txt"))
+    assert cli.repo.git("diff").strip() == ""
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="tab, newline, backslash, and double-quote are illegal in Windows filenames",
+)
+@pytest.mark.parametrize(
+    "path",
+    ["od\ttab.txt", "od\nnl.txt", "od\\back.txt", 'od"q.txt'],
+    ids=["tab", "newline", "backslash", "quote"],
+)
+def test_quoted_path_modified_file_round_trips(cli: GitHunkCLI, path: str) -> None:
+    cli.repo.write_file(path, "a\nb\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file(path, "a\nB\n")
+
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
+    assert [h["file"] for h in hunks] == [path]
+
+    cli.run_ok("stage", _hunk_id_for(cli, path))
+    assert cli.repo.git("show", f":{path}") == "a\nB\n"
+
+    staged = cli.run_list_json("list", "--staged", "--json")
+    cli.run_ok("unstage", staged[0]["id"])
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+    cli.run_ok("discard", _hunk_id_for(cli, path))
     assert cli.repo.git("diff").strip() == ""


### PR DESCRIPTION
git always double-quotes and C-escapes a diff header whose path contains a tab, newline, backslash, or double-quote, regardless of `core.quotePath`. `extract_file_path` only matched the unquoted `diff --git a/… b/…` form, so such files were silently dropped from `list`/`stage`/`discard`. This adds a quoted-header branch that C-unescapes the logical path (`\t \n \\ \" \a \b \f \r \v` and octal `\NNN`); `git apply` already round-trips the raw quoted header, so patch emission is unchanged.

## Test plan
- [x] New parametrized e2e cases in `tests/e2e/quoted_paths_test.py` round-trip `list`/`stage`/`unstage`/`discard` for a tab, newline, backslash, and double-quote in the filename
- [x] Real CLI smoke: a tab-named file now appears in `git-hunk list` and stages to the correct content (was silently dropped before)
- [x] `make lint` and full `make test` (195 passed)

Closes #30
