### PR TITLE
feat: content/pattern-based line selection for partial hunk staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to
   change without touching the index or working tree (#25).
 - `context_before` field in `list --json`, exposing the function/section heading
   git names after the `@@` header (#27).
+- `--include-matching` / `--exclude-matching` for `stage`, `unstage`, and
+  `discard`, selecting changed lines by content instead of by line number
+  (literal substring by default, `--regex` for regular expressions; repeatable
+  and OR'd), so an agent can drop a line by what it contains without a
+  `show` round trip (#55).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,18 @@ git-hunk show --unstaged               # show all unstaged hunks
 git-hunk stage d161935                 # stage a hunk
 git-hunk stage d161935 a3f82c1         # stage multiple hunks
 git-hunk stage d161935 -l 3,5-7        # stage specific lines only
+git-hunk stage d161935 --exclude-matching debug    # stage all but lines containing "debug"
+git-hunk stage d161935 --include-matching xfail    # stage only lines containing "xfail"
 git-hunk unstage d161935               # move back to working tree
 git-hunk unstage d161935 -l 3,5-7      # unstage specific lines only
 git-hunk discard d161935               # restore from HEAD
 git-hunk discard d161935 -l ^3,^5-7    # discard excluding specific lines
 ```
+
+`--include-matching` / `--exclude-matching` select changed lines by content
+instead of line number (literal substring by default, `--regex` for regular
+expressions). Both are repeatable and OR'd, case-sensitive, and error if nothing
+matches. They are mutually exclusive with `-l` and with each other.
 
 ### Commit
 

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from dataclasses import dataclass
 from dataclasses import replace
 from typing import Final
 
@@ -19,6 +20,7 @@ from ._hunk import Hunk
 from ._hunk import parse_diff
 from ._lines import filter_hunk_lines
 from ._lines import parse_line_spec
+from ._lines import resolve_matching_lines
 from ._patch import build_patch
 from ._skills import Skill
 from ._skills import load_skills
@@ -145,19 +147,72 @@ def _select_hunks(hunks: list[Hunk], args: list[str]) -> list[Hunk]:
     return selected
 
 
+@dataclass(frozen=True)
+class _Selection:
+    line_spec: str | None
+    include_matching: tuple[str, ...]
+    exclude_matching: tuple[str, ...]
+    regex: bool
+
+    def is_active(self) -> bool:
+        return (
+            self.line_spec is not None
+            or bool(self.include_matching)
+            or bool(self.exclude_matching)
+        )
+
+    def resolve(self, hunk: Hunk) -> tuple[set[int], bool]:
+        if self.line_spec is not None:
+            return parse_line_spec(self.line_spec)
+        if self.include_matching:
+            lines = resolve_matching_lines(
+                hunk, self.include_matching, regex=self.regex
+            )
+            return lines, False
+        lines = resolve_matching_lines(hunk, self.exclude_matching, regex=self.regex)
+        return lines, True
+
+
+def _build_selection(
+    line_spec: str | None,
+    include_matching: tuple[str, ...],
+    exclude_matching: tuple[str, ...],
+    regex: bool,
+    *,
+    usage: str,
+) -> _Selection:
+    mechanisms = [line_spec is not None, bool(include_matching), bool(exclude_matching)]
+    if sum(mechanisms) > 1:
+        raise CliError(
+            "choose one of -l, --include-matching, or --exclude-matching",
+            usage=usage,
+        )
+    if regex and not (include_matching or exclude_matching):
+        raise CliError(
+            "--regex requires --include-matching or --exclude-matching",
+            usage=usage,
+        )
+    return _Selection(
+        line_spec=line_spec,
+        include_matching=include_matching,
+        exclude_matching=exclude_matching,
+        regex=regex,
+    )
+
+
 def _apply_line_filter(
-    hunks: list[Hunk], line_spec: str | None, *, reverse: bool
+    hunks: list[Hunk], selection: _Selection, *, reverse: bool
 ) -> list[Hunk]:
-    if line_spec is None:
+    if not selection.is_active():
         return hunks
     if len(hunks) != 1:
-        raise CliError("line selection (-l) requires exactly one hunk")
+        raise CliError("line selection requires exactly one hunk")
     if _is_whole_file_hunk(hunks[0]):
         raise CliError(
-            "line selection (-l) is not supported for binary or mode-only changes"
+            "line selection is not supported for binary or mode-only changes"
         )
     try:
-        lines, exclude = parse_line_spec(line_spec)
+        lines, exclude = selection.resolve(hunks[0])
         return [filter_hunk_lines(hunks[0], lines, exclude=exclude, reverse=reverse)]
     except ValueError as exc:
         raise CliError(str(exc)) from exc
@@ -171,7 +226,7 @@ def _is_whole_file_hunk(hunk: Hunk) -> bool:
 
 def _apply_selection(
     args: list[str],
-    line_spec: str | None,
+    selection: _Selection,
     *,
     usage: str,
     command_name: str,
@@ -188,7 +243,7 @@ def _apply_selection(
 
     hunks, diff_output = _get_hunks(staged=staged)
     selected = _select_hunks(hunks, args)
-    selected = _apply_line_filter(selected, line_spec, reverse=reverse)
+    selected = _apply_line_filter(selected, selection, reverse=reverse)
 
     whole_file = [h for h in selected if _is_whole_file_hunk(h)]
     text = [h for h in selected if not _is_whole_file_hunk(h)]
@@ -213,7 +268,7 @@ def _apply_selection(
 
 def _run_patch_command(
     args: list[str],
-    line_spec: str | None,
+    selection: _Selection,
     *,
     usage: str,
     command_name: str,
@@ -225,7 +280,7 @@ def _run_patch_command(
 ) -> None:
     selected = _apply_selection(
         args,
-        line_spec,
+        selection,
         usage=usage,
         command_name=command_name,
         staged=staged,
@@ -407,18 +462,30 @@ def cmd_skills(args: tuple[str, ...], force_json: bool, show_help: bool) -> None
 
 @cli.command("stage", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
+@click.option("--include-matching", "include_matching", multiple=True)
+@click.option("--exclude-matching", "exclude_matching", multiple=True)
+@click.option("--regex", "use_regex", is_flag=True)
 @click.option("--dry-run", "dry_run", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("targets", nargs=-1)
 def cmd_stage(
-    targets: tuple[str, ...], line_spec: str | None, dry_run: bool, show_help: bool
+    targets: tuple[str, ...],
+    line_spec: str | None,
+    include_matching: tuple[str, ...],
+    exclude_matching: tuple[str, ...],
+    use_regex: bool,
+    dry_run: bool,
+    show_help: bool,
 ) -> None:
     if show_help:
         print_help(HELP_STAGE)
         return
+    selection = _build_selection(
+        line_spec, include_matching, exclude_matching, use_regex, usage=USAGE_STAGE
+    )
     _run_patch_command(
         list(targets),
-        line_spec,
+        selection,
         usage=USAGE_STAGE,
         command_name="stage",
         staged=False,
@@ -431,18 +498,30 @@ def cmd_stage(
 
 @cli.command("unstage", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
+@click.option("--include-matching", "include_matching", multiple=True)
+@click.option("--exclude-matching", "exclude_matching", multiple=True)
+@click.option("--regex", "use_regex", is_flag=True)
 @click.option("--dry-run", "dry_run", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("targets", nargs=-1)
 def cmd_unstage(
-    targets: tuple[str, ...], line_spec: str | None, dry_run: bool, show_help: bool
+    targets: tuple[str, ...],
+    line_spec: str | None,
+    include_matching: tuple[str, ...],
+    exclude_matching: tuple[str, ...],
+    use_regex: bool,
+    dry_run: bool,
+    show_help: bool,
 ) -> None:
     if show_help:
         print_help(HELP_UNSTAGE)
         return
+    selection = _build_selection(
+        line_spec, include_matching, exclude_matching, use_regex, usage=USAGE_UNSTAGE
+    )
     _run_patch_command(
         list(targets),
-        line_spec,
+        selection,
         usage=USAGE_UNSTAGE,
         command_name="unstage",
         staged=True,
@@ -455,18 +534,30 @@ def cmd_unstage(
 
 @cli.command("discard", add_help_option=False)
 @click.option("-l", "line_spec", default=None)
+@click.option("--include-matching", "include_matching", multiple=True)
+@click.option("--exclude-matching", "exclude_matching", multiple=True)
+@click.option("--regex", "use_regex", is_flag=True)
 @click.option("--dry-run", "dry_run", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("targets", nargs=-1)
 def cmd_discard(
-    targets: tuple[str, ...], line_spec: str | None, dry_run: bool, show_help: bool
+    targets: tuple[str, ...],
+    line_spec: str | None,
+    include_matching: tuple[str, ...],
+    exclude_matching: tuple[str, ...],
+    use_regex: bool,
+    dry_run: bool,
+    show_help: bool,
 ) -> None:
     if show_help:
         print_help(HELP_DISCARD)
         return
+    selection = _build_selection(
+        line_spec, include_matching, exclude_matching, use_regex, usage=USAGE_DISCARD
+    )
     _run_patch_command(
         list(targets),
-        line_spec,
+        selection,
         usage=USAGE_DISCARD,
         command_name="discard",
         staged=False,
@@ -501,9 +592,12 @@ def cmd_commit(
             tip="commit them with 'git commit', or unstage with 'git-hunk unstage'",
         )
 
+    selection = _Selection(
+        line_spec=line_spec, include_matching=(), exclude_matching=(), regex=False
+    )
     selected = _apply_selection(
         list(targets),
-        line_spec,
+        selection,
         usage=USAGE_COMMIT,
         command_name="commit",
         staged=False,

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Sequence
 from dataclasses import replace
 from typing import NamedTuple
 
@@ -115,6 +116,48 @@ def _render_body_lines(kept: list[_BodyLine]) -> list[str]:
     return rendered
 
 
+def _body_lines(hunk: Hunk) -> list[str]:
+    return strip_trailing_empty_lines(hunk.diff.split("\n")[1:])
+
+
+def resolve_matching_lines(
+    hunk: Hunk, patterns: Sequence[str], *, regex: bool
+) -> set[int]:
+    """Return 1-based body line numbers of changed lines matching any pattern.
+
+    Patterns are OR'd. Only changed ('+'/'-') lines are considered, matched
+    against their content (the text after the prefix). Raises if nothing matches,
+    so a typo'd pattern never silently selects nothing or everything.
+    """
+    compiled: list[re.Pattern[str]] | None = None
+    if regex:
+        try:
+            compiled = [re.compile(p) for p in patterns]
+        except re.error as exc:
+            raise ValueError(f"invalid regex: {exc}") from exc
+
+    selected: set[int] = set()
+    line_num = 0
+    for line in _body_lines(hunk):
+        if is_no_newline_marker(line):
+            continue
+        line_num += 1
+        if not line.startswith(("+", "-")):
+            continue
+        content = line[1:]
+        if compiled is not None:
+            matched = any(pattern.search(content) for pattern in compiled)
+        else:
+            matched = any(pattern in content for pattern in patterns)
+        if matched:
+            selected.add(line_num)
+
+    if not selected:
+        joined = ", ".join(repr(p) for p in patterns)
+        raise ValueError(f"no changed line matches {joined}")
+    return selected
+
+
 def _filter_body_lines(
     body: list[str],
     selected: set[int],
@@ -140,9 +183,8 @@ def filter_hunk_lines(
     reverse=True (unstage, discard) swaps those so the patch applies against the
     NEW content the index or working tree already holds.
     """
-    diff_lines = hunk.diff.split("\n")
-    header = diff_lines[0]
-    body = strip_trailing_empty_lines(diff_lines[1:])
+    header = hunk.diff.split("\n", 1)[0]
+    body = _body_lines(hunk)
 
     total = sum(1 for line in body if not is_no_newline_marker(line))
 

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -206,7 +206,10 @@ def print_version(version: str) -> None:
 
 _LINE_OPT_ROW = """\
   [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk (requires exactly one hunk)
-             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""  # noqa: E501
+             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)
+  [bold cyan]--include-matching[/bold cyan] [cyan]<pattern>[/cyan]  Select changed lines containing <pattern> (repeatable, OR'd)
+  [bold cyan]--exclude-matching[/bold cyan] [cyan]<pattern>[/cyan]  Select every changed line except those matching (repeatable, OR'd)
+  [bold cyan]--regex[/bold cyan]    Treat matching patterns as regular expressions (default: literal substring)"""  # noqa: E501
 
 _LINE_OPTS = f"""\
 [bold green]Options:[/bold green]
@@ -249,6 +252,8 @@ _EXAMPLES_STAGE: Final = [
     ("git-hunk stage d161935 a3f82c1", "Stage multiple hunks"),
     ("git-hunk stage src/foo.py", "Stage every hunk in a file"),
     ("git-hunk stage d161935 -l 3,5-7", "Stage specific lines only"),
+    ("git-hunk stage d161935 --include-matching xfail", "Stage only matching lines"),
+    ("git-hunk stage d161935 --exclude-matching debug", "Stage all but matching lines"),
     ("git-hunk stage d161935 --dry-run", "Preview without changing anything"),
 ]
 _EXAMPLES_UNSTAGE: Final = [

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -107,6 +107,19 @@ Line numbers are the 1-based positions shown by `git-hunk show <id>`. After a
 partial stage, the rest of the hunk stays in the working tree with the same ID;
 stage it into a later commit, or drop it.
 
+Select by content instead of line number with `--include-matching` /
+`--exclude-matching` (no `show` round trip, and stable if the hunk shifts):
+
+```bash
+git-hunk stage d161935 --exclude-matching 'print(debug)'  # stage all but matching lines
+git-hunk stage d161935 --include-matching '"mark": "xfail"'  # stage only matching lines
+```
+
+Patterns match the content of changed (`+`/`-`) lines, literal substring by
+default (`--regex` opts into regular expressions). Both flags are repeatable
+(OR'd), case-sensitive, error if nothing matches, and are mutually exclusive
+with `-l` and with each other.
+
 ## Common workflows
 
 ### Dirty tree to conventional commits

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -93,6 +93,20 @@ def test_malformed_line_spec_rejected(cli: GitHunkCLI) -> None:
     assert "expected start-end" in r.stderr  # readable message, not raw int() error
 
 
+def test_empty_line_spec_rejected(cli: GitHunkCLI) -> None:
+    # An empty -l must error, not silently fall through and stage the whole hunk.
+    cli.repo.write_file("f.py", "a\nb\nc\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "A\nb\nC\n")
+
+    hunk_id = cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
+    r = cli.run("stage", hunk_id, "-l", "")
+    assert r.returncode != 0
+    assert "empty line specification" in r.stderr
+    assert cli.repo.git("show", ":f.py") == "a\nb\nc\n"  # nothing staged
+
+
 def test_line_spec_with_multiple_hunks_fails(cli: GitHunkCLI) -> None:
     lines = [f"line{i}" for i in range(1, 21)]
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")

--- a/tests/e2e/pattern_selection_test.py
+++ b/tests/e2e/pattern_selection_test.py
@@ -1,0 +1,159 @@
+from pathlib import Path
+
+import pytest
+
+from .conftest import GitHunkCLI
+
+# HEAD "keep" -> working "keep / DEBUG line / FEATURE line": one hunk, two added
+# lines. Body line numbers: 1=" keep" 2="+DEBUG line" 3="+FEATURE line".
+
+
+@pytest.fixture
+def added_lines(cli: GitHunkCLI) -> GitHunkCLI:
+    cli.repo.write_file("f.txt", "keep\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "keep\nDEBUG line\nFEATURE line\n")
+    return cli
+
+
+def _only_id(cli: GitHunkCLI, *flags: str) -> str:
+    hunks = cli.run_list_json("list", *flags, "--json")
+    assert len(hunks) == 1
+    return hunks[0]["id"]
+
+
+def _working(cli: GitHunkCLI) -> str:
+    return (Path(cli.repo.path) / "f.txt").read_text()
+
+
+def test_stage_exclude_matching(added_lines: GitHunkCLI) -> None:
+    added_lines.run_ok(
+        "stage", _only_id(added_lines, "--unstaged"), "--exclude-matching", "DEBUG"
+    )
+    assert added_lines.repo.git("show", ":f.txt") == "keep\nFEATURE line\n"
+
+
+def test_stage_include_matching(added_lines: GitHunkCLI) -> None:
+    added_lines.run_ok(
+        "stage", _only_id(added_lines, "--unstaged"), "--include-matching", "DEBUG"
+    )
+    assert added_lines.repo.git("show", ":f.txt") == "keep\nDEBUG line\n"
+
+
+def test_unstage_include_matching(added_lines: GitHunkCLI) -> None:
+    added_lines.run_ok("stage", _only_id(added_lines, "--unstaged"))
+    added_lines.run_ok(
+        "unstage", _only_id(added_lines, "--staged"), "--include-matching", "DEBUG"
+    )
+    assert added_lines.repo.git("show", ":f.txt") == "keep\nFEATURE line\n"
+
+
+def test_discard_include_matching(added_lines: GitHunkCLI) -> None:
+    added_lines.run_ok(
+        "discard", _only_id(added_lines, "--unstaged"), "--include-matching", "DEBUG"
+    )
+    assert _working(added_lines) == "keep\nFEATURE line\n"
+
+
+def test_discard_exclude_matching(added_lines: GitHunkCLI) -> None:
+    added_lines.run_ok(
+        "discard", _only_id(added_lines, "--unstaged"), "--exclude-matching", "DEBUG"
+    )
+    assert _working(added_lines) == "keep\nDEBUG line\n"
+
+
+def test_unstage_regex(added_lines: GitHunkCLI) -> None:
+    added_lines.run_ok("stage", _only_id(added_lines, "--unstaged"))
+    added_lines.run_ok(
+        "unstage",
+        _only_id(added_lines, "--staged"),
+        "--include-matching",
+        "D.BUG",
+        "--regex",
+    )
+    assert added_lines.repo.git("show", ":f.txt") == "keep\nFEATURE line\n"
+
+
+def test_repeated_flag_is_ored(added_lines: GitHunkCLI) -> None:
+    added_lines.run_ok(
+        "stage",
+        _only_id(added_lines, "--unstaged"),
+        "--include-matching",
+        "DEBUG",
+        "--include-matching",
+        "FEATURE",
+    )
+    assert added_lines.repo.git("show", ":f.txt") == "keep\nDEBUG line\nFEATURE line\n"
+
+
+def test_matching_is_case_sensitive(added_lines: GitHunkCLI) -> None:
+    r = added_lines.run(
+        "stage", _only_id(added_lines, "--unstaged"), "--include-matching", "debug"
+    )
+    assert r.returncode != 0
+    assert "no changed line matches" in r.stderr
+    assert added_lines.repo.git("show", ":f.txt") == "keep\n"
+
+
+def test_literal_metacharacters_match_literally(added_lines: GitHunkCLI) -> None:
+    # 'D.BUG' is not a substring of any line; as a literal it matches nothing.
+    r = added_lines.run(
+        "stage", _only_id(added_lines, "--unstaged"), "--include-matching", "D.BUG"
+    )
+    assert r.returncode != 0
+    assert "no changed line matches" in r.stderr
+
+
+def test_regex_opt_in(added_lines: GitHunkCLI) -> None:
+    added_lines.run_ok(
+        "stage",
+        _only_id(added_lines, "--unstaged"),
+        "--include-matching",
+        "D.BUG",
+        "--regex",
+    )
+    assert added_lines.repo.git("show", ":f.txt") == "keep\nDEBUG line\n"
+
+
+def test_zero_matches_stages_nothing(added_lines: GitHunkCLI) -> None:
+    r = added_lines.run(
+        "stage", _only_id(added_lines, "--unstaged"), "--exclude-matching", "nope"
+    )
+    assert r.returncode != 0
+    assert "no changed line matches" in r.stderr
+    assert added_lines.repo.git("show", ":f.txt") == "keep\n"
+
+
+def test_line_spec_and_matching_are_mutually_exclusive(added_lines: GitHunkCLI) -> None:
+    r = added_lines.run(
+        "stage",
+        _only_id(added_lines, "--unstaged"),
+        "-l",
+        "2",
+        "--include-matching",
+        "DEBUG",
+    )
+    assert r.returncode != 0
+    assert "choose one of" in r.stderr
+
+
+def test_both_matching_flags_are_mutually_exclusive(added_lines: GitHunkCLI) -> None:
+    r = added_lines.run(
+        "stage",
+        _only_id(added_lines, "--unstaged"),
+        "--include-matching",
+        "DEBUG",
+        "--exclude-matching",
+        "FEATURE",
+    )
+    assert r.returncode != 0
+    assert "choose one of" in r.stderr
+
+
+def test_regex_without_matching_flag_is_rejected(added_lines: GitHunkCLI) -> None:
+    # --regex alone has no effect; reject it rather than silently staging the hunk.
+    r = added_lines.run("stage", _only_id(added_lines, "--unstaged"), "--regex")
+    assert r.returncode != 0
+    assert "--regex requires" in r.stderr
+    assert added_lines.repo.git("show", ":f.txt") == "keep\n"

--- a/tests/unit/_lines/conftest.py
+++ b/tests/unit/_lines/conftest.py
@@ -1,0 +1,24 @@
+from collections.abc import Callable
+
+import pytest
+
+from git_hunk._hunk import Hunk
+from git_hunk._hunk import count_changes
+
+
+@pytest.fixture
+def make_hunk() -> Callable[[str], Hunk]:
+    def _make(diff: str) -> Hunk:
+        body = diff.split("\n")[1:]
+        additions, deletions = count_changes(body)
+        return Hunk(
+            id="abc1234",
+            file="test.py",
+            header=diff.split("\n")[0],
+            additions=additions,
+            deletions=deletions,
+            context_before="",
+            diff=diff,
+        )
+
+    return _make

--- a/tests/unit/_lines/filter_test.py
+++ b/tests/unit/_lines/filter_test.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 
 from git_hunk._hunk import NO_NEWLINE_MARKER
@@ -5,26 +7,9 @@ from git_hunk._hunk import Hunk
 from git_hunk._lines import filter_hunk_lines
 
 
-def _make_hunk(diff: str) -> Hunk:
-    lines = diff.split("\n")
-    header = lines[0]
-    body = lines[1:]
-    additions = sum(1 for line in body if line.startswith("+"))
-    deletions = sum(1 for line in body if line.startswith("-"))
-    return Hunk(
-        id="abc1234",
-        file="test.py",
-        header=header,
-        additions=additions,
-        deletions=deletions,
-        context_before="",
-        diff=diff,
-    )
-
-
-def test_include_additions() -> None:
+def test_include_additions(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,3 +1,5 @@ def foo():\n ctx1\n+add1\n+add2\n ctx2\n+add3"
-    hunk = _make_hunk(diff)
+    hunk = make_hunk(diff)
     result = filter_hunk_lines(hunk, {2}, exclude=False)
     assert result.additions == 1
     assert result.deletions == 0
@@ -33,18 +18,18 @@ def test_include_additions() -> None:
     assert "add3" not in result.diff
 
 
-def test_include_deletions() -> None:
+def test_include_deletions(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,4 +1,2 @@ def foo():\n ctx1\n-del1\n-del2\n ctx2"
-    hunk = _make_hunk(diff)
+    hunk = make_hunk(diff)
     result = filter_hunk_lines(hunk, {2}, exclude=False)
     assert result.deletions == 1
     assert "-del1" in result.diff
     assert " del2" in result.diff
 
 
-def test_exclude_mode() -> None:
+def test_exclude_mode(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,3 +1,5 @@ def foo():\n ctx1\n+add1\n+add2\n ctx2\n+add3"
-    hunk = _make_hunk(diff)
+    hunk = make_hunk(diff)
     result = filter_hunk_lines(hunk, {3}, exclude=True)
     assert result.additions == 2
     assert "+add1" in result.diff
@@ -52,23 +37,23 @@ def test_exclude_mode() -> None:
     assert "+add3" in result.diff
 
 
-def test_no_changes_remain_errors() -> None:
+def test_no_changes_remain_errors(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,2 +1,3 @@ def foo():\n ctx1\n+add1\n ctx2"
-    hunk = _make_hunk(diff)
+    hunk = make_hunk(diff)
     with pytest.raises(ValueError, match="no changes remain"):
         filter_hunk_lines(hunk, {2}, exclude=True)
 
 
-def test_out_of_range_errors() -> None:
+def test_out_of_range_errors(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,2 +1,3 @@ def foo():\n ctx1\n+add1\n ctx2"
-    hunk = _make_hunk(diff)
+    hunk = make_hunk(diff)
     with pytest.raises(ValueError, match="out of range"):
         filter_hunk_lines(hunk, {99}, exclude=False)
 
 
-def test_header_recalculated() -> None:
+def test_header_recalculated(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,4 +1,5 @@ def foo():\n ctx1\n-del1\n+add1\n+add2\n ctx2"
-    hunk = _make_hunk(diff)
+    hunk = make_hunk(diff)
     result = filter_hunk_lines(hunk, {3}, exclude=False)
     assert result.additions == 1
     assert result.deletions == 0
@@ -76,9 +61,9 @@ def test_header_recalculated() -> None:
     assert "+1,4" in result.header
 
 
-def test_mixed_changes() -> None:
+def test_mixed_changes(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,3 +1,4 @@ def foo():\n ctx\n-old\n+new1\n+new2"
-    hunk = _make_hunk(diff)
+    hunk = make_hunk(diff)
     result = filter_hunk_lines(hunk, {3}, exclude=False)
     assert result.additions == 1
     assert result.deletions == 0
@@ -90,9 +75,11 @@ def test_mixed_changes() -> None:
 _TWO_GROUP = "@@ -1,4 +1,4 @@\n a\n-b\n+B\n c\n-d\n+D"
 
 
-def test_reverse_include_drops_unselected_deletion_keeps_addition() -> None:
+def test_reverse_include_drops_unselected_deletion_keeps_addition(
+    make_hunk: Callable[[str], Hunk],
+) -> None:
     # Reverse (unstage/discard): unselected '+' becomes context, '-' drops.
-    hunk = _make_hunk(_TWO_GROUP)
+    hunk = make_hunk(_TWO_GROUP)
     result = filter_hunk_lines(hunk, {2, 3}, exclude=False, reverse=True)
     assert result.additions == 1
     assert result.deletions == 1
@@ -102,8 +89,8 @@ def test_reverse_include_drops_unselected_deletion_keeps_addition() -> None:
     assert "-d" not in result.diff  # unselected -d dropped
 
 
-def test_reverse_exclude_first_group() -> None:
-    hunk = _make_hunk(_TWO_GROUP)
+def test_reverse_exclude_first_group(make_hunk: Callable[[str], Hunk]) -> None:
+    hunk = make_hunk(_TWO_GROUP)
     result = filter_hunk_lines(hunk, {2, 3}, exclude=True, reverse=True)
     assert result.additions == 1
     assert result.deletions == 1
@@ -116,21 +103,25 @@ def test_reverse_exclude_first_group() -> None:
 _NO_NEWLINE_TO_NEWLINE = f"@@ -1,2 +1,2 @@\n a\n-b\n{NO_NEWLINE_MARKER}\n+B"
 
 
-def test_keep_addition_splits_stale_no_newline_context() -> None:
+def test_keep_addition_splits_stale_no_newline_context(
+    make_hunk: Callable[[str], Hunk],
+) -> None:
     # The unselected '-b' (no trailing newline) survives as context, but the
     # kept '+B' now follows it: it must split into -b/+b so the marker stays on
     # the old side and 'b' gains a newline rather than merging with 'B'.
-    hunk = _make_hunk(_NO_NEWLINE_TO_NEWLINE)
+    hunk = make_hunk(_NO_NEWLINE_TO_NEWLINE)
     result = filter_hunk_lines(hunk, {3}, exclude=False)
     assert result.diff == (f"@@ -1,2 +1,3 @@\n a\n-b\n{NO_NEWLINE_MARKER}\n+b\n+B")
     assert result.additions == 2
     assert result.deletions == 1
 
 
-def test_keep_deletion_drops_no_newline_marker_from_dropped_addition() -> None:
+def test_keep_deletion_drops_no_newline_marker_from_dropped_addition(
+    make_hunk: Callable[[str], Hunk],
+) -> None:
     # Keeping only '-b' drops '+B' and its marker; 'b' keeps no trailing newline
     # as the old side's final line, the new side ends at the ' a' context.
-    hunk = _make_hunk(_NO_NEWLINE_TO_NEWLINE)
+    hunk = make_hunk(_NO_NEWLINE_TO_NEWLINE)
     result = filter_hunk_lines(hunk, {2}, exclude=False)
     assert result.diff == f"@@ -1,2 +1,1 @@\n a\n-b\n{NO_NEWLINE_MARKER}"
     assert result.additions == 0
@@ -142,11 +133,13 @@ _REVERSE_NEW_SIDE_NO_NEWLINE = (
 )
 
 
-def test_reverse_keeps_no_newline_new_context_without_split() -> None:
+def test_reverse_keeps_no_newline_new_context_without_split(
+    make_hunk: Callable[[str], Hunk],
+) -> None:
     # Reverse keeps the unselected '+D' (new-side EOF, no trailing newline) as
     # context. It is always the last body line, so its marker stays put and it
     # never splits: the '+'-origin split branch of _render_body_lines is dead.
-    hunk = _make_hunk(_REVERSE_NEW_SIDE_NO_NEWLINE)
+    hunk = make_hunk(_REVERSE_NEW_SIDE_NO_NEWLINE)
     result = filter_hunk_lines(hunk, {3}, exclude=False, reverse=True)
     assert result.diff == (f"@@ -1,3 +1,4 @@\n a\n+B\n c\n D\n{NO_NEWLINE_MARKER}")
     assert result.additions == 1

--- a/tests/unit/_lines/resolve_matching_test.py
+++ b/tests/unit/_lines/resolve_matching_test.py
@@ -1,0 +1,62 @@
+from collections.abc import Callable
+
+import pytest
+
+from git_hunk._hunk import Hunk
+from git_hunk._lines import resolve_matching_lines
+
+_TWO_GROUP = "@@ -1,4 +1,4 @@\n a\n-b\n+B\n c\n-d\n+D"
+
+
+def test_literal_matches_changed_line_content(
+    make_hunk: Callable[[str], Hunk],
+) -> None:
+    assert resolve_matching_lines(make_hunk(_TWO_GROUP), ["B"], regex=False) == {3}
+
+
+def test_literal_ignores_context_lines(make_hunk: Callable[[str], Hunk]) -> None:
+    # 'a' and 'c' are context; only the changed +/- lines are matchable.
+    with pytest.raises(ValueError, match="no changed line matches"):
+        resolve_matching_lines(make_hunk(_TWO_GROUP), ["a"], regex=False)
+
+
+def test_multiple_patterns_are_ored(make_hunk: Callable[[str], Hunk]) -> None:
+    result = resolve_matching_lines(make_hunk(_TWO_GROUP), ["b", "D"], regex=False)
+    assert result == {2, 6}
+
+
+def test_literal_is_case_sensitive(make_hunk: Callable[[str], Hunk]) -> None:
+    hunk = make_hunk(_TWO_GROUP)
+    assert resolve_matching_lines(hunk, ["b"], regex=False) == {2}
+    assert resolve_matching_lines(hunk, ["B"], regex=False) == {3}
+
+
+def test_literal_treats_metacharacters_literally(
+    make_hunk: Callable[[str], Hunk],
+) -> None:
+    hunk = make_hunk("@@ -1,1 +1,2 @@\n ctx\n+value = items[0].get('x')")
+    assert resolve_matching_lines(hunk, ["[0]"], regex=False) == {2}
+    with pytest.raises(ValueError, match="no changed line matches"):
+        resolve_matching_lines(hunk, ["x.y"], regex=False)
+
+
+def test_regex_search(make_hunk: Callable[[str], Hunk]) -> None:
+    hunk = make_hunk("@@ -1,1 +1,3 @@\n ctx\n+foo123\n+bar")
+    assert resolve_matching_lines(hunk, [r"\d+"], regex=True) == {2}
+
+
+def test_regex_metacharacters_are_special(make_hunk: Callable[[str], Hunk]) -> None:
+    hunk = make_hunk("@@ -1,1 +1,3 @@\n ctx\n+value = items[0]\n+plain")
+    assert resolve_matching_lines(hunk, [r"items\[0\]"], regex=True) == {2}
+
+
+def test_invalid_regex_errors(make_hunk: Callable[[str], Hunk]) -> None:
+    with pytest.raises(ValueError, match="invalid regex"):
+        resolve_matching_lines(make_hunk(_TWO_GROUP), ["("], regex=True)
+
+
+def test_zero_matches_errors_with_pattern_in_message(
+    make_hunk: Callable[[str], Hunk],
+) -> None:
+    with pytest.raises(ValueError, match="nonexistent"):
+        resolve_matching_lines(make_hunk(_TWO_GROUP), ["nonexistent"], regex=False)


### PR DESCRIPTION
Closes #55

## Summary
- Add `--include-matching` / `--exclude-matching` to `stage`, `unstage`, and `discard`, selecting changed (`+`/`-`) lines by content instead of by line number — so an agent can drop a line by what it contains without a `show` round trip or positional staleness.
- Patterns are literal substrings by default; `--regex` opts into Python regular expressions. Both flags are repeatable and OR'd, and case-sensitive.
- Zero matches is an error (nothing staged), so a typo'd pattern never silently stages nothing or everything.
- The matching flags are mutually exclusive with `-l` and with each other; `--regex` without a matching flag is rejected. Positional `-l` is unchanged.
- Pattern resolution reuses the existing line-filter machinery (`filter_hunk_lines`); the only new logic is mapping a pattern to the body line numbers `-l` already uses.

## Test plan
- [x] unit tests for `resolve_matching_lines` (literal/regex, OR, case-sensitivity, metacharacters, zero-match): `tests/unit/_lines/resolve_matching_test.py`
- [x] e2e tests across stage/unstage/discard incl. exclude, regex, mutual-exclusion, and `--regex`-without-pattern: `tests/e2e/pattern_selection_test.py`
- [x] regression test that empty `-l ""` still errors: `tests/e2e/error_test.py`
- [x] `uv run ruff format --check . && uv run ruff check . && uv run ty check` clean
- [x] full suite green (`uv run pytest`, 206 passed)
- [x] manual CLI smoke: exclude-matching drops the targeted line and leaves it unstaged; all error paths exit non-zero (1 content / 2 usage)
