### PR TITLE
test: cover untracked-symlink working-tree mode (b_mode 120000)

### DIFF
--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -1,5 +1,9 @@
+import sys
+from pathlib import Path
 from typing import Any
 from typing import cast
+
+import pytest
 
 from git_hunk._cli import JSON_SCHEMA_VERSION
 
@@ -206,6 +210,27 @@ def test_status_filters_exclude_untracked(cli: GitHunkCLI) -> None:
     unstaged = cli.run_list_json("list", "--unstaged", "--json")
     assert len(unstaged) == 1
     assert unstaged[0]["status"] == "unstaged"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="git does not track symlinks on Windows"
+)
+def test_list_untracked_symlink_reports_symlink_mode(cli: GitHunkCLI) -> None:
+    # An untracked symlink derives its would-be added mode from the working tree
+    # (lstat), so b_mode must be "120000" rather than a regular-file mode.
+    cli.repo.write_file("f.py", "init\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    (Path(cli.repo.path) / "link").symlink_to("f.py")
+
+    hunks = cli.run_list_json("list", "--json")
+    untracked = [h for h in hunks if h["status"] == "untracked"]
+    assert len(untracked) == 1
+    assert untracked[0]["file"]["text"] == "link"
+    assert untracked[0]["change_kind"] == "A"
+    assert untracked[0]["a_mode"] is None
+    assert untracked[0]["b_mode"] == "120000"
 
 
 def test_empty_new_file_is_not_a_bogus_mode_hunk(cli: GitHunkCLI) -> None:


### PR DESCRIPTION
`_working_tree_mode` (`git_hunk/_cli.py`) derives an untracked file's would-be
added mode from the working tree via `os.lstat` + `stat.S_ISLNK`, returning
`"120000"` for a symlink. Only the regular-file branch was exercised: the
existing `test_list_default_shows_untracked` asserts `b_mode == "100644"`, and
the symlink coverage in `binary_test.py` goes through the *tracked* type-change
path (`parse_diff`), not `_working_tree_mode`. So the `"120000"` return was
uncovered on `main`.

This adds one e2e test creating an untracked symlink and asserting
`list --json` reports `change_kind == "A"`, `a_mode is None`, `b_mode == "120000"`,
mirroring the adjacent untracked test and the `win32` skip idiom from
`binary_test.py`.

## Test plan
- [x] `uv run pytest tests/e2e/list_test.py::test_list_untracked_symlink_reports_symlink_mode`
- [x] full suite green (`uv run pytest -q`, 265 passed); coverage confirms the
      previously-missing `_cli.py` symlink branch is now hit
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check`
