### PR TITLE
test: add unit coverage for _find_hunks_by_ids id resolution

### DIFF
--- a/tests/unit/_cli/find_hunks_by_ids_test.py
+++ b/tests/unit/_cli/find_hunks_by_ids_test.py
@@ -1,0 +1,63 @@
+import pytest
+
+from git_hunk._cli import CliError
+from git_hunk._cli import _find_hunks_by_ids
+from git_hunk._hunk import Hunk
+
+
+def _make_hunk(*, hunk_id: str) -> Hunk:
+    return Hunk(
+        id=hunk_id,
+        file="f.py",
+        change_kind="M",
+        a_mode="100644",
+        b_mode="100644",
+        binary=False,
+        header=None,
+        context_before=None,
+        additions=0,
+        deletions=0,
+        diff="",
+    )
+
+
+@pytest.fixture
+def hunks() -> list[Hunk]:
+    return [_make_hunk(hunk_id="ab12cd0"), _make_hunk(hunk_id="ab34ef0")]
+
+
+def test_unique_prefix_resolves_to_one_hunk(hunks: list[Hunk]) -> None:
+    assert _find_hunks_by_ids(hunks, ["ab12"]) == [hunks[0]]
+
+
+def test_multiple_ids_resolve_in_order(hunks: list[Hunk]) -> None:
+    assert _find_hunks_by_ids(hunks, ["ab12", "ab34"]) == [hunks[0], hunks[1]]
+
+
+def test_ambiguous_prefix_raises_with_matches_tip(hunks: list[Hunk]) -> None:
+    with pytest.raises(CliError) as exc_info:
+        _find_hunks_by_ids(hunks, ["ab"])
+    assert str(exc_info.value) == "ambiguous hunk id 'ab'"
+    assert exc_info.value.tip == "matches: ab12cd0, ab34ef0"
+
+
+def test_unmatched_prefix_raises_not_found(hunks: list[Hunk]) -> None:
+    with pytest.raises(CliError) as exc_info:
+        _find_hunks_by_ids(hunks, ["ff"])
+    assert str(exc_info.value) == "hunk 'ff' not found"
+    assert exc_info.value.tip == "available hunk ids: ab12cd0, ab34ef0"
+
+
+def test_not_found_with_empty_pool_has_no_tip() -> None:
+    with pytest.raises(CliError) as exc_info:
+        _find_hunks_by_ids([], ["ff"])
+    assert str(exc_info.value) == "hunk 'ff' not found"
+    assert exc_info.value.tip is None
+
+
+@pytest.mark.parametrize("blank", ["", "  "])
+def test_blank_id_rejected(hunks: list[Hunk], blank: str) -> None:
+    with pytest.raises(CliError) as exc_info:
+        _find_hunks_by_ids(hunks, [blank])
+    assert str(exc_info.value) == "hunk id must not be empty or whitespace"
+    assert exc_info.value.tip is None


### PR DESCRIPTION
Adds a unit suite for `git_hunk._cli._find_hunks_by_ids`, the prefix-resolution
helper behind `stage`/`unstage`/`discard`/`show` id lookup. The **ambiguous-prefix**
branch (a short prefix matching more than one hunk id) previously had no coverage at
any level; the not-found and blank-id guards were exercised only incidentally through
e2e CLI tests, never against the helper directly.

The new file pins every branch of the helper's contract: unique-prefix resolution,
multi-id accumulation (the path `show` uses), the ambiguous error and its `matches:`
tip, not-found with and without the `available hunk ids:` tip (empty pool), and the
blank/whitespace id guard. No production code changed.

## Test plan
- [x] `tests/unit/_cli/find_hunks_by_ids_test.py` (new, 7 cases)
- [x] `make test` — 245 passed
- [x] `make lint`
