### PR TITLE
ci: bind publish job to pypi environment for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
The PyPI trusted-publisher for `wkentaro/git-hunk` now specifies **Environment name: `pypi`**. PyPI therefore requires the GitHub OIDC token to carry that environment claim — but `publish.yml` declared no environment, so the **next `v*` release would have been rejected at publish time**. This adds `environment: name: pypi` to the publish job so the claim matches.

Part of #64 (steps remaining there: create the `pypi` GitHub Environment with a required reviewer in repo Settings to add the human approval gate; end-to-end verification on the next tagged release).

## Test plan
- [x] `make lint` (yamlfix) passes
- [ ] Verified end-to-end on the next `v*` release (cannot be exercised without publishing)
