### PR TITLE
test: cover parse_diff skipping a headerless file-diff block

### DIFF
--- a/tests/unit/_hunk/parse_diff_test.py
+++ b/tests/unit/_hunk/parse_diff_test.py
@@ -239,3 +239,27 @@ def test_delete_then_unrelated_add_is_not_merged_as_typechange() -> None:
     assert hunks[1].file == "b.txt"
     assert hunks[1].change_kind == "A"
     assert hunks[1].additions == 1
+
+
+def test_chunk_without_diff_header_is_skipped() -> None:
+    # A chunk with no `diff --git` header has no extractable path, so parse_diff
+    # skips it rather than emitting a pathless hunk; the following well-formed
+    # file diff still parses. The leading chunk carries an @@ body so the skip is
+    # load-bearing: without it a spurious hunk with no file would be counted.
+    diff = (
+        "@@ -1 +1 @@\n"
+        "-orphan\n"
+        "+orphan2\n"
+        "diff --git a/f.py b/f.py\n"
+        "index abc..def 100644\n"
+        "--- a/f.py\n"
+        "+++ b/f.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " a\n"
+        "+b\n"
+        " c\n"
+    )
+    hunks = parse_diff(diff)
+    assert len(hunks) == 1
+    assert hunks[0].file == "f.py"
+    assert hunks[0].additions == 1


### PR DESCRIPTION
`parse_diff` skips a split file-diff block whose first line is not a `diff --git`
header (so `extract_file_path` returns `None`), before it can emit a hunk with no
path (`git_hunk/_hunk.py:251-253`). That skip branch was untested. This adds a
direct test: a leading block carrying an `@@` body (which makes the skip
load-bearing, i.e. without the guard a spurious pathless hunk would be counted)
followed by a well-formed file diff, asserting only the real hunk survives.

## Test plan
- [x] `uv run pytest tests/unit/_hunk/parse_diff_test.py` (9 passed)
- [x] confirmed the test fails if the `filepath is None` skip is removed (mutation: 2 hunks instead of 1)
- [x] `make lint`
