### PR TITLE
test: cover CliGroup KeyboardInterrupt exit code 130

### DIFF
--- a/tests/unit/_cli/keyboard_interrupt_test.py
+++ b/tests/unit/_cli/keyboard_interrupt_test.py
@@ -1,0 +1,17 @@
+from typing import NoReturn
+
+from click.testing import CliRunner
+
+from git_hunk._cli import CliGroup
+
+
+def test_keyboard_interrupt_exits_130() -> None:
+    group = CliGroup()
+
+    @group.command()
+    def boom() -> NoReturn:
+        raise KeyboardInterrupt
+
+    result = CliRunner().invoke(group, ["boom"])
+
+    assert result.exit_code == 130


### PR DESCRIPTION
`CliGroup.invoke`'s `except KeyboardInterrupt: ctx.exit(130)` handler (the standard 128+SIGINT convention scripts rely on for Ctrl-C) had no test coverage. This adds a unit test that drives a throwaway command on a fresh `CliGroup` so the interrupt path is exercised directly, without coupling to any real command's internals.

## Test plan
- [x] `uv run pytest tests/unit/_cli/keyboard_interrupt_test.py` passes; mutation-checked (removing the handler makes it fail with exit code 1)
- [x] `uv run ruff check` / `uv run ty check` clean