### PR TITLE
feat: support Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.13']
+        python-version: ['3.10', '3.14']
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Version Control :: Git",
 ]
 dependencies = ["click>=8", "rich>=13"]


### PR DESCRIPTION
Python 3.14 is released; the full suite (238 tests) passes on it unchanged, so this declares support: adds the trove classifier and the CI matrix entry. `requires-python` stays `>=3.10`.

Note: touches the same `python-version` line as #75 (test-matrix trim), so whichever merges second will need a trivial rebase. If #75 lands first, the matrix becomes `['3.10', '3.14']` (3.14 as the new highest).

## Test plan
- [x] `uv run --python 3.14 pytest tests/` — 238 passed
