### PR TITLE
refactor: reuse whole_file_hunk factory for untracked entries

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -21,6 +21,7 @@ from ._git import unstage_files
 from ._hunk import Hunk
 from ._hunk import is_whole_file_hunk
 from ._hunk import parse_diff
+from ._hunk import whole_file_hunk
 from ._lines import filter_hunk_lines
 from ._lines import parse_line_spec
 from ._lines import resolve_matching_lines
@@ -343,18 +344,12 @@ def _get_untracked_entries(files: list[str] | None = None) -> list[Hunk]:
         wanted = {_normalize_path_arg(f) for f in files}
         paths = [p for p in paths if p in wanted]
     return [
-        Hunk(
-            id="",
-            file=p,
+        whole_file_hunk(
+            p,
             change_kind="A",
             a_mode=None,
             b_mode=_working_tree_mode(p),
             binary=False,
-            header=None,
-            context_before=None,
-            additions=0,
-            deletions=0,
-            diff="",
             status="untracked",
         )
         for p in paths

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -192,15 +192,16 @@ def _extract_context_before(header: str) -> str | None:
     return match.group(1).strip() or None
 
 
-def _whole_file_hunk(
+def whole_file_hunk(
     filepath: str,
     *,
     change_kind: str,
     a_mode: str | None,
     b_mode: str | None,
     binary: bool,
+    status: str = "unstaged",
 ) -> Hunk:
-    """A change applied by staging the whole file (binary, mode-only, type)."""
+    """A change applied by staging the whole file (binary, mode-only, type, new)."""
     return Hunk(
         id="",
         file=filepath,
@@ -213,6 +214,7 @@ def _whole_file_hunk(
         additions=0,
         deletions=0,
         diff="",
+        status=status,
     )
 
 
@@ -267,7 +269,7 @@ def parse_diff(diff_output: str) -> list[Hunk]:
             next_kind, _, new_b_mode = _block_modes(next_diff)
             if next_kind == "A" and extract_file_path(next_diff) == filepath:
                 hunks.append(
-                    _whole_file_hunk(
+                    whole_file_hunk(
                         filepath,
                         change_kind="T",
                         a_mode=a_mode,
@@ -280,7 +282,7 @@ def parse_diff(diff_output: str) -> list[Hunk]:
 
         if _is_binary(file_diff):
             hunks.append(
-                _whole_file_hunk(
+                whole_file_hunk(
                     filepath,
                     change_kind=change_kind,
                     a_mode=a_mode,
@@ -299,7 +301,7 @@ def parse_diff(diff_output: str) -> list[Hunk]:
             # no @@ body) is left out, matching git-hunk's prior behavior.
             if change_kind == "M" and a_mode != b_mode:
                 hunks.append(
-                    _whole_file_hunk(
+                    whole_file_hunk(
                         filepath,
                         change_kind=change_kind,
                         a_mode=a_mode,


### PR DESCRIPTION
`_get_untracked_entries` in `_cli.py` hand-wrote the same 11-field whole-file
`Hunk` literal (`id=""`, `header=None`, `context_before=None`, `additions=0`,
`deletions=0`, `diff=""`, …) that `_hunk.py`'s `_whole_file_hunk` already
factors, so adding a field to `Hunk` would silently drift the untracked path.
Promote the factory to public `whole_file_hunk` with a `status` parameter (the
untracked case passes `status="untracked"`; the three in-module callers keep the
`"unstaged"` default) and reuse it. Output is byte-identical.

## Test plan
- [x] `make test` (264 passed) — existing untracked-entry e2e coverage unchanged
- [x] `make lint` (ruff format + check, ty, taplo, mdformat, yamlfix, typos)
- [x] Smoke: `git-hunk list --json` on an untracked file still yields
      `status=untracked, change_kind=A, a_mode=null, b_mode=100644, binary=false`
