### PR TITLE
fix: surface git failures on bad path arguments as clean CLI errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,5 +73,8 @@ and this project adheres to
   (#145).
 - Report a clean `error:` message instead of a raw `FileNotFoundError`
   traceback when the `git` executable is not found on `PATH` (#122).
+- Report a git failure on a bad path argument (e.g. `git-hunk list ':(bogus)x'`)
+  as a clean `error:` message instead of crashing with a raw Python traceback
+  (#107).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -103,7 +103,10 @@ def _echo_json(data: object) -> None:
 
 def _get_hunks(staged: bool, files: list[str] | None = None) -> tuple[list[Hunk], str]:
     _require_git_repo()
-    diff_output = get_diff(staged=staged, files=files)
+    try:
+        diff_output = get_diff(staged=staged, files=files)
+    except RuntimeError as exc:
+        raise CliError(str(exc)) from exc
     hunks = parse_diff(diff_output)
     status = "staged" if staged else "unstaged"
     hunks = [replace(h, status=status) for h in hunks]

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -189,3 +189,11 @@ def test_line_spec_with_multiple_hunks_fails(cli: GitHunkCLI) -> None:
     r = cli.run("stage", hunks[0]["id"], hunks[1]["id"], "-l", "1")
     assert r.returncode != 0
     assert "exactly one hunk" in r.stderr
+
+
+def test_bad_pathspec_reports_clean_error(cli: GitHunkCLI) -> None:
+    # A git failure on a user-supplied path argument must surface as a clean
+    # CLI error, not a raw Python traceback.
+    r = cli.run("list", ":(bogus)x")
+    assert r.returncode != 0
+    assert "pathspec" in r.stderr


### PR DESCRIPTION
A git failure on a user-supplied path argument crashed with a raw Python
traceback instead of the clean `error:` message the CLI produces everywhere
else. `get_diff`'s `RuntimeError` (raised by `run_git` on any non-zero git exit)
escaped `_get_hunks` unwrapped, unlike every other git call site in the CLI.
`git-hunk list ':(bogus)x'` (an invalid pathspec magic) is the easiest trigger,
and this CLI's AI-agent audience parses stderr for a stable `error:` prefix.

Wrap the `get_diff` call in `_get_hunks` with the same
`except RuntimeError -> CliError` idiom already used at the other git call sites,
so the failure surfaces as `error: ...` (exit 1) instead of a traceback.

The `commit` pre-check and untracked-file git calls are intentionally left
unwrapped: neither receives a user pathspec, so no user input can reach them.
Wrapping them would add untested defensive branches for non-reachable scenarios,
out of scope for this surgical fix.

## Test plan
- [x] `test_bad_pathspec_reports_clean_error` (`tests/e2e/error_test.py`) fails with a raw `RuntimeError` before the fix, passes after
- [x] full suite green: `uv run pytest` (265 passed)
- [x] `make lint` (ruff format + ruff check + ty + typos) clean
- [x] manual: real CLI on `git-hunk list ':(bogus)x'` prints `error: ...` (exit 1), no traceback
