### PR TITLE
refactor: drop unreachable empty-section guard in _ui

### DIFF
--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -88,8 +88,6 @@ def _print_status_section(
     color: str,
     show_hunks: bool = True,
 ) -> None:
-    if not hunks:
-        return
     out.print(f"[dim]{header}[/dim]")
     by_file: dict[str, list[Hunk]] = defaultdict(list)
     for hunk in hunks:


### PR DESCRIPTION
`_print_status_section`'s only caller, `print_hunk_list`, already skips empty
sections with `if not section_hunks: continue` before invoking it, so the
`if not hunks: return` guard at the top of the helper was unreachable. Coverage
confirmed the line never executed; removing it brings `git_hunk/_ui.py` to 100%.

Pure internal dead-code removal, no observable behavior change (not user-facing,
so no CHANGELOG entry).

## Test plan
- [x] `uv run pytest tests/` — 256 passed
- [x] `make lint` equivalents: `ruff format --check`, `ruff check`, `ty check` all clean
- [x] `git_hunk/_ui.py` coverage now 100% (previously "Missing: 92")
