### PR TITLE
chore: cancel superseded PR CI runs via concurrency group

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
   workflow_call:
+concurrency:
+  # Cancel only superseded PR runs. Pushes to main and the tag-triggered publish
+  # run (which reuses this workflow via workflow_call, inheriting the caller's
+  # "push" event) are never cancelled.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Every push to a PR currently starts a fresh CI run while the superseded run keeps
going to completion. For the Test workflow that is 12 jobs (3 OS x 4 Python) left
running per stale commit. This adds a `concurrency` group to the Test and Lint
workflows so a new push to a pull request cancels the in-progress run for that PR.

`cancel-in-progress` is gated on `github.event_name == 'pull_request'`, so pushes
to `main` and the tag-triggered publish run (which reuses `test.yml` via
`workflow_call`) are never cancelled. `publish.yml` is intentionally left
untouched.

## Test plan
- [x] `make lint` (ruff, ty, taplo, mdformat, yamlfix, typos) green
- [x] `uv run pytest tests/` green (219 passed)
