### PR TITLE
refactor: dedup the @@-hunk-header split regex into a shared helper

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -126,6 +126,10 @@ def split_file_diffs(diff_output: str) -> list[str]:
     return re.split(r"(?=^diff --git )", diff_output, flags=re.MULTILINE)
 
 
+def split_at_hunk_headers(file_diff: str, *, maxsplit: int = 0) -> list[str]:
+    return re.split(r"(?=^@@)", file_diff, maxsplit=maxsplit, flags=re.MULTILINE)
+
+
 def _unquote_c_path(path: str) -> str:
     C_ESCAPES: Final = {
         "a": "\a",
@@ -285,7 +289,7 @@ def parse_diff(diff_output: str) -> list[Hunk]:
             i += 1
             continue
 
-        parts = re.split(r"(?=^@@)", file_diff, flags=re.MULTILINE)
+        parts = split_at_hunk_headers(file_diff)
 
         if len(parts) == 1:
             # No text hunks: surface a pure mode change (chmod) that would

--- a/git_hunk/_patch.py
+++ b/git_hunk/_patch.py
@@ -1,7 +1,6 @@
-import re
-
 from ._hunk import Hunk
 from ._hunk import extract_file_path
+from ._hunk import split_at_hunk_headers
 from ._hunk import split_file_diffs
 
 
@@ -11,9 +10,7 @@ def _extract_file_headers(diff_output: str) -> dict[str, str]:
         filepath = extract_file_path(file_diff)
         if filepath is None:
             continue
-        headers[filepath] = re.split(
-            r"(?=^@@)", file_diff, maxsplit=1, flags=re.MULTILINE
-        )[0]
+        headers[filepath] = split_at_hunk_headers(file_diff, maxsplit=1)[0]
     return headers
 
 


### PR DESCRIPTION
The lookahead split `re.split(r"(?=^@@)", ...)` that separates a file diff into its
pre-hunk header and per-`@@` sections was hand-rolled in two modules: `parse_diff`
(`_hunk.py`) and `_extract_file_headers` (`_patch.py`). This extracts it as
`split_at_hunk_headers`, a sibling to the existing `split_file_diffs`, so the
hunk-boundary rule lives in one place.

Pure refactor, no behavior change. The helper takes an optional keyword-only `maxsplit`
so `_patch.py` keeps its original bounded (`maxsplit=1`) split, which only needs the
header before the first `@@`.

## Test plan
- [x] `uv run pytest -q` (264 passed), `ruff check`, `ruff format --check`, `ty check`
- [x] Smoke: `git-hunk list` (two-hunk file) then `stage <first-id>` stages only the
  first hunk, exercising both the full split (`parse_diff`) and the bounded split
  (`build_patch`)
