### PR TITLE
fix: reject empty --include/--exclude-matching pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,5 +52,8 @@ and this project adheres to
 - Split the no-newline last line when partial line-staging (`-l`) gives it a
   trailing newline, so staging only the addition no longer merges it with the
   added line and corrupts the file (#54).
+- Reject an empty `--include-matching` / `--exclude-matching` pattern, which
+  previously matched every line and silently selected the whole hunk, so an
+  accidentally-empty pattern now errors like an empty `-l` spec (#87).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -128,7 +128,14 @@ def resolve_matching_lines(
     Patterns are OR'd. Only changed ('+'/'-') lines are considered, matched
     against their content (the text after the prefix). Raises if nothing matches,
     so a typo'd pattern never silently selects nothing or everything.
+
+    An empty pattern is rejected: it would match every changed line and silently
+    select the whole hunk, mirroring how an empty -l spec errors rather than
+    falling through to select everything.
     """
+    if "" in patterns:
+        raise ValueError("empty match pattern")
+
     compiled: list[re.Pattern[str]] | None = None
     if regex:
         try:

--- a/tests/e2e/pattern_selection_test.py
+++ b/tests/e2e/pattern_selection_test.py
@@ -157,3 +157,14 @@ def test_regex_without_matching_flag_is_rejected(added_lines: GitHunkCLI) -> Non
     assert r.returncode != 0
     assert "--regex requires" in r.stderr
     assert added_lines.repo.git("show", ":f.txt") == "keep\n"
+
+
+def test_empty_include_matching_is_rejected(added_lines: GitHunkCLI) -> None:
+    # An empty pattern would match every line; reject it rather than silently
+    # staging the whole hunk.
+    r = added_lines.run(
+        "stage", _only_id(added_lines, "--unstaged"), "--include-matching", ""
+    )
+    assert r.returncode != 0
+    assert "empty match pattern" in r.stderr
+    assert added_lines.repo.git("show", ":f.txt") == "keep\n"

--- a/tests/unit/_lines/resolve_matching_test.py
+++ b/tests/unit/_lines/resolve_matching_test.py
@@ -63,6 +63,22 @@ def test_zero_matches_errors_with_pattern_in_message(
         resolve_matching_lines(make_hunk(_TWO_GROUP), ["nonexistent"], regex=False)
 
 
+def test_empty_pattern_rejected(make_hunk: Callable[[str], Hunk]) -> None:
+    # An empty pattern matches every line; reject it instead of silently
+    # selecting the whole hunk (parallels an empty -l spec erroring).
+    with pytest.raises(ValueError, match="empty match pattern"):
+        resolve_matching_lines(make_hunk(_TWO_GROUP), [""], regex=False)
+    with pytest.raises(ValueError, match="empty match pattern"):
+        resolve_matching_lines(make_hunk(_TWO_GROUP), ["B", ""], regex=False)
+
+
+def test_whitespace_pattern_allowed(make_hunk: Callable[[str], Hunk]) -> None:
+    # A whitespace pattern is meaningful (matches lines containing it), unlike an
+    # empty one, so it is not rejected.
+    hunk = make_hunk("@@ -1,1 +1,2 @@\n ctx\n+a b")
+    assert resolve_matching_lines(hunk, [" "], regex=False) == {2}
+
+
 def test_interleaved_no_newline_marker_does_not_consume_a_line_number(
     make_hunk: Callable[[str], Hunk],
 ) -> None:


### PR DESCRIPTION
`--include-matching ""` matched every changed line (an empty string is a substring
of every line, and an empty regex compiles fine), so it silently
staged/unstaged/discarded the whole hunk instead of erroring. That inverts the
policy the code already states in its own docstring ("a typo'd pattern never
silently selects nothing or everything") and is inconsistent with an empty `-l`
spec, which already errors. `--exclude-matching ""` only errored by accident,
tripping an unrelated "no changes remain" check.

Reject an empty pattern up front in `resolve_matching_lines`, mirroring
`parse_line_spec`'s empty-spec rejection. A whitespace pattern stays valid — it is
a meaningful substring/regex, unlike an empty one.

## Test plan
- [x] unit: `tests/unit/_lines/resolve_matching_test.py` — empty rejected (incl. an OR'd list with one empty pattern); whitespace still allowed
- [x] e2e: `tests/e2e/pattern_selection_test.py::test_empty_include_matching_is_rejected`
- [x] `make lint` (ruff, ty, taplo, mdformat, yamlfix, typos) and full `pytest` green
- [x] manual: `git-hunk stage <id> --include-matching ""` now errors (`empty match pattern`) and stages nothing; `--include-matching " "` still works
