### PR TITLE
fix: normalize CLI path arguments before matching files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,5 +55,9 @@ and this project adheres to
 - Reject an empty `--include-matching` / `--exclude-matching` pattern, which
   previously matched every line and silently selected the whole hunk, so an
   accidentally-empty pattern now errors like an empty `-l` spec (#87).
+- Normalize file-path arguments before matching, so `git-hunk list ./foo.py`
+  surfaces an untracked `foo.py` instead of silently dropping it, and path
+  arguments resolve consistently across `list`/`stage`/`unstage`/`discard`
+  regardless of the platform's path separator (#95).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+import posixpath
 import re
 import stat
 from dataclasses import dataclass
@@ -126,6 +127,13 @@ def _find_hunks_by_ids(hunks: list[Hunk], ids: list[str]) -> list[Hunk]:
     return found
 
 
+def _normalize_path_arg(arg: str) -> str:
+    # git reports forward-slash paths on every platform, so translate the
+    # OS-native separator and collapse ./ before comparing a CLI path argument
+    # against them (os.path would rewrite separators the wrong way on Windows).
+    return posixpath.normpath(arg.replace(os.sep, "/"))
+
+
 def _select_hunks(hunks: list[Hunk], args: list[str]) -> list[Hunk]:
     files = {h.file for h in hunks}
     selected: list[Hunk] = []
@@ -135,7 +143,7 @@ def _select_hunks(hunks: list[Hunk], args: list[str]) -> list[Hunk]:
             raise CliError("hunk id or file path must not be empty or whitespace")
         # A path that matches a changed file wins; otherwise hunk ids are hex,
         # so a non-hex argument can only have been meant as a (missing) path.
-        path = os.path.normpath(arg)
+        path = _normalize_path_arg(arg)
         if path in files:
             matches = [h for h in hunks if h.file == path]
         elif re.fullmatch(r"[0-9a-f]+", arg):
@@ -319,7 +327,8 @@ def _get_untracked_entries(files: list[str] | None = None) -> list[Hunk]:
     _require_git_repo()
     paths = get_untracked_files()
     if files:
-        paths = [p for p in paths if p in files]
+        wanted = {_normalize_path_arg(f) for f in files}
+        paths = [p for p in paths if p in wanted]
     return [
         Hunk(
             id="",

--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -127,6 +127,22 @@ def test_list_file_filter(cli: GitHunkCLI) -> None:
     assert hunks[0]["file"]["text"] == "a.py"
 
 
+def test_list_file_filter_untracked_normalizes_path(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "init\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    cli.repo.write_file("untracked.py", "new\n")
+    cli.repo.write_file("sub/nested.py", "new\n")
+
+    hunks = cli.run_list_json("list", "--json", "./untracked.py")
+    assert [h["file"]["text"] for h in hunks] == ["untracked.py"]
+    assert hunks[0]["status"] == "untracked"
+
+    hunks = cli.run_list_json("list", "--json", "sub/nested.py")
+    assert [h["file"]["text"] for h in hunks] == ["sub/nested.py"]
+
+
 def test_list_new_file(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "init\n")
     cli.repo.git("add", ".")

--- a/tests/e2e/path_shorthand_test.py
+++ b/tests/e2e/path_shorthand_test.py
@@ -48,6 +48,17 @@ def test_dot_slash_prefixed_path(multi_hunk_repo: GitHunkCLI) -> None:
     assert staged == ["big.py"]
 
 
+def test_subdirectory_path(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("sub/nested.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("sub/nested.py", "new\n")
+
+    cli.run_ok("stage", "sub/nested.py")
+    staged = cli.repo.git("diff", "--cached", "--name-only").split()
+    assert staged == ["sub/nested.py"]
+
+
 def test_mixing_path_and_id(multi_hunk_repo: GitHunkCLI) -> None:
     cli = multi_hunk_repo
     hunks = cli.run_list_json("list", "--unstaged", "--json")

--- a/tests/unit/_cli/normalize_path_arg_test.py
+++ b/tests/unit/_cli/normalize_path_arg_test.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+
+from git_hunk import _cli
+from git_hunk._cli import _normalize_path_arg
+
+
+@pytest.mark.parametrize(
+    ("arg", "expected"),
+    [
+        ("foo.py", "foo.py"),
+        ("./foo.py", "foo.py"),
+        ("sub/nested.py", "sub/nested.py"),
+        ("./sub/../foo.py", "foo.py"),
+    ],
+)
+def test_normalize_path_arg_collapses_to_git_form(arg: str, expected: str) -> None:
+    assert _normalize_path_arg(arg) == expected
+
+
+def test_normalize_path_arg_translates_windows_separator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_cli.os, "sep", "\\")
+    assert os.sep == "\\"
+    assert _normalize_path_arg("sub\\nested.py") == "sub/nested.py"


### PR DESCRIPTION
`git-hunk list ./foo.py` silently dropped an untracked `foo.py`. The untracked
filter compared `git ls-files`' canonical paths against the raw CLI argument, so
a `./`-prefixed (or otherwise non-canonical) path never matched, even though the
tracked-file half of the same command resolves it fine through git's pathspec.

The fix routes every CLI path argument through one `_normalize_path_arg` helper,
shared by `_select_hunks` and the untracked filter. It collapses `./` and
translates the OS-native separator via `posixpath` (git reports forward-slash
paths on every platform, so `os.path.normpath` would rewrite `/` to `\` and
mismatch on Windows).

## Test plan
- [x] `tests/e2e/list_test.py::test_list_file_filter_untracked_normalizes_path` reproduces the bug (fails without the fix)
- [x] `tests/e2e/path_shorthand_test.py::test_subdirectory_path` covers subdir path matching
- [x] `tests/unit/_cli/normalize_path_arg_test.py` covers the helper, incl. a monkeypatched Windows-separator case
- [x] `make test` (263 passed) and `make lint`
