### PR TITLE
fix: report untracked files with repo-root-relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,5 +104,8 @@ and this project adheres to
   hunk as carrying a usable `id`: an `untracked` entry's `id` is empty, so no
   git-hunk command can address it, and plain `list` renders it as a bare path
   (#162).
+- Report untracked files with repo-root-relative paths, matching tracked hunks,
+  so running `git-hunk` from a subdirectory no longer emits an untracked `file`
+  on a different path basis than the staged/unstaged hunks beside it (#103).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -15,6 +15,7 @@ from ._git import apply_patch
 from ._git import commit
 from ._git import discard_files
 from ._git import get_diff
+from ._git import get_repo_root
 from ._git import get_untracked_files
 from ._git import is_git_repo
 from ._git import stage_files
@@ -340,16 +341,16 @@ def _working_tree_mode(path: str) -> str:
 
 def _get_untracked_entries(files: list[str] | None = None) -> list[Hunk]:
     _require_git_repo()
-    paths = get_untracked_files()
-    if files:
-        wanted = {_normalize_path_arg(f) for f in files}
-        paths = [p for p in paths if p in wanted]
+    paths = get_untracked_files(files=files)
+    if not paths:
+        return []
+    root = get_repo_root()
     return [
         whole_file_hunk(
             p,
             change_kind="A",
             a_mode=None,
-            b_mode=_working_tree_mode(p),
+            b_mode=_working_tree_mode(posixpath.join(root, p)),
             binary=False,
             status="untracked",
         )

--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -36,8 +36,18 @@ def get_diff(staged: bool = False, files: list[str] | None = None) -> str:
     return run_git(*args)
 
 
-def get_untracked_files() -> list[str]:
-    output = run_git("ls-files", "--others", "--exclude-standard", "-z")
+def get_repo_root() -> str:
+    return run_git("rev-parse", "--show-toplevel").strip()
+
+
+def get_untracked_files(files: list[str] | None = None) -> list[str]:
+    # --full-name yields repo-root-relative paths, matching get_diff's basis, so
+    # untracked and tracked hunks report `file` consistently from a subdirectory.
+    # files is a pathspec git resolves relative to cwd, exactly as get_diff does.
+    args = ["ls-files", "--others", "--exclude-standard", "--full-name", "-z", "--"]
+    if files:
+        args.extend(files)
+    output = run_git(*args)
     return [f for f in output.split("\0") if f]
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -15,13 +15,16 @@ class GitHunkCLI:
     def __init__(self, repo: GitRepo) -> None:
         self.repo = repo
 
-    def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+    def run(
+        self, *args: str, subdir: str | None = None
+    ) -> subprocess.CompletedProcess[str]:
         # rich sizes its output from COLUMNS; pin it so the lines tests assert
         # verbatim do not wrap when the suite runs in a narrow terminal.
         runner = CliRunner(env={"COLUMNS": "200"})
         old_cwd = os.getcwd()
+        cwd = os.path.join(self.repo.path, subdir) if subdir else self.repo.path
         try:
-            os.chdir(self.repo.path)
+            os.chdir(cwd)
             result = runner.invoke(git_hunk_cli, list(args))
         finally:
             os.chdir(old_cwd)
@@ -36,8 +39,8 @@ class GitHunkCLI:
             stderr=result.stderr or "",
         )
 
-    def run_ok(self, *args: str) -> str:
-        r = self.run(*args)
+    def run_ok(self, *args: str, subdir: str | None = None) -> str:
+        r = self.run(*args, subdir=subdir)
         assert r.returncode == 0, f"git-hunk {' '.join(args)} failed: {r.stderr}"
         return r.stdout
 
@@ -46,13 +49,18 @@ class GitHunkCLI:
         # `list --json` returns an envelope; use run_list_json for that.
         return cast("list[dict[str, Any]]", json.loads(self.run_ok(*args)))
 
-    def run_list_envelope(self, *args: str) -> dict[str, Any]:
-        return cast("dict[str, Any]", json.loads(self.run_ok(*args)))
+    def run_list_envelope(
+        self, *args: str, subdir: str | None = None
+    ) -> dict[str, Any]:
+        return cast("dict[str, Any]", json.loads(self.run_ok(*args, subdir=subdir)))
 
-    def run_list_json(self, *args: str) -> list[dict[str, Any]]:
+    def run_list_json(
+        self, *args: str, subdir: str | None = None
+    ) -> list[dict[str, Any]]:
         # `list --json` (and `show --json`) wrap the hunks in a versioned
         # envelope; tests that only need the hunks call this to unwrap it.
-        return cast("list[dict[str, Any]]", self.run_list_envelope(*args)["hunks"])
+        envelope = self.run_list_envelope(*args, subdir=subdir)
+        return cast("list[dict[str, Any]]", envelope["hunks"])
 
 
 @pytest.fixture

--- a/tests/e2e/subdirectory_test.py
+++ b/tests/e2e/subdirectory_test.py
@@ -1,0 +1,33 @@
+from .conftest import GitHunkCLI
+
+
+def test_untracked_file_path_matches_tracked_basis_from_subdirectory(
+    cli: GitHunkCLI,
+) -> None:
+    cli.repo.write_file("sub/tracked.py", "line1\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    cli.repo.write_file("sub/tracked.py", "line1\nline2\n")
+    cli.repo.write_file("sub/untracked.py", "new\n")
+
+    hunks = cli.run_list_json("list", "--json", subdir="sub")
+    by_status = {h["status"]: h for h in hunks}
+    assert by_status["unstaged"]["file"]["text"] == "sub/tracked.py"
+    assert by_status["untracked"]["file"]["text"] == "sub/untracked.py"
+    assert by_status["untracked"]["b_mode"] == "100644"
+
+
+def test_untracked_file_filtered_by_relative_arg_from_subdirectory(
+    cli: GitHunkCLI,
+) -> None:
+    cli.repo.write_file("sub/keep.py", "init\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    cli.repo.write_file("sub/wanted.py", "new\n")
+    cli.repo.write_file("sub/other.py", "new\n")
+
+    hunks = cli.run_list_json("list", "--json", "wanted.py", subdir="sub")
+    assert [h["file"]["text"] for h in hunks] == ["sub/wanted.py"]
+    assert hunks[0]["status"] == "untracked"


### PR DESCRIPTION
## Summary
- `git ls-files --others` returned paths relative to the current working directory, while `git diff` always reports repo-root-relative paths. Run from a subdirectory, `git-hunk list` emitted untracked hunks whose `file` was on a different path basis than the staged/unstaged hunks in the same envelope.
- Add `--full-name` so untracked paths are repo-root-relative too, and let git resolve the file-path filter as a pathspec (`get_untracked_files(files=...)`), mirroring `get_diff(files=...)` instead of matching paths by hand on a mismatched basis.
- The working-tree mode is looked up via the repo root so `lstat` still finds the file from a subdirectory.

## Test plan
- [x] Added `tests/e2e/subdirectory_test.py`: untracked `file` matches the tracked basis from a subdirectory, and filtering an untracked file by a relative arg from a subdirectory still matches.
- [x] Smoke: real `git-hunk list --json` run from `pkg/sub/` reports `unstaged pkg/app.py` and `untracked pkg/sub/fresh.py` (both repo-root-relative).
- [x] `uv run pytest -q` (266 passed), `uv run ruff check .`, `uv run ty check`
