### PR TITLE
feat: --json schema v2 typed Hunk model (ADR 0001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,42 +125,70 @@ the selected hunks.
 ### JSON output
 
 ```bash
-git-hunk list --json
+git-hunk list --json     # inventory: every hunk, no body
+git-hunk show <id> --json # the same hunks plus a structured per-line body
 ```
 
-`list --json` emits a versioned envelope so consumers can depend on a stable
-shape:
+Both emit a versioned envelope (`schema_version` is currently `2`) so consumers
+can depend on a stable shape. `list --json` is a lean inventory and carries no
+body; `show --json` adds a structured `lines` array. A `show --json` hunk
+(`list --json` is identical but without the `lines` field):
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "hunks": [
     {
       "id": "d161935",
-      "file": "src/main.py",
+      "file": { "text": "src/main.py" },
       "status": "unstaged",
-      "header": "@@ -10,3 +10,5 @@ def main():",
-      "context_before": "def main():",
+      "change_kind": "M",
+      "a_mode": "100644",
+      "b_mode": "100644",
+      "binary": false,
+      "header": "@@ -10,3 +10,5 @@",
+      "context_before": { "text": "def main():" },
       "additions": 2,
       "deletions": 0,
-      "diff": "..."
+      "lines": [
+        { "n": 1, "op": " ", "content": { "text": "    x = 1" } },
+        { "n": 2, "op": "+", "content": { "text": "    y = 2" } }
+      ]
     }
   ]
 }
 ```
 
-| Field            | Type   | Description                                                                                        |
-| ---------------- | ------ | -------------------------------------------------------------------------------------------------- |
-| `schema_version` | int    | Envelope version; bumped on any incompatible change to the shape below.                            |
-| `hunks`          | array  | The hunks (empty array when there are no changes).                                                 |
-| `id`             | string | Stable, content-based hunk id (7-char SHA-256 prefix); accepts prefixes.                           |
-| `file`           | string | Path of the changed file.                                                                          |
-| `status`         | string | One of `staged`, `unstaged`, `untracked`.                                                          |
-| `header`         | string | The hunk's `@@ ... @@` header, or a `Binary file (...)` / `Mode ...` label for whole-file changes. |
-| `context_before` | string | The function/section git names after the `@@` header; empty when git provides no context.          |
-| `additions`      | int    | Number of added lines.                                                                             |
-| `deletions`      | int    | Number of removed lines.                                                                           |
-| `diff`           | string | The unified diff for the hunk (empty for whole-file changes).                                      |
+| Field            | Type           | Description                                                                                                  |
+| ---------------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
+| `schema_version` | int            | Envelope version; bumped on any incompatible change to the shape below.                                      |
+| `hunks`          | array          | The hunks (empty array when there are no changes).                                                           |
+| `id`             | string         | Stable, content-based hunk id (7-char SHA-256 prefix); accepts prefixes.                                     |
+| `file`           | union          | Path of the changed file, as a byte-safe `{text\|bytes}` union (see below).                                  |
+| `status`         | string         | One of `staged`, `unstaged`, `untracked`.                                                                    |
+| `change_kind`    | string         | Git status letter: `A` added, `D` deleted, `M` modified, `T` typechange (`R`/`C` reserved). Always present.  |
+| `a_mode`         | string \| null | 6-digit octal git mode on the pre-image side; `null` when that side does not exist.                          |
+| `b_mode`         | string \| null | 6-digit octal git mode on the post-image side; `null` when that side does not exist.                         |
+| `binary`         | bool           | Whether the change is binary. Always present.                                                                |
+| `header`         | string \| null | The hunk's bare `@@ -a,b +c,d @@` range; `null` for a whole-file (binary, mode-only, or type) change.        |
+| `context_before` | union \| null  | The function/section git names after the `@@` header, as a `{text\|bytes}` union; `null` when there is none. |
+| `additions`      | int            | Number of added lines.                                                                                       |
+| `deletions`      | int            | Number of removed lines.                                                                                     |
+| `lines`          | array          | `show --json` only. The structured body; `[]` for a whole-file hunk. See below.                              |
+
+A `lines` entry is `{ "n", "op", "content", "no_newline"? }`:
+
+| Field        | Type   | Description                                                                                         |
+| ------------ | ------ | --------------------------------------------------------------------------------------------------- |
+| `n`          | int    | 1-based position within the hunk body — the index `-l` line selection uses. Counts every body line. |
+| `op`         | string | `" "` context, `"+"` addition, `"-"` deletion.                                                      |
+| `content`    | union  | The line text **without** its leading op character, as a `{text\|bytes}` union.                     |
+| `no_newline` | bool   | Present and `true` only when the line has no trailing newline; consumes no `n`.                     |
+
+Any field carrying arbitrary git/source bytes (`file`, `context_before`,
+`lines[].content`) is a byte-safe `{text | bytes}` union: `{"text": "..."}` for
+valid UTF-8, else `{"bytes": "<base64>"}`. It is always an object, so consumers
+have one code path and strict JSON parsers never see a lone surrogate.
 
 Adding a new field is backward-compatible and does not change `schema_version`;
 renaming, removing, or changing the type of an existing field bumps it. (Before

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import stat
 from dataclasses import dataclass
 from dataclasses import replace
 from typing import Final
@@ -48,8 +49,8 @@ from ._ui import print_hunk_list
 from ._ui import print_skill_list
 from ._ui import print_version
 
-# Bump when the `list --json` shape changes incompatibly (see README JSON output).
-JSON_SCHEMA_VERSION: Final = 1
+# Bump when the `--json` shape changes incompatibly (see README JSON output).
+JSON_SCHEMA_VERSION: Final = 2
 
 
 class CliError(Exception):
@@ -209,7 +210,7 @@ def _apply_line_filter(
         raise CliError("line selection requires exactly one hunk")
     if _is_whole_file_hunk(hunks[0]):
         raise CliError(
-            "line selection is not supported for binary or mode-only changes"
+            "line selection is not supported for binary, mode, or type changes"
         )
     try:
         lines, exclude = selection.resolve(hunks[0])
@@ -303,6 +304,13 @@ def cli(ctx: click.Context, show_help: bool, show_version: bool) -> None:
         print_help(HELP)
 
 
+def _working_tree_mode(path: str) -> str:
+    mode = os.lstat(path).st_mode
+    if stat.S_ISLNK(mode):
+        return "120000"
+    return "100755" if mode & 0o100 else "100644"
+
+
 def _get_untracked_entries(files: list[str] | None = None) -> list[Hunk]:
     _require_git_repo()
     paths = get_untracked_files()
@@ -312,10 +320,14 @@ def _get_untracked_entries(files: list[str] | None = None) -> list[Hunk]:
         Hunk(
             id="",
             file=p,
-            header="",
+            change_kind="A",
+            a_mode=None,
+            b_mode=_working_tree_mode(p),
+            binary=False,
+            header=None,
+            context_before=None,
             additions=0,
             deletions=0,
-            context_before="",
             diff="",
             status="untracked",
         )
@@ -367,11 +379,13 @@ def cmd_list(
 @cli.command("show", add_help_option=False)
 @click.option("--staged", is_flag=True)
 @click.option("--unstaged", is_flag=True)
+@click.option("--json", "force_json", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("ids", nargs=-1)
 def cmd_show(
     staged: bool,
     unstaged: bool,
+    force_json: bool,
     show_help: bool,
     ids: tuple[str, ...],
 ) -> None:
@@ -396,7 +410,14 @@ def cmd_show(
     else:
         matched = hunks
 
-    print_hunk_diffs(matched)
+    if force_json:
+        envelope = {
+            "schema_version": JSON_SCHEMA_VERSION,
+            "hunks": [h.to_dict(include_lines=True) for h in matched],
+        }
+        click.echo(json.dumps(envelope, indent=2))
+    else:
+        print_hunk_diffs(matched)
 
 
 def _find_skill(skills: list[Skill], name: str) -> Skill:

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import re
 from collections import Counter
@@ -13,28 +14,72 @@ def is_no_newline_marker(line: str) -> bool:
     return line == NO_NEWLINE_MARKER
 
 
+def _byte_safe(text: str) -> dict[str, str]:
+    # git output is decoded with surrogateescape (see _git.run_git), so non-UTF-8
+    # bytes survive as lone surrogates. Emit valid UTF-8 as {"text": ...} and
+    # anything else as {"bytes": base64}, so strict JSON parsers never choke on a
+    # lone surrogate. The ripgrep --json idiom; always an object so consumers have
+    # one code path.
+    raw = text.encode("utf-8", "surrogateescape")
+    try:
+        return {"text": raw.decode("utf-8")}
+    except UnicodeDecodeError:
+        return {"bytes": base64.b64encode(raw).decode("ascii")}
+
+
 @dataclass(frozen=True)
 class Hunk:
     id: str
     file: str
-    header: str
+    change_kind: str
+    a_mode: str | None
+    b_mode: str | None
+    binary: bool
+    header: str | None
+    context_before: str | None
     additions: int
     deletions: int
-    context_before: str
     diff: str
     status: str = "unstaged"
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
+    def to_dict(self, *, include_lines: bool = False) -> dict[str, Any]:
+        data: dict[str, Any] = {
             "id": self.id,
-            "file": self.file,
+            "file": _byte_safe(self.file),
             "status": self.status,
+            "change_kind": self.change_kind,
+            "a_mode": self.a_mode,
+            "b_mode": self.b_mode,
+            "binary": self.binary,
             "header": self.header,
-            "context_before": self.context_before,
+            "context_before": (
+                _byte_safe(self.context_before)
+                if self.context_before is not None
+                else None
+            ),
             "additions": self.additions,
             "deletions": self.deletions,
-            "diff": self.diff,
         }
+        if include_lines:
+            data["lines"] = _body_lines(self.diff)
+        return data
+
+
+def _body_lines(diff: str) -> list[dict[str, Any]]:
+    if not diff:
+        return []
+    _, *body = diff.split("\n")
+    body = strip_trailing_empty_lines(body)
+    lines: list[dict[str, Any]] = []
+    for line in body:
+        if is_no_newline_marker(line):
+            if lines:
+                lines[-1]["no_newline"] = True
+            continue
+        lines.append(
+            {"n": len(lines) + 1, "op": line[:1], "content": _byte_safe(line[1:])}
+        )
+    return lines
 
 
 def count_changes(lines: list[str]) -> tuple[int, int]:
@@ -127,67 +172,136 @@ def extract_file_path(file_diff: str) -> str | None:
     return m.group(2) if m else None
 
 
-def _extract_context_before(header: str) -> str:
+def _bare_header(at_line: str) -> str:
+    # "@@ -1,3 +1,3 @@ def foo():" -> "@@ -1,3 +1,3 @@" (strip git's heading; the
+    # heading is carried separately in context_before).
+    m = re.match(r"(@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@)", at_line)
+    return m.group(1) if m else at_line
+
+
+def _extract_context_before(header: str) -> str | None:
     match = re.search(r"@@.*?@@\s*(.*)", header)
-    return match.group(1).strip() if match else ""
+    if not match:
+        return None
+    return match.group(1).strip() or None
 
 
-def _whole_file_hunk(filepath: str, header: str) -> Hunk:
-    """A change applied by staging the whole file (binary or mode-only)."""
+def _whole_file_hunk(
+    filepath: str,
+    *,
+    change_kind: str,
+    a_mode: str | None,
+    b_mode: str | None,
+    binary: bool,
+) -> Hunk:
+    """A change applied by staging the whole file (binary, mode-only, type)."""
     return Hunk(
         id="",
         file=filepath,
-        header=header,
+        change_kind=change_kind,
+        a_mode=a_mode,
+        b_mode=b_mode,
+        binary=binary,
+        header=None,
+        context_before=None,
         additions=0,
         deletions=0,
-        context_before="",
         diff="",
     )
 
 
-def _binary_file_header(file_diff: str) -> str:
-    if re.search(r"^deleted file mode ", file_diff, flags=re.MULTILINE):
-        return "Binary file (deleted)"
-    if re.search(r"^new file mode ", file_diff, flags=re.MULTILINE):
-        return "Binary file (added)"
-    return "Binary file (modified)"
+def _block_modes(file_diff: str) -> tuple[str, str | None, str | None]:
+    """Derive (change_kind, a_mode, b_mode) from one file diff's header lines."""
+    new_file = re.search(r"^new file mode (\d+)", file_diff, flags=re.MULTILINE)
+    if new_file:
+        return "A", None, new_file.group(1)
+    deleted = re.search(r"^deleted file mode (\d+)", file_diff, flags=re.MULTILINE)
+    if deleted:
+        return "D", deleted.group(1), None
+    old_mode = re.search(r"^old mode (\d+)", file_diff, flags=re.MULTILINE)
+    new_mode = re.search(r"^new mode (\d+)", file_diff, flags=re.MULTILINE)
+    if old_mode and new_mode:
+        return "M", old_mode.group(1), new_mode.group(1)
+    index = re.search(
+        r"^index [0-9a-f]+\.\.[0-9a-f]+ (\d+)", file_diff, flags=re.MULTILINE
+    )
+    if index:
+        return "M", index.group(1), index.group(1)
+    return "M", None, None
 
 
-def _mode_change_header(file_diff: str) -> str | None:
-    old = re.search(r"^old mode (\d+)$", file_diff, flags=re.MULTILINE)
-    new = re.search(r"^new mode (\d+)$", file_diff, flags=re.MULTILINE)
-    if not (old and new):
-        return None
-    return f"Mode {old.group(1)} -> {new.group(1)}"
+def _is_binary(file_diff: str) -> bool:
+    return (
+        re.search(r"^Binary files .* differ$", file_diff, flags=re.MULTILINE)
+        is not None
+    )
 
 
 def parse_diff(diff_output: str) -> list[Hunk]:
     if not diff_output.strip():
         return []
 
+    file_diffs = [fd for fd in split_file_diffs(diff_output) if fd.strip()]
+
     hunks = []
-    file_diffs = split_file_diffs(diff_output)
-
-    for file_diff in file_diffs:
-        if not file_diff.strip():
-            continue
-
+    i = 0
+    while i < len(file_diffs):
+        file_diff = file_diffs[i]
         filepath = extract_file_path(file_diff)
         if filepath is None:
+            i += 1
             continue
 
-        if re.search(r"^Binary files .* differ$", file_diff, flags=re.MULTILINE):
-            hunks.append(_whole_file_hunk(filepath, _binary_file_header(file_diff)))
+        change_kind, a_mode, b_mode = _block_modes(file_diff)
+
+        # git emits a type change (e.g. file -> symlink) as two consecutive blocks
+        # for the same path: a delete of the old type then an add of the new one.
+        next_diff = file_diffs[i + 1] if i + 1 < len(file_diffs) else None
+        if change_kind == "D" and next_diff is not None:
+            next_kind, _, new_b_mode = _block_modes(next_diff)
+            if next_kind == "A" and extract_file_path(next_diff) == filepath:
+                hunks.append(
+                    _whole_file_hunk(
+                        filepath,
+                        change_kind="T",
+                        a_mode=a_mode,
+                        b_mode=new_b_mode,
+                        binary=_is_binary(file_diff) or _is_binary(next_diff),
+                    )
+                )
+                i += 2
+                continue
+
+        if _is_binary(file_diff):
+            hunks.append(
+                _whole_file_hunk(
+                    filepath,
+                    change_kind=change_kind,
+                    a_mode=a_mode,
+                    b_mode=b_mode,
+                    binary=True,
+                )
+            )
+            i += 1
             continue
 
         parts = re.split(r"(?=^@@)", file_diff, flags=re.MULTILINE)
 
         if len(parts) == 1:
             # No text hunks: surface a pure mode change (chmod) that would
-            # otherwise be dropped silently.
-            mode_header = _mode_change_header(file_diff)
-            if mode_header is not None:
-                hunks.append(_whole_file_hunk(filepath, mode_header))
+            # otherwise be dropped silently. An empty new/deleted file (A/D with
+            # no @@ body) is left out, matching git-hunk's prior behavior.
+            if change_kind == "M" and a_mode != b_mode:
+                hunks.append(
+                    _whole_file_hunk(
+                        filepath,
+                        change_kind=change_kind,
+                        a_mode=a_mode,
+                        b_mode=b_mode,
+                        binary=False,
+                    )
+                )
+            i += 1
             continue
 
         # Each @@ section is one hunk. get_diff pins -U3, where git already
@@ -202,12 +316,17 @@ def parse_diff(diff_output: str) -> list[Hunk]:
                 Hunk(
                     id="",
                     file=filepath,
-                    header=header_line,
+                    change_kind=change_kind,
+                    a_mode=a_mode,
+                    b_mode=b_mode,
+                    binary=False,
+                    header=_bare_header(header_line),
+                    context_before=_extract_context_before(header_line),
                     additions=additions,
                     deletions=deletions,
-                    context_before=_extract_context_before(header_line),
                     diff=header_line + "\n" + "\n".join(body_lines),
                 )
             )
+        i += 1
 
     return _with_stable_ids(hunks)

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -213,15 +213,15 @@ def filter_hunk_lines(
     if not m:
         raise ValueError(f"cannot parse hunk header: {header}")
 
-    new_header = (
-        f"@@ -{m.group(1)},{old_count} +{m.group(2)},{new_count} @@{m.group(3)}"
-    )
-    new_diff = new_header + "\n" + "\n".join(new_body)
+    range_header = f"@@ -{m.group(1)},{old_count} +{m.group(2)},{new_count} @@"
+    # diff keeps git's verbatim @@ line (heading included) for git apply / show;
+    # the JSON header field is the bare range (heading lives in context_before).
+    new_diff = range_header + m.group(3) + "\n" + "\n".join(new_body)
 
     return replace(
         hunk,
         diff=new_diff,
-        header=new_header,
+        header=range_header,
         additions=additions,
         deletions=deletions,
     )

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -35,6 +35,21 @@ def _safe(text: str) -> str:
     return text.encode("utf-8", errors="backslashreplace").decode("utf-8")
 
 
+def _whole_file_label(hunk: Hunk) -> str:
+    # Human label for a hunk with no @@ range, derived from its typed fields
+    # (the data layer no longer stores the label string).
+    if hunk.change_kind == "T":
+        return f"Type change ({hunk.a_mode} -> {hunk.b_mode})"
+    if hunk.binary:
+        labels = {"A": "Binary file (added)", "D": "Binary file (deleted)"}
+        return labels.get(hunk.change_kind, "Binary file (modified)")
+    return f"Mode {hunk.a_mode} -> {hunk.b_mode}"
+
+
+def _header_text(hunk: Hunk) -> str:
+    return hunk.header if hunk.header is not None else _whole_file_label(hunk)
+
+
 def _append_stats(text: Text, hunk: Hunk) -> None:
     if hunk.additions:
         text.append(f"+{hunk.additions}", style="green")
@@ -49,7 +64,7 @@ def _print_hunk_line(out: Console, hunk: Hunk) -> None:
     line.append("  ")
     line.append(hunk.id, style="cyan")
     line.append("  ")
-    line.append(_safe(hunk.header), style="dim")
+    line.append(_safe(_header_text(hunk)), style="dim")
     if hunk.context_before:
         line.append(f"  {_safe(hunk.context_before)}", style="dim italic")
     line.append("  ")
@@ -118,7 +133,7 @@ def print_hunk_list(hunks: list[Hunk]) -> None:
 def _print_hunk_diff(out: Console, hunk: Hunk) -> None:
     out.print(f"[bold]{escape(_safe(hunk.file))}[/bold]  [dim]{escape(hunk.id)}[/dim]")
     if not hunk.diff:
-        out.print(Text(_safe(hunk.header), style="dim"))
+        out.print(Text(_safe(_header_text(hunk)), style="dim"))
         return
     line_num = 0
     for line in hunk.diff.split("\n"):
@@ -167,7 +182,7 @@ def print_applied(hunks: list[Hunk], *, verb: str) -> None:
         line.append(hunk.id, style="cyan")
         line.append("  ")
         line.append(_safe(hunk.file), style="bold")
-        line.append(f"  {_safe(hunk.header)}", style="dim")
+        line.append(f"  {_safe(_header_text(hunk))}", style="dim")
         if hunk.context_before:
             line.append(f"  {_safe(hunk.context_before)}", style="dim italic")
         line.append("  ")
@@ -334,6 +349,7 @@ IDs support prefix matching.
 [bold green]Options:[/bold green]
   [bold cyan]--staged[/bold cyan]     Show only staged hunks
   [bold cyan]--unstaged[/bold cyan]   Show only unstaged hunks
+  [bold cyan]--json[/bold cyan]       Output as JSON (with a structured per-line body)
 
 {_format_examples(_EXAMPLES_SHOW)}"""
 

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -181,9 +181,10 @@ git-hunk discard d161935 --dry-run   # preview the restore, change nothing
 
 In `list` (see Quickstart), hunks group under `staged`, `unstaged`, and
 `untracked` (new files git isn't tracking yet). Each hunk line is `id`, the `@@`
-header with its enclosing context, then `+N -N`. A binary or mode-only change
-has no `@@` line; it shows a `Binary file (modified|added|deleted)` or
-`Mode <old> -> <new>` header instead and is staged whole (no `-l`).
+header with its enclosing context, then `+N -N`. A binary, mode-only, or type
+change has no `@@` line; it shows a `Binary file (modified|added|deleted)`,
+`Mode <old> -> <new>`, or `Type change (<old> -> <new>)` label instead and is
+staged whole (no `-l`).
 
 ## Useful flags
 
@@ -191,12 +192,18 @@ has no `@@` line; it shows a `Binary file (modified|added|deleted)` or
 git-hunk list <file>...   # filter hunks to specific files
 git-hunk list --staged    # only staged hunks (also --unstaged; both work on show)
 git-hunk show             # show every hunk's diff (no args)
-git-hunk list --json      # machine-readable; plain output is usually enough
+git-hunk list --json      # machine-readable inventory; plain output is usually enough
+git-hunk show <id> --json # machine-readable diff with a structured per-line body
 ```
 
