### PR TITLE
test: cover skills path --json output

### DIFF
--- a/tests/e2e/skills_test.py
+++ b/tests/e2e/skills_test.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -73,6 +74,16 @@ def test_path_rejects_multiple_names(cli: GitHunkCLI) -> None:
     result = cli.run("skills", "path", "core", "extra")
     assert result.returncode == 2
     assert "at most one" in result.stderr
+
+
+def test_path_json(cli: GitHunkCLI) -> None:
+    data = json.loads(cli.run_ok("skills", "path", "--json"))
+    assert data["path"].endswith("skills")
+
+
+def test_path_json_of_named_skill(cli: GitHunkCLI) -> None:
+    data = json.loads(cli.run_ok("skills", "path", "core", "--json"))
+    assert Path(data["path"]).parts[-2:] == ("skills", "core")
 
 
 def test_list_rejects_arguments(cli: GitHunkCLI) -> None:


### PR DESCRIPTION
`skills list --json` and `skills get --json` each have a test, but `skills path --json` had none, so its output branch (`_echo_json({"path": ...})` in `_cli.py`) was unverified. Adds two tests mirroring the existing plain-text `skills path` coverage, for the root path and a named skill.

## Test plan
- [x] `uv run pytest tests/e2e/skills_test.py -q` (16 passed)
- [x] `make lint`
