### PR TITLE
test: cover the python -m git_hunk module entry point

### DIFF
--- a/tests/e2e/module_entry_test.py
+++ b/tests/e2e/module_entry_test.py
@@ -1,0 +1,15 @@
+import runpy
+import sys
+
+import pytest
+
+
+# `python -m git_hunk` runs __main__.py, which the CliRunner-based tests never
+# import; this proves that entry point delegates to cli() and exits cleanly.
+def test_python_m_git_hunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["git-hunk", "--version"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_module("git_hunk", run_name="__main__")
+
+    assert excinfo.value.code == 0


### PR DESCRIPTION
`git_hunk/__main__.py` (the `python -m git_hunk` entry point) had no test: the
e2e suite drives the CLI through click's `CliRunner`, which calls `cli()`
directly and never imports `__main__.py`, so that delegation was the only
uncovered module (0% → 100%). This adds one `runpy`-based test that executes the
module the way `python -m` does and asserts it exits cleanly.

## Test plan
- [x] `make test` (new test passes; `git_hunk/__main__.py` now 100% covered)
- [x] `make lint` (ruff format + check, ty all clean)
