### PR TITLE
test: cover RuntimeError-to-CliError wrapping in _apply_selection

### DIFF
--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -1,6 +1,8 @@
 from collections import Counter
 from pathlib import Path
 
+import pytest
+
 from tests.conftest import GitRepo
 
 from .conftest import GitHunkCLI
@@ -154,6 +156,30 @@ def test_empty_line_spec_rejected(cli: GitHunkCLI) -> None:
     assert r.returncode != 0
     assert "empty line specification" in r.stderr
     assert cli.repo.git("show", ":f.py") == "a\nb\nc\n"  # nothing staged
+
+
+def test_git_apply_failure_becomes_clean_error(
+    cli: GitHunkCLI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A low-level git failure during apply must surface as a clean CLI error,
+    # not a raw traceback. _apply_selection rebuilds the patch fresh from the
+    # working tree each run, so a genuine `git apply` failure is not practically
+    # reproducible here; inject one at the apply boundary instead.
+    cli.repo.write_file("f.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "new\n")
+
+    hunk_id = cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("git apply refused the patch")
+
+    monkeypatch.setattr("git_hunk._cli.apply_patch", _fail)
+
+    r = cli.run("stage", hunk_id)
+    assert r.returncode == 1
+    assert "git apply refused the patch" in r.stderr
 
 
 def test_line_spec_with_multiple_hunks_fails(cli: GitHunkCLI) -> None:


### PR DESCRIPTION
`_apply_selection` catches a `RuntimeError` from a low-level git operation
(`apply_patch` / `stage_files` / `unstage_files` / `discard_files`) and re-raises
it as a `CliError`, so the user sees a clean `error: ...` message instead of a raw
traceback. That wrapping (`git_hunk/_cli.py:276-277`) was previously uncovered.

The added e2e test stubs `apply_patch` to raise `RuntimeError` and asserts the
`stage` command exits 1 with the message on stderr. The failure is injected at the
apply boundary because `_apply_selection` rebuilds the patch fresh from the working
tree each run, so a genuine `git apply` failure is not deterministically
reproducible at that call site.

## Test plan
- [x] `uv run pytest tests/e2e/error_test.py -q` (new test passes)
- [x] `uv run pytest -q` (265 passed; coverage closes `_cli.py:276-277`)
- [x] `uv run ruff check .` / `uv run ty check`