-`list` and `show` search both staged and unstaged by default. `list --json`
-returns a versioned envelope, `{"schema_version": 1, "hunks": [...]}`; read the
-hunks from the `hunks` array.
+`list` and `show` search both staged and unstaged by default. Both `--json`
+outputs are a versioned envelope, `{"schema_version": 2, "hunks": [...]}`; read
+the hunks from the `hunks` array. `list --json` is a lean inventory (no body);
+`show --json` adds a `lines: [{n, op, content, no_newline?}]` body where `n` is
+the same 1-based index that `-l` selects. Each hunk carries typed
+`change_kind`/`a_mode`/`b_mode`/`binary` fields, a bare `@@` `header` (`null` for
+whole-file changes), and byte-safe `{text|bytes}` unions for `file`,
+`context_before`, and `lines[].content`.
 
 ## Working safely
 

--- a/tests/e2e/binary_test.py
+++ b/tests/e2e/binary_test.py
@@ -9,7 +9,7 @@ from .conftest import GitHunkCLI
 
 def _id_for(cli: GitHunkCLI, path: str, *flags: str) -> str:
     hunks = cli.run_list_json("list", *flags, "--json")
-    return next(h["id"] for h in hunks if h["file"] == path)
+    return next(h["id"] for h in hunks if h["file"]["text"] == path)
 
 
 @pytest.fixture
