### PR TITLE
test: cover plain-text list section and file-group separators

### DIFF
--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -217,6 +217,29 @@ def test_list_status_field_in_json(cli: GitHunkCLI) -> None:
     assert hunks[0]["status"] == "unstaged"
 
 
+def test_list_plaintext_blank_lines_separate_sections_and_file_groups(
+    cli: GitHunkCLI,
+) -> None:
+    cli.repo.write_file("s.py", "s\n")
+    cli.repo.write_file("a.py", "a\n")
+    cli.repo.write_file("b.py", "b\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    cli.repo.write_file("s.py", "S\n")
+    cli.repo.git("add", "s.py")
+    cli.repo.write_file("a.py", "A\n")
+    cli.repo.write_file("b.py", "B\n")
+
+    blocks = cli.run_ok("list").strip("\n").split("\n\n")
+    assert len(blocks) == 3
+    assert blocks[0].startswith("staged:")
+    assert "s.py" in blocks[0]
+    assert blocks[1].startswith("unstaged:")
+    assert "a.py" in blocks[1]
+    assert "b.py" in blocks[2]
+
+
 def test_list_context_before_field_in_json_matches_display(cli: GitHunkCLI) -> None:
     body = ["def foo():"] + [f"    x{i} = {i}" for i in range(8)]
     cli.repo.write_file("f.py", "\n".join(body) + "\n")


### PR DESCRIPTION
The plain-text `list` renderer emits two blank-line separators that no test exercised: between status sections (`git_hunk/_ui.py:126`) and between file groups within a section (`git_hunk/_ui.py:101`). Every existing `list` test goes through `--json` or only checks a substring, so both branches were uncovered. This locks the behavior by staging one file and leaving two others unstaged, then asserting the plain-text output splits into a `staged:` block and two separate unstaged file-group blocks.

## Test plan
- [x] `uv run pytest -q` (256 passed)
- [x] `_ui.py` lines 101 and 126 now covered (`--cov-report=term-missing`)
- [x] `make lint`
