### PR TITLE
refactor: dedup staged/unstaged hunk selection in list/show

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -339,6 +339,31 @@ def _get_untracked_entries(files: list[str] | None = None) -> list[Hunk]:
     ]
 
 
+def _collect_hunks(
+    *,
+    staged: bool,
+    unstaged: bool,
+    files: list[str] | None,
+    include_untracked: bool,
+) -> list[Hunk]:
+    if staged and unstaged:
+        raise CliError("cannot use --staged and --unstaged together")
+
+    if staged:
+        hunks, _ = _get_hunks(staged=True, files=files)
+        return hunks
+    if unstaged:
+        hunks, _ = _get_hunks(staged=False, files=files)
+        return hunks
+
+    hunks_staged, _ = _get_hunks(staged=True, files=files)
+    hunks_unstaged, _ = _get_hunks(staged=False, files=files)
+    hunks = hunks_staged + hunks_unstaged
+    if include_untracked:
+        hunks += _get_untracked_entries(files=files)
+    return hunks
+
+
 @cli.command("list", add_help_option=False)
 @click.option("--staged", is_flag=True)
 @click.option("--unstaged", is_flag=True)
@@ -358,17 +383,12 @@ def cmd_list(
 
     file_list = list(files) if files else None
 
-    if staged and unstaged:
-        raise CliError("cannot use --staged and --unstaged together")
-
-    if staged:
-        hunks, _ = _get_hunks(staged=True, files=file_list)
-    elif unstaged:
-        hunks, _ = _get_hunks(staged=False, files=file_list)
-    else:
-        hunks_staged, _ = _get_hunks(staged=True, files=file_list)
-        hunks_unstaged, _ = _get_hunks(staged=False, files=file_list)
-        hunks = hunks_staged + hunks_unstaged + _get_untracked_entries(files=file_list)
+    hunks = _collect_hunks(
+        staged=staged,
+        unstaged=unstaged,
+        files=file_list,
+        include_untracked=True,
+    )
 
     if force_json:
         envelope = {
@@ -397,17 +417,12 @@ def cmd_show(
         print_help(HELP_SHOW)
         return
 
-    if staged and unstaged:
-        raise CliError("cannot use --staged and --unstaged together")
-
-    if staged:
-        hunks, _ = _get_hunks(staged=True)
-    elif unstaged:
-        hunks, _ = _get_hunks(staged=False)
-    else:
-        hunks_staged, _ = _get_hunks(staged=True)
-        hunks_unstaged, _ = _get_hunks(staged=False)
-        hunks = hunks_staged + hunks_unstaged
+    hunks = _collect_hunks(
+        staged=staged,
+        unstaged=unstaged,
+        files=None,
+        include_untracked=False,
+    )
 
     if ids:
         matched = _find_hunks_by_ids(hunks, list(ids))


### PR DESCRIPTION
`cmd_list` and `cmd_show` each carried a byte-for-byte copy of the same
`--staged`/`--unstaged` mutual-exclusion check and three-way (staged / unstaged /
both) hunk selection. This extracts that into one `_collect_hunks(*, staged, unstaged,
files, include_untracked)` helper. The two callers' only real differences stay explicit
at the call site: `list` passes the file filter and includes untracked entries in the
default case; `show` passes neither.

Behavior-preserving; no `--json` schema or CLI surface change, so no CHANGELOG entry.

## Test plan
- [x] `make test` — 256 passed
- [x] `make lint` — ruff format/check, ty, taplo, mdformat, yamlfix, typos all clean
- [x] Drove the real CLI in a temp repo: `list` (default shows staged+unstaged+untracked),
      `list --staged` / `--unstaged` (filtered, untracked omitted), `show` (default,
      no untracked), `show --staged`, and `list/show --staged --unstaged` (both error
      `cannot use --staged and --unstaged together`, exit 1)
