### PR TITLE
docs: document the CHANGELOG.md convention for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md
 
+## Changelog
+
+User-facing changes go in `CHANGELOG.md` under `## [Unreleased]`
+([Keep a Changelog](https://keepachangelog.com/) format), with the PR number.
+At release, that section is promoted to the new version.
+
 ## Agent skills
 
 ### Issue tracker


### PR DESCRIPTION
The repo already keeps a Keep a Changelog `CHANGELOG.md` (`[Unreleased]`,
sectioned entries, PR numbers), but `AGENTS.md` never told agents to maintain
it, so the convention was followed by habit rather than instruction. This adds a
short `## Changelog` section documenting it, mirroring the convention added in
wkentaro/acron#94.

## Test plan
- [x] `uv run mdformat AGENTS.md` leaves it unchanged