### PR TITLE
fix: show a Usage hint on the --staged/--unstaged conflict error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,5 +76,7 @@ and this project adheres to
 - Report a git failure on a bad path argument (e.g. `git-hunk list ':(bogus)x'`)
   as a clean `error:` message instead of crashing with a raw Python traceback
   (#107).
+- Show a `Usage:` hint on the `--staged`/`--unstaged` conflict error for `list`
+  and `show`, matching every other conflicting-flags error (#117).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -38,6 +38,8 @@ from ._ui import HELP_UNSTAGE
 from ._ui import USAGE
 from ._ui import USAGE_COMMIT
 from ._ui import USAGE_DISCARD
+from ._ui import USAGE_LIST
+from ._ui import USAGE_SHOW
 from ._ui import USAGE_SKILLS
 from ._ui import USAGE_STAGE
 from ._ui import USAGE_UNSTAGE
@@ -361,9 +363,10 @@ def _collect_hunks(
     unstaged: bool,
     files: list[str] | None,
     include_untracked: bool,
+    usage: str,
 ) -> list[Hunk]:
     if staged and unstaged:
-        raise CliError("cannot use --staged and --unstaged together")
+        raise CliError("cannot use --staged and --unstaged together", usage=usage)
 
     if staged:
         hunks, _ = _get_hunks(staged=True, files=files)
@@ -404,6 +407,7 @@ def cmd_list(
         unstaged=unstaged,
         files=file_list,
         include_untracked=True,
+        usage=USAGE_LIST,
     )
 
     if force_json:
@@ -438,6 +442,7 @@ def cmd_show(
         unstaged=unstaged,
         files=None,
         include_untracked=False,
+        usage=USAGE_SHOW,
     )
 
     if ids:

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -230,6 +230,7 @@ _LINE_OPTS = f"""\
   [bold cyan]--dry-run[/bold cyan]   Report what would change without touching the index or working tree"""  # noqa: E501
 
 USAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk[/bold cyan] [cyan]<COMMAND>[/cyan]"  # noqa: E501
+USAGE_LIST = "[bold green]Usage:[/bold green] [bold cyan]git-hunk list[/bold cyan] [cyan][OPTIONS][/cyan] [cyan][<file>...][/cyan]"  # noqa: E501
 USAGE_SHOW = "[bold green]Usage:[/bold green] [bold cyan]git-hunk show[/bold cyan] [cyan][<id>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_STAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk stage[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
 USAGE_UNSTAGE = "[bold green]Usage:[/bold green] [bold cyan]git-hunk unstage[/bold cyan] [cyan]<id|file>[/cyan] [cyan][<id|file>...][/cyan] [cyan][OPTIONS][/cyan]"  # noqa: E501
@@ -330,7 +331,7 @@ Non-interactive git hunk staging for AI agents.
 HELP_LIST = f"""\
 List hunks (unstaged, staged, and untracked by default).
 
-[bold green]Usage:[/bold green] [bold cyan]git-hunk list[/bold cyan] [cyan][OPTIONS][/cyan] [cyan][<file>...][/cyan]
+{USAGE_LIST}
 
 [bold green]Options:[/bold green]
   [bold cyan]--staged[/bold cyan]      Show only staged hunks

--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -219,6 +219,8 @@ def test_list_unstaged_filter(cli: GitHunkCLI) -> None:
 def test_list_staged_and_unstaged_mutual_exclusion(cli: GitHunkCLI) -> None:
     r = cli.run("list", "--staged", "--unstaged")
     assert r.returncode != 0
+    assert "cannot use --staged and --unstaged together" in r.stderr
+    assert "Usage: git-hunk list" in r.stderr
 
 
 def test_list_status_field_in_json(cli: GitHunkCLI) -> None:

--- a/tests/e2e/show_test.py
+++ b/tests/e2e/show_test.py
@@ -85,6 +85,8 @@ def test_show_staged_and_unstaged_together_errors(cli: GitHunkCLI) -> None:
 
     r = cli.run("show", "--staged", "--unstaged")
     assert r.returncode != 0
+    assert "cannot use --staged and --unstaged together" in r.stderr
+    assert "Usage: git-hunk show" in r.stderr
 
 
 def test_show_renders_no_newline_marker_unnumbered(cli: GitHunkCLI) -> None:


### PR DESCRIPTION
The `--staged`/`--unstaged` mutual-exclusion error is raised in the shared
`_collect_hunks` helper (used by both `list` and `show`), and was the only
conflicting-flags error in the CLI that omitted the `usage=` hint every sibling
error already carries (`stage`/`unstage`/`discard`/`commit`/`skills`). The user
got no `Usage:` line and, because `usage` was absent, the error exited 1 instead
of the 2 those sibling errors use.

This threads each command's usage string through `_collect_hunks` (`list` →
`USAGE_LIST`, `show` → `USAGE_SHOW`) and extracts `USAGE_LIST` so `HELP_LIST`
references the constant like every other `HELP_*` block instead of inlining a
duplicate literal. The `usage` parameter is required (no default) so a future
third caller can't silently regress.

## Test plan
- [x] Extended `test_list_staged_and_unstaged_mutual_exclusion` and
  `test_show_staged_and_unstaged_together_errors` to assert the per-command
  `Usage:` line
- [x] `uv run pytest -q` (264 passed)
- [x] `make lint`
- [x] Drove both commands: `git-hunk list --staged --unstaged` and
  `git-hunk show --staged --unstaged` now print their command-specific usage and
  exit 2; `list --help` renders byte-identically from the extracted constant