@@ -31,12 +31,14 @@ def test_list_distinguishes_modified_and_deleted_binary(cli: GitHunkCLI) -> None
     (root / "a.bin").write_bytes(b"\x00\x02A\xfe")
     (root / "d.bin").unlink()
 
-    headers = {
-        h["file"]: h["header"]
-        for h in cli.run_list_json("list", "--unstaged", "--json")
+    by_file = {
+        h["file"]["text"]: h for h in cli.run_list_json("list", "--unstaged", "--json")
     }
-    assert headers["a.bin"] == "Binary file (modified)"
-    assert headers["d.bin"] == "Binary file (deleted)"
+    assert by_file["a.bin"]["binary"] is True
+    assert by_file["a.bin"]["change_kind"] == "M"
+    assert by_file["a.bin"]["header"] is None
+    assert by_file["d.bin"]["binary"] is True
+    assert by_file["d.bin"]["change_kind"] == "D"
 
 
 def test_show_binary_has_no_blank_numbered_line(modified_binary: GitHunkCLI) -> None:
@@ -63,7 +65,7 @@ def test_line_selection_rejected_on_binary(modified_binary: GitHunkCLI) -> None:
     cli = modified_binary
     r = cli.run("stage", _id_for(cli, "a.bin", "--unstaged"), "-l", "1")
     assert r.returncode != 0
-    assert "not supported for binary or mode-only" in r.stderr
+    assert "not supported for binary, mode, or type changes" in r.stderr
 
 
 def test_stage_deleted_binary(cli: GitHunkCLI) -> None:
@@ -89,12 +91,46 @@ def test_stage_added_binary(cli: GitHunkCLI) -> None:
 
     cli.repo.git("add", "n.bin")
     staged = {
-        h["file"]: h["header"] for h in cli.run_list_json("list", "--staged", "--json")
+        h["file"]["text"]: h for h in cli.run_list_json("list", "--staged", "--json")
     }
-    assert staged["n.bin"] == "Binary file (added)"
+    assert staged["n.bin"]["binary"] is True
+    assert staged["n.bin"]["change_kind"] == "A"
 
     cli.run_ok("unstage", _id_for(cli, "n.bin", "--staged"))
     assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="git does not track symlinks on Windows"
+)
+def test_typechange_stage_unstage_discard(cli: GitHunkCLI) -> None:
+    # git emits a file -> symlink type change as a delete + add pair; git-hunk
+    # surfaces it as a single "T" whole-file hunk staged whole.
+    path = Path(cli.repo.path) / "tc.txt"
+    path.write_text("hello\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    path.unlink()
+    path.symlink_to("target")
+
+    by_file = {
+        h["file"]["text"]: h for h in cli.run_list_json("list", "--unstaged", "--json")
+    }
+    assert by_file["tc.txt"]["change_kind"] == "T"
+    assert by_file["tc.txt"]["a_mode"] == "100644"
+    assert by_file["tc.txt"]["b_mode"] == "120000"
+    assert by_file["tc.txt"]["header"] is None
+    # The human label is derived from the typed fields at display time.
+    assert "Type change (100644 -> 120000)" in cli.run_ok("list", "--unstaged")
+
+    cli.run_ok("stage", _id_for(cli, "tc.txt", "--unstaged"))
+    assert "T\ttc.txt" in cli.repo.git("diff", "--cached", "--name-status")
+
+    cli.run_ok("unstage", _id_for(cli, "tc.txt", "--staged"))
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+    cli.run_ok("discard", _id_for(cli, "tc.txt", "--unstaged"))
+    assert cli.repo.git("diff").strip() == ""
 
 
 @pytest.mark.skipif(
@@ -108,11 +144,15 @@ def test_stage_and_discard_mode_only_change(cli: GitHunkCLI) -> None:
     cli.repo.git("commit", "-m", "init")
     os.chmod(path, 0o755)
 
-    headers = {
-        h["file"]: h["header"]
-        for h in cli.run_list_json("list", "--unstaged", "--json")
+    by_file = {
+        h["file"]["text"]: h for h in cli.run_list_json("list", "--unstaged", "--json")
     }
-    assert headers["m.sh"].startswith("Mode ")
+    assert by_file["m.sh"]["change_kind"] == "M"
+    assert by_file["m.sh"]["binary"] is False
+    assert by_file["m.sh"]["header"] is None
+    assert by_file["m.sh"]["a_mode"] != by_file["m.sh"]["b_mode"]
+    # The human label is derived from the typed fields at display time.
+    assert "Mode 100644 -> 100755" in cli.run_ok("list", "--unstaged")
 
     cli.run_ok("stage", _id_for(cli, "m.sh", "--unstaged"))
     assert "m.sh" in cli.repo.git("diff", "--cached", "--name-only")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from typing import Any
 from typing import cast
 
 import pytest
@@ -38,18 +39,18 @@ class GitHunkCLI:
         assert r.returncode == 0, f"git-hunk {' '.join(args)} failed: {r.stderr}"
         return r.stdout
 
-    def run_json(self, *args: str) -> list[dict[str, str]]:
+    def run_json(self, *args: str) -> list[dict[str, Any]]:
         # For commands whose --json output is a bare array (e.g. `skills`).
         # `list --json` returns an envelope; use run_list_json for that.
-        return cast("list[dict[str, str]]", json.loads(self.run_ok(*args)))
+        return cast("list[dict[str, Any]]", json.loads(self.run_ok(*args)))
 
-    def run_list_envelope(self, *args: str) -> dict[str, object]:
-        return cast("dict[str, object]", json.loads(self.run_ok(*args)))
+    def run_list_envelope(self, *args: str) -> dict[str, Any]:
+        return cast("dict[str, Any]", json.loads(self.run_ok(*args)))
 
-    def run_list_json(self, *args: str) -> list[dict[str, str]]:
-        # `list --json` wraps the hunks in a versioned envelope; tests that only
-        # need the hunks call this to unwrap it.
-        return cast("list[dict[str, str]]", self.run_list_envelope(*args)["hunks"])
+    def run_list_json(self, *args: str) -> list[dict[str, Any]]:
+        # `list --json` (and `show --json`) wrap the hunks in a versioned
+        # envelope; tests that only need the hunks call this to unwrap it.
+        return cast("list[dict[str, Any]]", self.run_list_envelope(*args)["hunks"])
 
 
 @pytest.fixture

--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import cast
 
 from git_hunk._cli import JSON_SCHEMA_VERSION
@@ -8,10 +9,14 @@ _REQUIRED_HUNK_KEYS = {
     "id",
     "file",
     "status",
+    "change_kind",
+    "a_mode",
+    "b_mode",
+    "binary",
     "header",
+    "context_before",
     "additions",
     "deletions",
-    "diff",
 }
 _STATUSES = {"staged", "unstaged", "untracked"}
 
@@ -24,11 +29,13 @@ def test_json_envelope_contract(cli: GitHunkCLI) -> None:
 
     envelope = cli.run_list_envelope("list", "--json")
     assert envelope["schema_version"] == JSON_SCHEMA_VERSION
-    hunks = cast("list[dict[str, str]]", envelope["hunks"])
+    hunks = cast("list[dict[str, Any]]", envelope["hunks"])
     assert hunks
     for hunk in hunks:
         assert _REQUIRED_HUNK_KEYS <= hunk.keys()
         assert hunk["status"] in _STATUSES
+        assert "diff" not in hunk
+        assert "lines" not in hunk
 
 
 def test_json_envelope_present_when_empty(cli: GitHunkCLI) -> None:
@@ -58,7 +65,7 @@ def test_single_file_single_hunk(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
-    assert hunks[0]["file"] == "f.py"
+    assert hunks[0]["file"]["text"] == "f.py"
     assert hunks[0]["additions"] == 1
     assert hunks[0]["deletions"] == 1
     assert "id" in hunks[0]
@@ -76,7 +83,7 @@ def test_single_file_multiple_hunks(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
-    assert all(h["file"] == "f.py" for h in hunks)
+    assert all(h["file"]["text"] == "f.py" for h in hunks)
 
 
 def test_multi_file_changes(cli: GitHunkCLI) -> None:
@@ -90,7 +97,7 @@ def test_multi_file_changes(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 2
-    files = {h["file"] for h in hunks}
+    files = {h["file"]["text"] for h in hunks}
     assert files == {"a.py", "b.py"}
 
 
@@ -103,7 +110,7 @@ def test_list_staged(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--staged", "--json")
     assert len(hunks) == 1
-    assert hunks[0]["file"] == "f.py"
+    assert hunks[0]["file"]["text"] == "f.py"
 
 
 def test_list_file_filter(cli: GitHunkCLI) -> None:
@@ -117,7 +124,7 @@ def test_list_file_filter(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json", "a.py")
     assert len(hunks) == 1
-    assert hunks[0]["file"] == "a.py"
+    assert hunks[0]["file"]["text"] == "a.py"
 
 
 def test_list_new_file(cli: GitHunkCLI) -> None:
@@ -130,7 +137,7 @@ def test_list_new_file(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--staged", "--json")
     assert len(hunks) == 1
-    assert hunks[0]["file"] == "new.py"
+    assert hunks[0]["file"]["text"] == "new.py"
     assert int(hunks[0]["additions"]) >= 1
     assert hunks[0]["deletions"] == 0
 
@@ -159,7 +166,24 @@ def test_list_default_shows_untracked(cli: GitHunkCLI) -> None:
     hunks = cli.run_list_json("list", "--json")
     untracked = [h for h in hunks if h["status"] == "untracked"]
     assert len(untracked) == 1
-    assert untracked[0]["file"] == "untracked.py"
+    assert untracked[0]["file"]["text"] == "untracked.py"
+    # change_kind "A" must carry a b_mode (the would-be added side), per the ADR.
+    assert untracked[0]["change_kind"] == "A"
+    assert untracked[0]["a_mode"] is None
+    assert untracked[0]["b_mode"] == "100644"
+
+
+def test_empty_new_file_is_not_a_bogus_mode_hunk(cli: GitHunkCLI) -> None:
+    # A staged empty new file has no @@ body and no mode change; it must not
+    # surface as a whole-file hunk (which would render "Mode None -> ...").
+    cli.repo.write_file("keep.txt", "x\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("empty.txt", "")
+    cli.repo.git("add", "empty.txt")
+
+    assert cli.run_list_json("list", "--staged", "--json") == []
+    assert "Mode None" not in cli.run_ok("list", "--staged")
 
 
 def test_list_unstaged_filter(cli: GitHunkCLI) -> None:
@@ -204,6 +228,6 @@ def test_list_context_before_field_in_json_matches_display(cli: GitHunkCLI) -> N
 
     hunks = cli.run_list_json("list", "--json")
     assert len(hunks) == 1
-    assert hunks[0]["context_before"] == "def foo():"
+    assert hunks[0]["context_before"] == {"text": "def foo():"}
     # Parity: the field equals the function context shown in the human display.
     assert "def foo():" in cli.run_ok("list")

--- a/tests/e2e/no_newline_test.py
+++ b/tests/e2e/no_newline_test.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from git_hunk._hunk import NO_NEWLINE_MARKER
-
 from .conftest import GitHunkCLI
 
 
@@ -77,7 +75,8 @@ def test_stage_line_selection_on_no_newline_hunk(cli: GitHunkCLI) -> None:
 
     # The dropped change still carries its no-newline marker in the remainder.
     remaining = cli.run_list_json("list", "--unstaged", "--json")
-    assert NO_NEWLINE_MARKER in remaining[0]["diff"]
+    body = cli.run_list_json("show", remaining[0]["id"], "--unstaged", "--json")[0]
+    assert any(line.get("no_newline") for line in body["lines"])
 
 
 def test_list_counts_ignore_no_newline_marker(cli: GitHunkCLI) -> None:

--- a/tests/e2e/non_utf8_test.py
+++ b/tests/e2e/non_utf8_test.py
@@ -22,7 +22,7 @@ def latin1_repo(cli: GitHunkCLI) -> GitHunkCLI:
 
 def test_list_does_not_crash_on_non_utf8_content(latin1_repo: GitHunkCLI) -> None:
     hunks = latin1_repo.run_list_json("list", "--unstaged", "--json")
-    assert [h["file"] for h in hunks] == ["latin1.txt"]
+    assert [h["file"]["text"] for h in hunks] == ["latin1.txt"]
 
     latin1_repo.run_ok("list", "--unstaged")
 

--- a/tests/e2e/path_shorthand_test.py
+++ b/tests/e2e/path_shorthand_test.py
@@ -20,7 +20,7 @@ def multi_hunk_repo(cli: GitHunkCLI) -> GitHunkCLI:
 def test_stage_whole_file_by_path(multi_hunk_repo: GitHunkCLI) -> None:
     cli = multi_hunk_repo
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    assert len([h for h in hunks if h["file"] == "big.py"]) == 2
+    assert len([h for h in hunks if h["file"]["text"] == "big.py"]) == 2
 
     cli.run_ok("stage", "big.py")
     assert cli.repo.git("diff", "--cached", "--name-only").split() == ["big.py"]
@@ -51,7 +51,7 @@ def test_dot_slash_prefixed_path(multi_hunk_repo: GitHunkCLI) -> None:
 def test_mixing_path_and_id(multi_hunk_repo: GitHunkCLI) -> None:
     cli = multi_hunk_repo
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    b_id = next(h["id"] for h in hunks if h["file"] == "b.py")
+    b_id = next(h["id"] for h in hunks if h["file"]["text"] == "b.py")
 
     cli.run_ok("stage", "big.py", b_id)
     staged = sorted(cli.repo.git("diff", "--cached", "--name-only").split())

--- a/tests/e2e/quoted_paths_test.py
+++ b/tests/e2e/quoted_paths_test.py
@@ -7,7 +7,7 @@ from .conftest import GitHunkCLI
 
 def _hunk_id_for(cli: GitHunkCLI, path: str) -> str:
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    return next(h["id"] for h in hunks if h["file"] == path)
+    return next(h["id"] for h in hunks if h["file"]["text"] == path)
 
 
 def test_non_ascii_modified_file_round_trips(cli: GitHunkCLI) -> None:
@@ -35,7 +35,7 @@ def test_non_ascii_untracked_shows_real_path(cli: GitHunkCLI) -> None:
 
     hunks = cli.run_list_json("list", "--json")
     untracked = [h for h in hunks if h["status"] == "untracked"]
-    assert [h["file"] for h in untracked] == ["untrack𝟙.txt"]
+    assert [h["file"]["text"] for h in untracked] == ["untrack𝟙.txt"]
 
 
 def test_filename_with_b_slash_substring_stages(cli: GitHunkCLI) -> None:
@@ -45,7 +45,7 @@ def test_filename_with_b_slash_substring_stages(cli: GitHunkCLI) -> None:
     cli.repo.write_file("a b/c.txt", "x\nY\n")
 
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    assert [h["file"] for h in hunks] == ["a b/c.txt"]
+    assert [h["file"]["text"] for h in hunks] == ["a b/c.txt"]
 
     cli.run_ok("stage", _hunk_id_for(cli, "a b/c.txt"))
     assert cli.repo.git("show", ":a b/c.txt") == "x\nY\n"
@@ -74,7 +74,7 @@ def test_quoted_path_modified_file_round_trips(cli: GitHunkCLI, path: str) -> No
     cli.repo.write_file(path, "a\nB\n")
 
     hunks = cli.run_list_json("list", "--unstaged", "--json")
-    assert [h["file"] for h in hunks] == [path]
+    assert [h["file"]["text"] for h in hunks] == [path]
 
     cli.run_ok("stage", _hunk_id_for(cli, path))
     assert cli.repo.git("show", f":{path}") == "a\nB\n"

--- a/tests/e2e/show_json_test.py
+++ b/tests/e2e/show_json_test.py
@@ -1,0 +1,57 @@
+import base64
+from pathlib import Path
+
+from git_hunk._cli import JSON_SCHEMA_VERSION
+
+from .conftest import GitHunkCLI
+
+
+def _two_group(cli: GitHunkCLI) -> str:
+    cli.repo.write_file("f.txt", "a\nb\nc\nd\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "a\nB\nc\nD\n")
+    return cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
+
+
+def test_show_json_envelope_and_structured_body(cli: GitHunkCLI) -> None:
+    hid = _two_group(cli)
+
+    envelope = cli.run_list_envelope("show", hid, "--unstaged", "--json")
+    assert envelope["schema_version"] == JSON_SCHEMA_VERSION
+    body = envelope["hunks"][0]
+
+    assert "diff" not in body  # the raw blob is gone from JSON
+    ops = [line["op"] for line in body["lines"]]
+    assert ops == [" ", "-", "+", " ", "-", "+"]
+    # n is the 1-based body position; every line is counted, context included.
+    assert [line["n"] for line in body["lines"]] == [1, 2, 3, 4, 5, 6]
+    assert body["lines"][2]["content"] == {"text": "B"}
+
+
+def test_show_json_n_round_trips_with_line_selection(cli: GitHunkCLI) -> None:
+    hid = _two_group(cli)
+    lines = cli.run_list_json("show", hid, "--unstaged", "--json")[0]["lines"]
+
+    # Select exactly the first change group (the b -> B pair) by its n indices.
+    ns = [line["n"] for line in lines if line["content"]["text"] in ("b", "B")]
+    cli.run_ok("stage", hid, "-l", ",".join(str(n) for n in ns))
+
+    assert cli.repo.git("show", ":f.txt") == "a\nB\nc\nd\n"
+
+
+def test_show_json_non_utf8_content_round_trips_as_bytes(cli: GitHunkCLI) -> None:
+    path = Path(cli.repo.path) / "f.txt"
+    path.write_bytes(b"line\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    path.write_bytes(b"l\xe9ne\n")  # 0xe9 is invalid standalone UTF-8
+
+    hid = cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
+    body = cli.run_list_json("show", hid, "--unstaged", "--json")[0]
+
+    byte_contents = [
+        line["content"] for line in body["lines"] if "bytes" in line["content"]
+    ]
+    assert byte_contents
+    assert base64.b64decode(byte_contents[0]["bytes"]) == b"l\xe9ne"

--- a/tests/e2e/stage_test.py
+++ b/tests/e2e/stage_test.py
@@ -55,7 +55,7 @@ def test_stage_from_different_files(cli: GitHunkCLI) -> None:
     cli.repo.write_file("b.py", "BBB\n")
 
     hunks = cli.run_list_json("list", "--json")
-    a_hunk = next(h for h in hunks if h["file"] == "a.py")
+    a_hunk = next(h for h in hunks if h["file"]["text"] == "a.py")
 
     cli.run_ok("stage", a_hunk["id"])
 

--- a/tests/unit/_hunk/extract_context_before_test.py
+++ b/tests/unit/_hunk/extract_context_before_test.py
@@ -14,13 +14,13 @@ def test_anchors_to_first_at_at_pair() -> None:
     assert _extract_context_before(header) == "class Foo:  # @@ tag"
 
 
-def test_empty_when_no_trailing_context() -> None:
-    assert _extract_context_before("@@ -1,3 +1,4 @@") == ""
+def test_none_when_no_trailing_context() -> None:
+    assert _extract_context_before("@@ -1,3 +1,4 @@") is None
 
 
-def test_empty_when_trailing_context_is_whitespace_only() -> None:
-    assert _extract_context_before("@@ -1,3 +1,4 @@   ") == ""
+def test_none_when_trailing_context_is_whitespace_only() -> None:
+    assert _extract_context_before("@@ -1,3 +1,4 @@   ") is None
 
 
-def test_empty_when_header_does_not_match() -> None:
-    assert _extract_context_before("diff --git a/f.py b/f.py") == ""
+def test_none_when_header_does_not_match() -> None:
+    assert _extract_context_before("diff --git a/f.py b/f.py") is None

--- a/tests/unit/_hunk/id_test.py
+++ b/tests/unit/_hunk/id_test.py
@@ -32,10 +32,14 @@ def _make_hunk(*, file: str, diff: str) -> Hunk:
     return Hunk(
         id="",
         file=file,
-        header="",
+        change_kind="M",
+        a_mode="100644",
+        b_mode="100644",
+        binary=False,
+        header=None,
+        context_before=None,
         additions=0,
         deletions=0,
-        context_before="",
         diff=diff,
     )
 

--- a/tests/unit/_hunk/parse_diff_test.py
+++ b/tests/unit/_hunk/parse_diff_test.py
@@ -26,7 +26,15 @@ def test_one_section_maps_to_one_hunk() -> None:
     hunks = parse_diff(diff)
     assert len(hunks) == 1
     assert hunks[0].additions == 2
-    assert hunks[0].header == "@@ -1,14 +1,16 @@ def foo():"
+    assert hunks[0].change_kind == "M"
+    assert hunks[0].a_mode == "100644"
+    assert hunks[0].b_mode == "100644"
+    assert hunks[0].binary is False
+    # The JSON header is the bare range; the heading lives in context_before.
+    assert hunks[0].header == "@@ -1,14 +1,16 @@"
+    assert hunks[0].context_before == "def foo():"
+    # The internal diff keeps git's verbatim @@ line (heading included).
+    assert hunks[0].diff.startswith("@@ -1,14 +1,16 @@ def foo():\n")
     assert "+added_top" in hunks[0].diff
     assert "+added_bottom" in hunks[0].diff
 
@@ -40,7 +48,9 @@ def test_binary_file() -> None:
     hunks = parse_diff(diff)
     assert len(hunks) == 1
     assert hunks[0].file == "foo.qm"
-    assert hunks[0].header == "Binary file (modified)"
+    assert hunks[0].binary is True
+    assert hunks[0].change_kind == "M"
+    assert hunks[0].header is None
     assert hunks[0].additions == 0
     assert hunks[0].deletions == 0
     assert hunks[0].diff == ""
@@ -64,8 +74,9 @@ def test_binary_file_mixed_with_text() -> None:
     hunks = parse_diff(diff)
     assert len(hunks) == 2
     assert hunks[0].file == "foo.qm"
-    assert hunks[0].header == "Binary file (modified)"
+    assert hunks[0].binary is True
     assert hunks[1].file == "bar.py"
+    assert hunks[1].binary is False
     assert hunks[1].additions == 1
 
 
@@ -78,7 +89,10 @@ def test_deleted_binary_distinguished() -> None:
     )
     hunks = parse_diff(diff)
     assert len(hunks) == 1
-    assert hunks[0].header == "Binary file (deleted)"
+    assert hunks[0].binary is True
+    assert hunks[0].change_kind == "D"
+    assert hunks[0].a_mode == "100644"
+    assert hunks[0].b_mode is None
     assert hunks[0].diff == ""
 
 
@@ -91,7 +105,10 @@ def test_added_binary_distinguished() -> None:
     )
     hunks = parse_diff(diff)
     assert len(hunks) == 1
-    assert hunks[0].header == "Binary file (added)"
+    assert hunks[0].binary is True
+    assert hunks[0].change_kind == "A"
+    assert hunks[0].a_mode is None
+    assert hunks[0].b_mode == "100644"
 
 
 def test_mode_only_change_surfaced() -> None:
@@ -99,7 +116,67 @@ def test_mode_only_change_surfaced() -> None:
     hunks = parse_diff(diff)
     assert len(hunks) == 1
     assert hunks[0].file == "m.sh"
-    assert hunks[0].header == "Mode 100644 -> 100755"
+    assert hunks[0].change_kind == "M"
+    assert hunks[0].a_mode == "100644"
+    assert hunks[0].b_mode == "100755"
+    assert hunks[0].binary is False
+    assert hunks[0].header is None
     assert hunks[0].additions == 0
     assert hunks[0].deletions == 0
     assert hunks[0].diff == ""
+
+
+def test_typechange_is_single_whole_file_hunk() -> None:
+    # git emits a file -> symlink type change as a delete block followed by an
+    # add block for the same path; parse_diff merges them into one "T" hunk.
+    diff = (
+        "diff --git a/link b/link\n"
+        "deleted file mode 100644\n"
+        "index ce01362..0000000\n"
+        "--- a/link\n"
+        "+++ /dev/null\n"
+        "@@ -1 +0,0 @@\n"
+        "-hello\n"
+        "diff --git a/link b/link\n"
+        "new file mode 120000\n"
+        "index 0000000..1de5659\n"
+        "--- /dev/null\n"
+        "+++ b/link\n"
+        "@@ -0,0 +1 @@\n"
+        "+target\n"
+        "\\ No newline at end of file\n"
+    )
+    hunks = parse_diff(diff)
+    assert len(hunks) == 1
+    assert hunks[0].file == "link"
+    assert hunks[0].change_kind == "T"
+    assert hunks[0].a_mode == "100644"
+    assert hunks[0].b_mode == "120000"
+    assert hunks[0].binary is False
+    assert hunks[0].header is None
+    assert hunks[0].diff == ""
+
+
+def test_typechange_from_binary_is_marked_binary() -> None:
+    # A binary file replaced by a symlink: the delete block is binary, so the
+    # merged "T" hunk must report binary=True (either side being binary counts).
+    diff = (
+        "diff --git a/x b/x\n"
+        "deleted file mode 100644\n"
+        "index abc1234..0000000\n"
+        "Binary files a/x and /dev/null differ\n"
+        "diff --git a/x b/x\n"
+        "new file mode 120000\n"
+        "index 0000000..1de5659\n"
+        "--- /dev/null\n"
+        "+++ b/x\n"
+        "@@ -0,0 +1 @@\n"
+        "+target\n"
+        "\\ No newline at end of file\n"
+    )
+    hunks = parse_diff(diff)
+    assert len(hunks) == 1
+    assert hunks[0].change_kind == "T"
+    assert hunks[0].binary is True
+    assert hunks[0].a_mode == "100644"
+    assert hunks[0].b_mode == "120000"

--- a/tests/unit/_hunk/to_dict_test.py
+++ b/tests/unit/_hunk/to_dict_test.py
@@ -1,29 +1,116 @@
 from git_hunk._hunk import Hunk
 
 
-def test_to_dict_includes_context_before() -> None:
-    hunk = Hunk(
+def _text_hunk(*, context_before: str | None) -> Hunk:
+    return Hunk(
         id="abc1234",
         file="f.py",
-        header="@@ -1,3 +1,3 @@ def foo():",
+        change_kind="M",
+        a_mode="100644",
+        b_mode="100644",
+        binary=False,
+        header="@@ -1,3 +1,3 @@",
+        context_before=context_before,
         additions=1,
         deletions=1,
-        context_before="def foo():",
-        diff="@@ -1,3 +1,3 @@ def foo():\n-a\n+b",
+        diff="@@ -1,3 +1,3 @@ def foo():\n ctx\n-a\n+b",
     )
-    assert hunk.to_dict()["context_before"] == "def foo():"
 
 
-def test_to_dict_context_before_empty_when_no_context() -> None:
+def test_to_dict_wraps_context_before_in_text_union() -> None:
+    serialized = _text_hunk(context_before="def foo():").to_dict()
+    assert serialized["context_before"] == {"text": "def foo():"}
+
+
+def test_to_dict_context_before_null_when_absent() -> None:
+    serialized = _text_hunk(context_before=None).to_dict()
+    assert serialized["context_before"] is None
+
+
+def test_to_dict_typed_fields_and_byte_safe_file() -> None:
+    serialized = _text_hunk(context_before=None).to_dict()
+    assert serialized["file"] == {"text": "f.py"}
+    assert serialized["change_kind"] == "M"
+    assert serialized["a_mode"] == "100644"
+    assert serialized["b_mode"] == "100644"
+    assert serialized["binary"] is False
+    assert serialized["header"] == "@@ -1,3 +1,3 @@"
+
+
+def test_to_dict_omits_lines_by_default() -> None:
+    assert "lines" not in _text_hunk(context_before=None).to_dict()
+
+
+def test_to_dict_includes_structured_lines_when_requested() -> None:
+    serialized = _text_hunk(context_before=None).to_dict(include_lines=True)
+    assert serialized["lines"] == [
+        {"n": 1, "op": " ", "content": {"text": "ctx"}},
+        {"n": 2, "op": "-", "content": {"text": "a"}},
+        {"n": 3, "op": "+", "content": {"text": "b"}},
+    ]
+
+
+def test_to_dict_lines_carry_no_newline_flag() -> None:
     hunk = Hunk(
         id="abc1234",
         file="f.txt",
-        header="@@ -1,3 +1,3 @@",
+        change_kind="M",
+        a_mode="100644",
+        b_mode="100644",
+        binary=False,
+        header="@@ -1 +1 @@",
+        context_before=None,
         additions=1,
         deletions=1,
-        context_before="",
-        diff="@@ -1,3 +1,3 @@\n-a\n+b",
+        diff=(
+            "@@ -1 +1 @@\n"
+            "-a\n"
+            "\\ No newline at end of file\n"
+            "+b\n"
+            "\\ No newline at end of file"
+        ),
     )
-    serialized = hunk.to_dict()
-    assert "context_before" in serialized
-    assert serialized["context_before"] == ""
+    lines = hunk.to_dict(include_lines=True)["lines"]
+    assert lines == [
+        {"n": 1, "op": "-", "content": {"text": "a"}, "no_newline": True},
+        {"n": 2, "op": "+", "content": {"text": "b"}, "no_newline": True},
+    ]
+
+
+def test_to_dict_whole_file_hunk_has_empty_lines_and_null_header() -> None:
+    hunk = Hunk(
+        id="abc1234",
+        file="logo.png",
+        change_kind="M",
+        a_mode="100644",
+        b_mode="100644",
+        binary=True,
+        header=None,
+        context_before=None,
+        additions=0,
+        deletions=0,
+        diff="",
+    )
+    serialized = hunk.to_dict(include_lines=True)
+    assert serialized["header"] is None
+    assert serialized["binary"] is True
+    assert serialized["lines"] == []
+
+
+def test_to_dict_byte_safe_content_falls_back_to_bytes() -> None:
+    # 0xe9 is invalid standalone UTF-8; it survives decode as a lone surrogate.
+    hunk = Hunk(
+        id="abc1234",
+        file="f.txt",
+        change_kind="M",
+        a_mode="100644",
+        b_mode="100644",
+        binary=False,
+        header="@@ -1 +1 @@",
+        context_before=None,
+        additions=1,
+        deletions=0,
+        diff="@@ -1 +1 @@\n+x\udce9y",
+    )
+    content = hunk.to_dict(include_lines=True)["lines"][0]["content"]
+    assert content == {"bytes": "eOl5"}

--- a/tests/unit/_lines/conftest.py
+++ b/tests/unit/_lines/conftest.py
@@ -14,10 +14,14 @@ def make_hunk() -> Callable[[str], Hunk]:
         return Hunk(
             id="abc1234",
             file="test.py",
+            change_kind="M",
+            a_mode="100644",
+            b_mode="100644",
+            binary=False,
             header=diff.split("\n")[0],
+            context_before=None,
             additions=additions,
             deletions=deletions,
-            context_before="",
             diff=diff,
         )
 

--- a/tests/unit/_lines/filter_test.py
+++ b/tests/unit/_lines/filter_test.py
@@ -57,8 +57,7 @@ def test_header_recalculated(make_hunk: Callable[[str], Hunk]) -> None:
     result = filter_hunk_lines(hunk, {3}, exclude=False)
     assert result.additions == 1
     assert result.deletions == 0
-    assert "-1,3" in result.header
-    assert "+1,4" in result.header
+    assert result.header == "@@ -1,3 +1,4 @@"
 
 
 def test_mixed_changes(make_hunk: Callable[[str], Hunk]) -> None:

--- a/tests/unit/_patch_test.py
+++ b/tests/unit/_patch_test.py
@@ -40,10 +40,14 @@ def _make_hunk(*, file: str, diff: str) -> Hunk:
     return Hunk(
         id="abc",
         file=file,
-        header="",
+        change_kind="M",
+        a_mode="100644",
+        b_mode="100644",
+        binary=False,
+        header=None,
+        context_before=None,
         additions=1,
         deletions=0,
-        context_before="",
         diff=diff,
     )
 

--- a/tests/unit/_ui/whole_file_label_test.py
+++ b/tests/unit/_ui/whole_file_label_test.py
@@ -1,0 +1,60 @@
+from git_hunk._hunk import Hunk
+from git_hunk._ui import _whole_file_label
+
+
+def _whole_file_hunk(
+    *, change_kind: str, a_mode: str | None, b_mode: str | None, binary: bool
+) -> Hunk:
+    return Hunk(
+        id="abc1234",
+        file="x",
+        change_kind=change_kind,
+        a_mode=a_mode,
+        b_mode=b_mode,
+        binary=binary,
+        header=None,
+        context_before=None,
+        additions=0,
+        deletions=0,
+        diff="",
+    )
+
+
+def test_type_change_label() -> None:
+    hunk = _whole_file_hunk(
+        change_kind="T", a_mode="100644", b_mode="120000", binary=False
+    )
+    assert _whole_file_label(hunk) == "Type change (100644 -> 120000)"
+
+
+def test_binary_type_change_keeps_type_change_label() -> None:
+    # A binary file replaced by a symlink: the typechange nature must win over the
+    # binary flag, otherwise the UI hides that this is a type change.
+    hunk = _whole_file_hunk(
+        change_kind="T", a_mode="100644", b_mode="120000", binary=True
+    )
+    assert _whole_file_label(hunk) == "Type change (100644 -> 120000)"
+
+
+def test_binary_added_label() -> None:
+    hunk = _whole_file_hunk(change_kind="A", a_mode=None, b_mode="100644", binary=True)
+    assert _whole_file_label(hunk) == "Binary file (added)"
+
+
+def test_binary_deleted_label() -> None:
+    hunk = _whole_file_hunk(change_kind="D", a_mode="100644", b_mode=None, binary=True)
+    assert _whole_file_label(hunk) == "Binary file (deleted)"
+
+
+def test_binary_modified_label() -> None:
+    hunk = _whole_file_hunk(
+        change_kind="M", a_mode="100644", b_mode="100644", binary=True
+    )
+    assert _whole_file_label(hunk) == "Binary file (modified)"
+
+
+def test_mode_change_label() -> None:
+    hunk = _whole_file_hunk(
+        change_kind="M", a_mode="100644", b_mode="100755", binary=False
+    )
+    assert _whole_file_label(hunk) == "Mode 100644 -> 100755"


### PR DESCRIPTION
## Summary

Implements the `--json` **schema v2** typed `Hunk` model from
[ADR 0001](docs/adr/0001-json-v2-hunk-schema.md) as one coordinated change, and
bumps `schema_version` 1 → 2 once. The five converged issues all rewrite the same
`Hunk` / `to_dict` / `parse_diff` surface and share the version bump, so they ship
together rather than as colliding partial-v2 schemas.

- **Typed change kind & modes** — `change_kind` (`A`/`D`/`M`/`T`), `a_mode`/`b_mode`
  (6-digit octal strings, `null` when a side is absent), and `binary` are typed
  fields; the UI derives the `Binary file (...)` / `Mode X -> Y` / `Type change (...)`
  labels from them, so the data layer no longer stores display strings. (#40)
- **Bare header** — `header` is the bare `@@ -a,b +c,d @@` range (or `null` for
  whole-file hunks); `context_before` is the single heading source, removing the
  duplicated heading from the human `list`/applied display. (#50)
- **Structured body** — `show --json` gains a `lines: [{n, op, content, no_newline?}]`
  body where `n` matches `-l` numbering; the raw `diff` blob is dropped from JSON and
  `list --json` stays a lean inventory (no body). (#56)
- **No-newline as a property** — the `\ No newline at end of file` marker becomes
  `lines[].no_newline` and consumes no `n` index. (#28)
- **Byte-safe JSON** — `file`, `context_before`, and `lines[].content` are
  `{text | bytes}` unions (base64 for non-UTF-8), so strict JSON parsers accept
  non-UTF-8 paths/content. (#44)

A type change (git's delete+add pair for one path) is surfaced as a single `T`
whole-file hunk, staged whole. Untracked entries carry `change_kind: "A"` with a
`b_mode` derived from the working-tree mode. Human (non-JSON) `show` output is
unchanged; `list` drops only the duplicated heading per #50.

## Test plan

- [x] `make lint` (ruff, ty, taplo, mdformat, yamlfix, typos)
- [x] full suite — `uv run pytest tests/` (208 passed)
- [x] new tests: `tests/e2e/show_json_test.py`, typechange + byte-safe + no_newline +
      empty-file + untracked cases across `tests/e2e/` and `tests/unit/_hunk/`
- [x] manual: drove `list --json` / `show --json` on a real repo across
      modify/chmod/deleted/binary/typechange/non-UTF-8/no-newline; confirmed strict
      JSON parse, `n`↔`-l` round-trip preserving non-UTF-8 bytes, and unchanged human output

Closes #67
Closes #28, #40, #44, #50, #56
