### PR TITLE
ci: harden PyPI publish workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,23 +3,25 @@ name: Publish to PyPI
 on:
   push:
     tags: [v*]
+permissions: {}
 jobs:
   test:
-    uses: ./.github/workflows/test.yml
-  publish:
-    needs: test
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
     permissions:
       contents: read
-      id-token: write
+    uses: ./.github/workflows/test.yml
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v6
-      - run: uv build
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
+      - name: Build
+        run: SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)" uv build
       - name: Verify built version matches tag
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -30,4 +32,21 @@ jobs:
               "PEP 440 version"
             exit 1
           }
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: dist
+          path: dist/
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/git-hunk
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.10', '3.14']
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: make test


### PR DESCRIPTION
## Summary
- Pin every GitHub Action to a full commit SHA (with a version comment) so a mutable tag, or the `release/v1` branch pointer on `gh-action-pypi-publish`, cannot swap action code under us. Pins cover the reusable `test` workflow too, since it gates publish via `workflow_call`.
- Split the single privileged `publish` job into a `build` job (`contents: read`; builds + verifies the wheel, uploads the dist artifact) and a `publish` job (`id-token: write` only; downloads the artifact and publishes). Build/test code never holds the OIDC token.
- Deny token permissions at the workflow level by default and grant each job only what it needs.
- Add `.github/dependabot.yml` for the `github-actions` ecosystem to keep the pinned SHAs current.
- `persist-credentials: false` on checkout, `SOURCE_DATE_EPOCH` for reproducible builds, and the `pypi` environment `url` for the published project.

All action SHAs were resolved via the GitHub API and verified against their version tags. No change to what gets published.

The `environment: pypi` protection rules (required reviewers / tag policy) are repo-admin settings and are not configurable from the workflow file; this PR adds the `environment:` binding so those rules apply once configured.

## Test plan
- [x] All three workflow/config files parse as YAML
- [x] `SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)" uv build` produces the sdist and the wheel the verify step checks

Closes #37
