### PR TITLE
test: cover -h/--help for each subcommand

### DIFF
--- a/tests/e2e/help_test.py
+++ b/tests/e2e/help_test.py
@@ -1,0 +1,33 @@
+import pytest
+
+from git_hunk._cli import cli as cli_group
+
+from .conftest import GitHunkCLI
+
+SUBCOMMAND_HELP = [
+    ("list", "List hunks"),
+    ("show", "Show the diff for one or more hunks"),
+    ("stage", "Stage one or more specific hunks"),
+    ("unstage", "Unstage one or more specific hunks"),
+    ("discard", "Discard unstaged changes for one or more specific hunks"),
+    ("commit", "Stage one or more specific hunks and commit them in one step"),
+    ("skills", "List and retrieve bundled skill content"),
+]
+
+
+@pytest.mark.parametrize("flag", ["-h", "--help"])
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    SUBCOMMAND_HELP,
+    ids=[command for command, _ in SUBCOMMAND_HELP],
+)
+def test_subcommand_help(
+    cli: GitHunkCLI, command: str, flag: str, expected: str
+) -> None:
+    r = cli.run(command, flag)
+    assert r.returncode == 0
+    assert expected in r.stderr
+
+
+def test_subcommand_help_covers_every_command() -> None:
+    assert {command for command, _ in SUBCOMMAND_HELP} == set(cli_group.commands)


### PR DESCRIPTION
Every subcommand (`list`, `show`, `stage`, `unstage`, `discard`, `commit`, `skills`) hand-wires its own `-h`/`--help` flag (`add_help_option=False` + a manual `show_help` branch), but only the top-level `--help` was tested. Each subcommand's `if show_help: print_help(...); return` path was uncovered, so a mis-wired help flag (e.g. printing the wrong `HELP_*` constant) would go unnoticed.

Adds `tests/e2e/help_test.py`: parametrizes `-h` and `--help` across all 7 subcommands, asserting exit 0 and that each prints its own help text. A `test_subcommand_help_covers_every_command` guard ties the table to `cli.commands`, so a newly added subcommand fails until it is covered.

## Test plan
- [x] `uv run pytest tests/e2e/help_test.py` — 15 passed
- [x] `make lint`
