### PR TITLE
refactor: drop dead unbared-header fallback in _bare_header

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -187,7 +187,12 @@ def _bare_header(at_line: str) -> str:
     # "@@ -1,3 +1,3 @@ def foo():" -> "@@ -1,3 +1,3 @@" (strip git's heading; the
     # heading is carried separately in context_before).
     m = re.match(r"(@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@)", at_line)
-    return m.group(1) if m else at_line
+    if not m:
+        # Unreachable for real input: parse_diff only ever passes a line that the
+        # (?=^@@) split guarantees starts with git's well-formed @@ header. Raise
+        # rather than silently mislabel if that invariant is ever broken.
+        raise ValueError(f"cannot parse hunk header: {at_line}")
+    return m.group(1)
 
 
 def _extract_context_before(header: str) -> str | None:

--- a/tests/unit/_hunk/bare_header_test.py
+++ b/tests/unit/_hunk/bare_header_test.py
@@ -1,0 +1,20 @@
+import pytest
+
+from git_hunk._hunk import _bare_header
+
+
+def test_strips_git_heading() -> None:
+    assert _bare_header("@@ -1,3 +1,3 @@ def foo():") == "@@ -1,3 +1,3 @@"
+
+
+def test_keeps_bare_header_unchanged() -> None:
+    assert _bare_header("@@ -1,3 +1,3 @@") == "@@ -1,3 +1,3 @@"
+
+
+def test_single_line_ranges_without_count() -> None:
+    assert _bare_header("@@ -1 +1 @@ def foo():") == "@@ -1 +1 @@"
+
+
+def test_raises_when_header_does_not_match() -> None:
+    with pytest.raises(ValueError, match="cannot parse hunk header"):
+        _bare_header("diff --git a/f.py b/f.py")


### PR DESCRIPTION
`_bare_header`'s `else at_line` fallback was dead: `parse_diff` splits each file diff on `(?=^@@)` and feeds every segment's first line, which — given git's pinned `-U3` output — always starts with a well-formed `@@ -a,b +c,d @@` header. The regex therefore always matches, and the fallback would only ever fire to silently return the *unbared* line (git's section heading included) as the JSON `header` field.

Replace it with a loud `ValueError` on non-match, mirroring `filter_hunk_lines` in `_lines.py`, which handles the same header shape and fails loudly rather than mislabeling. The raise is an unreachable invariant guard (documented as such), not a new runtime error path; the CLI parse path has no reachable `ValueError`, so no boundary handling is added.

## Test plan
- [x] tests added: `tests/unit/_hunk/bare_header_test.py` (heading strip, already-bare, single-line ranges, and the non-match raise)
- [x] `uv run pytest -q` (268 passed)
- [x] `uv run ruff check .` / `uv run ty check`
