### PR TITLE
refactor: dedup the shared line-selection options for stage/unstage/discard

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -3,6 +3,7 @@ import os
 import posixpath
 import re
 import stat
+from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import replace
 from typing import Final
@@ -510,14 +511,23 @@ def cmd_skills(args: tuple[str, ...], force_json: bool, show_help: bool) -> None
     raise CliError(f"unrecognized skills subcommand '{subcommand}'", usage=USAGE_SKILLS)
 
 
+def _add_patch_selection_options(command: Callable[..., None]) -> Callable[..., None]:
+    options = [
+        click.option("-l", "line_spec", default=None),
+        click.option("--include-matching", "include_matching", multiple=True),
+        click.option("--exclude-matching", "exclude_matching", multiple=True),
+        click.option("--regex", "use_regex", is_flag=True),
+        click.option("--dry-run", "dry_run", is_flag=True),
+        click.option("-h", "--help", "show_help", is_flag=True),
+        click.argument("targets", nargs=-1),
+    ]
+    for option in reversed(options):
+        command = option(command)
+    return command
+
+
 @cli.command("stage", add_help_option=False)
-@click.option("-l", "line_spec", default=None)
-@click.option("--include-matching", "include_matching", multiple=True)
-@click.option("--exclude-matching", "exclude_matching", multiple=True)
-@click.option("--regex", "use_regex", is_flag=True)
-@click.option("--dry-run", "dry_run", is_flag=True)
-@click.option("-h", "--help", "show_help", is_flag=True)
-@click.argument("targets", nargs=-1)
+@_add_patch_selection_options
 def cmd_stage(
     targets: tuple[str, ...],
     line_spec: str | None,
@@ -547,13 +557,7 @@ def cmd_stage(
 
 
 @cli.command("unstage", add_help_option=False)
-@click.option("-l", "line_spec", default=None)
-@click.option("--include-matching", "include_matching", multiple=True)
-@click.option("--exclude-matching", "exclude_matching", multiple=True)
-@click.option("--regex", "use_regex", is_flag=True)
-@click.option("--dry-run", "dry_run", is_flag=True)
-@click.option("-h", "--help", "show_help", is_flag=True)
-@click.argument("targets", nargs=-1)
+@_add_patch_selection_options
 def cmd_unstage(
     targets: tuple[str, ...],
     line_spec: str | None,
@@ -583,13 +587,7 @@ def cmd_unstage(
 
 
 @cli.command("discard", add_help_option=False)
-@click.option("-l", "line_spec", default=None)
-@click.option("--include-matching", "include_matching", multiple=True)
-@click.option("--exclude-matching", "exclude_matching", multiple=True)
-@click.option("--regex", "use_regex", is_flag=True)
-@click.option("--dry-run", "dry_run", is_flag=True)
-@click.option("-h", "--help", "show_help", is_flag=True)
-@click.argument("targets", nargs=-1)
+@_add_patch_selection_options
 def cmd_discard(
     targets: tuple[str, ...],
     line_spec: str | None,


### PR DESCRIPTION
`stage`, `unstage`, and `discard` each repeated the same 7-line click
option/argument stack (`-l`, `--include-matching`, `--exclude-matching`,
`--regex`, `--dry-run`, `-h/--help`, `targets`). Extract it into one
`_add_patch_selection_options` decorator so a future option added or renamed
in one command can't silently drift from the other two, the same failure class
fixed on the help-string side in #105.

Behavior-preserving: click binds parameters by dest name, so the resulting
`click.Command.params` order is unchanged and `--help` output is byte-identical
for all three commands. `cmd_commit` keeps its own smaller option set (it isn't
a subset of this stack) and is left untouched.

## Test plan
- [x] `uv run pytest -q` — 264 passed
- [x] `uv run ruff check` / `uv run ty check` — clean
- [x] `git-hunk {stage,unstage,discard} -h` output diffed against `main` — byte-identical
