### PR TITLE
test: cover load_skills' missing-root and non-skill-dir branches

### DIFF
--- a/tests/unit/_skills/load_skills_test.py
+++ b/tests/unit/_skills/load_skills_test.py
@@ -39,6 +39,24 @@ def test_unclosed_frontmatter_loads_with_directory_name(
     assert skill.description == ""
 
 
+def test_missing_skills_root_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GIT_HUNK_SKILLS_DIR", str(tmp_path / "does-not-exist"))
+
+    assert load_skills() == []
+
+
+def test_directory_without_skill_md_is_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_skill(tmp_path, "good", _VALID)
+    (tmp_path / "not-a-skill").mkdir()
+    monkeypatch.setenv("GIT_HUNK_SKILLS_DIR", str(tmp_path))
+
+    assert [s.name for s in load_skills()] == ["good"]
+
+
 @pytest.mark.skipif(
     sys.platform == "win32", reason="permission bits are not enforced on Windows"
 )


### PR DESCRIPTION
`load_skills()` had two uncovered branches in `git_hunk/_skills.py`: the
missing-root guard (`if not root.is_dir(): return []`) and the
non-skill-directory skip (`if not skill_md.is_file(): continue`). Both are
reachable at runtime via a misconfigured or partially-populated
`GIT_HUNK_SKILLS_DIR`, so this pins them down.

Reuses the file's existing `_write_skill` helper and `tmp_path` + `monkeypatch`
idiom; `git_hunk/_skills.py` goes to full line coverage under the suite.

## Test plan
- [x] `uv run pytest tests/` — 251 passed
- [x] `uv run ruff format --check && uv run ruff check && uv run ty check` — clean
