### PR TITLE
ci: test only lowest and highest supported Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.13']
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
Streamline the test matrix to the endpoints of the supported range
(`requires-python = ">=3.10"`): Python 3.10 and 3.13, dropping 3.11 and
3.12. Cuts the matrix from 12 jobs to 6 across the three OSes.

The middle versions add little signal for this codebase: a pure-Python CLI
that shells out to git and parses diffs, with no C extensions or
version-sensitive stdlib surface. A failure unique to 3.11/3.12 (passing on
both endpoints) would require a transient CPython regression introduced in a
middle version and fixed by 3.13 — rare, and unlikely to touch this code path.

## Test plan
- [x] CI runs green on the 3.10 and 3.13 jobs across ubuntu/macos/windows
