### PR TITLE
fix: stop commit --help advertising options it rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to
 
 ### Fixed
 
+- `commit --help` no longer advertises `--include-matching`,
+  `--exclude-matching`, and `--regex`, which the command never accepted; the
+  help now lists only the options `commit` actually supports (#105).
 - Preserve `\ No newline at end of file` markers so staging the last line of a
   file without a trailing newline no longer fails or silently stages nothing
   (#9).

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -217,9 +217,12 @@ def print_version(version: str) -> None:
     _err().print(f"git-hunk [dim]{version}[/dim]")
 
 
-_LINE_OPT_ROW = """\
+_LINE_SELECT_ROW = """\
   [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk (requires exactly one hunk)
-             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)
+             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""  # noqa: E501
+
+_LINE_OPT_ROW = f"""\
+{_LINE_SELECT_ROW}
   [bold cyan]--include-matching[/bold cyan] [cyan]<pattern>[/cyan]  Select changed lines containing <pattern> (repeatable, OR'd)
   [bold cyan]--exclude-matching[/bold cyan] [cyan]<pattern>[/cyan]  Select every changed line except those matching (repeatable, OR'd)
   [bold cyan]--regex[/bold cyan]    Treat matching patterns as regular expressions (default: literal substring)"""  # noqa: E501
@@ -391,7 +394,7 @@ hook) the hunks are left staged so you can retry with [bold cyan]git commit[/bol
 
 [bold green]Options:[/bold green]
   [bold cyan]-m[/bold cyan] [cyan]<msg>[/cyan]    Commit message (required)
-{_LINE_OPT_ROW}
+{_LINE_SELECT_ROW}
 
 {_format_examples(_EXAMPLES_COMMIT)}"""  # noqa: E501
 

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -60,6 +60,30 @@ def test_help_short_circuits_subcommand(cli: GitHunkCLI) -> None:
     assert cli.repo.git("diff", "--cached").strip() == ""
 
 
+def test_commit_help_omits_unsupported_matching_options(cli: GitHunkCLI) -> None:
+    r = cli.run("commit", "--help")
+    assert r.returncode == 0
+    assert "-m" in r.stderr
+    assert "-l" in r.stderr
+    assert "--include-matching" not in r.stderr
+    assert "--exclude-matching" not in r.stderr
+    assert "--regex" not in r.stderr
+
+
+def test_commit_rejects_matching_options(cli: GitHunkCLI) -> None:
+    r = cli.run("commit", "d161935", "--include-matching", "x", "-m", "msg")
+    assert r.returncode != 0
+
+
+def test_stage_help_advertises_matching_options(cli: GitHunkCLI) -> None:
+    r = cli.run("stage", "--help")
+    assert r.returncode == 0
+    assert "-l" in r.stderr
+    assert "--include-matching" in r.stderr
+    assert "--exclude-matching" in r.stderr
+    assert "--regex" in r.stderr
+
+
 def test_unknown_command(cli: GitHunkCLI) -> None:
     r = cli.run("bogus")
     assert r.returncode != 0


### PR DESCRIPTION
`git-hunk commit --help` advertised `--include-matching`, `--exclude-matching`,
and `--regex`, but `commit` only ever declared `-m`, `-l`, and `-h`. Passing any
of those flags failed with a raw Click `Error: No such option`, bypassing the
tool's own styled errors. The cause was `HELP_COMMIT` reusing the shared
`_LINE_OPT_ROW` (which carries the matching options) instead of just the `-l`
row. This extracts the `-l` row into `_LINE_SELECT_ROW` and has `HELP_COMMIT`
reference only that, so the help lists exactly the options `commit` accepts. The
`stage`/`unstage`/`discard` help is unchanged (still uses the full row).

## Test plan
- [x] `tests/e2e/error_test.py`: `commit --help` omits the three matching
  options and still shows `-m`/`-l`; `commit --include-matching` errors; and a
  guard that `stage --help` still advertises the matching options.
- [x] `uv run pytest -q` (267 passed), `uv run ruff check .`, `uv run ty check`
- [x] Drove `commit --help`, `commit --include-matching`, and `commit -l 1 -m`
  end-to-end.

Possible follow-up (not in this PR): the `HELP_*` strings are hand-kept in sync
with each command's `@click.option` declarations, so this drift class could
recur for another command. A parametrized test walking each command's real
Click params against its help string would prevent it, but parsing options out
of Rich-markup text is fiddly enough to be its own change.
