### PR TITLE
refactor: dedup hunk-id hashing into a shared _hash_id helper

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -100,20 +100,24 @@ def strip_trailing_empty_lines(lines: list[str]) -> list[str]:
     return lines
 
 
+def _hash_id(payload: str) -> str:
+    ID_LENGTH: Final = 7
+    # surrogateescape mirrors _git.run_git's decode so non-UTF-8 bytes hash.
+    data = payload.encode(errors="surrogateescape")
+    return hashlib.sha256(data).hexdigest()[:ID_LENGTH]
+
+
 def _body_id(filepath: str, diff_content: str) -> str:
     """Ignore @@ line numbers so a hunk's id survives other hunks being staged."""
     body = "\n".join(
         line for line in diff_content.split("\n") if not line.startswith("@@")
     )
-    # surrogateescape mirrors _git.run_git's decode so non-UTF-8 bytes hash.
-    data = f"{filepath}:{body}".encode(errors="surrogateescape")
-    return hashlib.sha256(data).hexdigest()[:7]
+    return _hash_id(f"{filepath}:{body}")
 
 
 def _full_id(filepath: str, diff_content: str) -> str:
     """Fallback for identical changed lines — includes @@ line numbers."""
-    data = f"{filepath}:{diff_content}".encode(errors="surrogateescape")
-    return hashlib.sha256(data).hexdigest()[:7]
+    return _hash_id(f"{filepath}:{diff_content}")
 
 
 def _with_stable_ids(hunks: list[Hunk]) -> list[Hunk]:


### PR DESCRIPTION
`_body_id` and `_full_id` each duplicated the same `encode(errors="surrogateescape")` + `sha256` + `[:7]` truncation, with the explanatory `surrogateescape` comment living on only one of the two copies. Extract a shared `_hash_id(payload)` helper so the encoding idiom, its rationale, and the short-id length live in one place; each caller now just builds its `f"{filepath}:..."` payload and delegates.

Byte-identical hunk-id output; no user-facing change (no CHANGELOG entry).

## Test plan
- [x] `uv run pytest tests/` (264 passed) — `tests/unit/_hunk/id_test.py` exercises `_body_id`/`_full_id` unchanged
- [x] `make lint`