### PR TITLE
refactor: dedup the context+stats tail in hunk-line rendering

### DIFF
--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -55,7 +55,10 @@ def _header_text(hunk: Hunk) -> str:
     return hunk.header if hunk.header is not None else _whole_file_label(hunk)
 
 
-def _append_stats(text: Text, hunk: Hunk) -> None:
+def _append_context_and_stats(text: Text, hunk: Hunk) -> None:
+    if hunk.context_before:
+        text.append(f"  {_safe(hunk.context_before)}", style="dim italic")
+    text.append("  ")
     if hunk.additions:
         text.append(f"+{hunk.additions}", style="green")
     if hunk.additions and hunk.deletions:
@@ -64,20 +67,13 @@ def _append_stats(text: Text, hunk: Hunk) -> None:
         text.append(f"-{hunk.deletions}", style="red")
 
 
-def _append_context_and_stats(text: Text, hunk: Hunk) -> None:
-    if hunk.context_before:
-        text.append(f"  {_safe(hunk.context_before)}", style="dim italic")
-    text.append("  ")
-    _append_stats(text, hunk)
-
-
 def _print_hunk_line(out: Console, hunk: Hunk) -> None:
     line = Text()
     line.append("  ")
     line.append(hunk.id, style="cyan")
     line.append("  ")
     line.append(_safe(_header_text(hunk)), style="dim")
-    _append_context_and_stats(line, hunk)
+    _append_context_and_stats(text=line, hunk=hunk)
     out.print(line)
 
 
@@ -190,7 +186,7 @@ def print_applied(hunks: list[Hunk], *, verb: str) -> None:
         line.append("  ")
         line.append(_safe(hunk.file), style="bold")
         line.append(f"  {_safe(_header_text(hunk))}", style="dim")
-        _append_context_and_stats(line, hunk)
+        _append_context_and_stats(text=line, hunk=hunk)
         err.print(line)
 
 

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -64,16 +64,20 @@ def _append_stats(text: Text, hunk: Hunk) -> None:
         text.append(f"-{hunk.deletions}", style="red")
 
 
+def _append_context_and_stats(text: Text, hunk: Hunk) -> None:
+    if hunk.context_before:
+        text.append(f"  {_safe(hunk.context_before)}", style="dim italic")
+    text.append("  ")
+    _append_stats(text, hunk)
+
+
 def _print_hunk_line(out: Console, hunk: Hunk) -> None:
     line = Text()
     line.append("  ")
     line.append(hunk.id, style="cyan")
     line.append("  ")
     line.append(_safe(_header_text(hunk)), style="dim")
-    if hunk.context_before:
-        line.append(f"  {_safe(hunk.context_before)}", style="dim italic")
-    line.append("  ")
-    _append_stats(line, hunk)
+    _append_context_and_stats(line, hunk)
     out.print(line)
 
 
@@ -186,10 +190,7 @@ def print_applied(hunks: list[Hunk], *, verb: str) -> None:
         line.append("  ")
         line.append(_safe(hunk.file), style="bold")
         line.append(f"  {_safe(_header_text(hunk))}", style="dim")
-        if hunk.context_before:
-            line.append(f"  {_safe(hunk.context_before)}", style="dim italic")
-        line.append("  ")
-        _append_stats(line, hunk)
+        _append_context_and_stats(line, hunk)
         err.print(line)
 
 


### PR DESCRIPTION
`_print_hunk_line` and `print_applied` each carried a byte-identical four-line
tail that appends the `context_before` heading, a two-space separator, and the
`+/-` stats to the rendered hunk line. Extract it into
`_append_context_and_stats` so the two renderers can no longer drift apart when
that trailing format changes. Pure refactor; rendered output is unchanged.

## Test plan
- [x] `uv run pytest -q` (264 passed)
- [x] `uv run ruff check .` / `uv run ruff format --check` / `uv run ty check` clean
- [x] Rendered `git-hunk list` and `git-hunk stage --dry-run` on a hunk with a
  `def foo():` heading; both show the heading + stats identically to `main`
