### PR TITLE
chore: ignore /.wt/ worktree dir in project gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Tools
 /.claude/
+
+# Worktrees
+/.wt/


### PR DESCRIPTION
The `.wt/` directory is the git-wt worktree base dir used in this repo's workflow
(several worktrees live there right now). It was only excluded via a personal
`~/.gitignore_global` entry, so a fresh clone or CI runner sees the whole `.wt/`
tree as untracked, risking an accidental `git add .` that commits checked-out
worktrees into the repo. Tracking the ignore in the project `.gitignore` makes the
convention self-documenting for collaborators, mirroring the existing `/.claude/`
entry. Root-anchored (`/.wt/`) so only the top-level dir matches.

## Test plan
- [x] `git check-ignore -v .wt` now reports `.gitignore` instead of the global file
