### PR TITLE
docs: correct discard as restoring from the index, not HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,5 +83,9 @@ and this project adheres to
   and `show`, matching every other conflicting-flags error (#117).
 - Match hunk ids case-insensitively, so an uppercased id like `git-hunk show 713B7B9` resolves like git's own object-id lookup instead of failing with a
   misleading "not found" / "no changed file matches" error (#150).
+- Correct the `discard` help, README, and skill docs, which described it as
+  restoring "from HEAD" when it restores from the index: discarding an unstaged
+  hunk reverts it to the staged content, leaving a staged sibling edit intact
+  (#109).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ git-hunk stage d161935 --exclude-matching debug    # stage all but lines contain
 git-hunk stage d161935 --include-matching xfail    # stage only lines containing "xfail"
 git-hunk unstage d161935               # move back to working tree
 git-hunk unstage d161935 -l 3,5-7      # unstage specific lines only
-git-hunk discard d161935               # restore from HEAD
+git-hunk discard d161935               # restore from the index
 git-hunk discard d161935 -l ^3,^5-7    # discard excluding specific lines
 ```
 

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -284,7 +284,7 @@ _EXAMPLES_UNSTAGE: Final = [
     ("git-hunk unstage d161935 --dry-run", "Preview without changing anything"),
 ]
 _EXAMPLES_DISCARD: Final = [
-    ("git-hunk discard d161935", "Restore a hunk from HEAD"),
+    ("git-hunk discard d161935", "Restore a hunk from the index"),
     ("git-hunk discard src/foo.py", "Discard every hunk in a file"),
     ("git-hunk discard d161935 -l ^3,^5-7", "Discard excluding specific lines"),
     ("git-hunk discard d161935 --dry-run", "Preview without changing anything"),
@@ -325,7 +325,7 @@ Non-interactive git hunk staging for AI agents.
   [bold cyan]show[/bold cyan]     Show diff for one or more hunks
   [bold cyan]stage[/bold cyan]    Stage specific hunks
   [bold cyan]unstage[/bold cyan]  Unstage specific hunks
-  [bold cyan]discard[/bold cyan]  Discard specific hunks (restore from HEAD)
+  [bold cyan]discard[/bold cyan]  Discard specific hunks (restore from the index)
   [bold cyan]commit[/bold cyan]   Stage specific hunks and commit them in one step
   [bold cyan]skills[/bold cyan]   Load bundled skill content for AI agents
 
@@ -370,7 +370,7 @@ Stage one or more specific hunks. IDs support prefix matching.
 {_format_examples(_EXAMPLES_STAGE)}"""
 
 HELP_DISCARD = f"""\
-Discard unstaged changes for one or more specific hunks (restore from HEAD).
+Discard unstaged changes for one or more specific hunks (restore from the index).
 IDs support prefix matching.
 
 {USAGE_DISCARD}

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -111,7 +111,7 @@ Stage a hunk but leave its debug lines behind, then discard them:
 ```bash
 git-hunk show d161935               # find the debug line numbers
 git-hunk stage d161935 -l ^4        # stage all but the debug line on line 4
-git-hunk discard d161935 -l 4       # restore that line from HEAD
+git-hunk discard d161935 -l 4       # restore that line from the index
 ```
 
 ### Separate a refactor from a feature
@@ -142,7 +142,7 @@ coordinate first and push with `git push --force-with-lease`.
 
 ```bash
 git-hunk unstage <id> <id> ...   # move staged hunks back to the working tree
-git-hunk discard <id> <id> ...   # permanently restore unstaged hunks from HEAD
+git-hunk discard <id> <id> ...   # permanently restore unstaged hunks from the index
 ```
 
 Both take `-l <lines>` for partial ranges, like `stage`. `discard` is

--- a/tests/e2e/discard_test.py
+++ b/tests/e2e/discard_test.py
@@ -39,3 +39,21 @@ def test_discard_one_of_multiple(cli: GitHunkCLI) -> None:
 
     content = cli.repo.run("cat", "f.py").stdout
     assert "CHANGED18" in content
+
+
+def test_discard_restores_from_index_not_head(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "line1\nline2\nline3\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    cli.repo.write_file("f.py", "STAGED\nline2\nline3\n")
+    cli.repo.git("add", ".")
+    cli.repo.write_file("f.py", "STAGED\nline2\nUNSTAGED\n")
+
+    unstaged = cli.run_list_json("list", "--unstaged", "--json")
+    assert len(unstaged) == 1
+
+    cli.run_ok("discard", unstaged[0]["id"])
+
+    content = cli.repo.run("cat", "f.py").stdout
+    assert content == "STAGED\nline2\nline3\n"


### PR DESCRIPTION
`git-hunk discard` reverse-applies the working-tree-vs-index diff (and runs `git restore -- <file>` for whole-file changes), so it restores a hunk to the staged content, not to HEAD. The `--help` text, README, and bundled skill doc all said "restore from HEAD", which only holds when the file has no staged sibling; with a staged edit in the same file, discarding an unstaged hunk leaves the staged edit intact rather than collapsing the file to the last commit.

Corrects all six spots and adds a regression test for the index-vs-HEAD distinction, which was previously uncovered.

## Test plan
- [x] `uv run pytest -q` — new `test_discard_restores_from_index_not_head` plus full suite (266 passing)
- [x] `uv run ruff check . && uv run ty check`
- [x] `git-hunk discard --help` renders "restore from the index"
