### PR TITLE
test: cover octal-escaped control chars in C-quoted diff paths

### DIFF
--- a/tests/e2e/quoted_paths_test.py
+++ b/tests/e2e/quoted_paths_test.py
@@ -60,12 +60,15 @@ def test_filename_with_b_slash_substring_stages(cli: GitHunkCLI) -> None:
 
 @pytest.mark.skipif(
     sys.platform == "win32",
-    reason="tab, newline, backslash, and double-quote are illegal in Windows filenames",
+    reason=(
+        "tab, newline, backslash, double-quote, and control characters "
+        "are illegal in Windows filenames"
+    ),
 )
 @pytest.mark.parametrize(
     "path",
-    ["od\ttab.txt", "od\nnl.txt", "od\\back.txt", 'od"q.txt'],
-    ids=["tab", "newline", "backslash", "quote"],
+    ["od\ttab.txt", "od\nnl.txt", "od\\back.txt", 'od"q.txt', "od\x1besc.txt"],
+    ids=["tab", "newline", "backslash", "quote", "escape"],
 )
 def test_quoted_path_modified_file_round_trips(cli: GitHunkCLI, path: str) -> None:
     cli.repo.write_file(path, "a\nb\n")

--- a/tests/unit/_hunk/extract_file_path_test.py
+++ b/tests/unit/_hunk/extract_file_path_test.py
@@ -10,6 +10,13 @@ def test_non_ascii_path_unquoted() -> None:
     assert extract_file_path("diff --git a/файл.txt b/файл.txt") == "файл.txt"
 
 
+def test_c_quoted_path_with_octal_escaped_control_char() -> None:
+    # ESC (0x1b) has no single-letter C escape, so git falls back to a 3-digit
+    # octal escape even under core.quotePath=false.
+    line = r'diff --git "a/f\033x.txt" "b/f\033x.txt"'
+    assert extract_file_path(line) == "f\x1bx.txt"
+
+
 def test_path_containing_b_slash_substring() -> None:
     line = "diff --git a/a b/c.txt b/a b/c.txt"
     assert extract_file_path(line) == "a b/c.txt"


### PR DESCRIPTION
`_unquote_c_path`'s octal-escape fallback (`git_hunk/_hunk.py:153-154`) was
untested: the four existing quoted-path cases (tab, newline, backslash, quote)
all map to single-letter `C_ESCAPES` entries, so none reach the octal branch.
git still quotes control characters that lack a single-letter C escape (e.g. ESC
`0x1b`) as 3-digit octal even under `core.quotePath=false`, so that branch is
genuinely reachable for real filenames.

Adds a unit test pinning the decode (`f\033x.txt` -> `f\x1bx.txt`) and an
`escape` row to the e2e round-trip parametrize proving real git output stages,
unstages, and discards. Closes the gap: `_hunk.py:153-154` now covered.

## Test plan
- [x] `uv run pytest -q` (266 passed)
- [x] `make lint`
- [x] `pytest --cov`: `_hunk.py` 153-154 no longer in missing lines
