### PR TITLE
test: cover commit rejecting an explicit blank -m message

### DIFF
--- a/tests/e2e/commit_test.py
+++ b/tests/e2e/commit_test.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from .conftest import GitHunkCLI
 
 
@@ -78,6 +80,19 @@ def test_commit_requires_message(cli: GitHunkCLI) -> None:
 
     before = _commit_count(cli)
     r = cli.run("commit", _unstaged_ids(cli)[0])
+    assert r.returncode != 0
+    assert "message" in r.stderr
+    assert _commit_count(cli) == before
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+@pytest.mark.parametrize("message", ["", "   "], ids=["empty", "whitespace"])
+def test_commit_rejects_blank_message(cli: GitHunkCLI, message: str) -> None:
+    _init(cli, {"f.txt": "a\n"})
+    cli.repo.write_file("f.txt", "AAA\n")
+
+    before = _commit_count(cli)
+    r = cli.run("commit", _unstaged_ids(cli)[0], "-m", message)
     assert r.returncode != 0
     assert "message" in r.stderr
     assert _commit_count(cli) == before


### PR DESCRIPTION
`commit` rejects a missing or blank `-m` message via
`if message is None or not message.strip()`, but the existing
`test_commit_requires_message` only omits `-m` entirely, so `message is None`
short-circuits and the `not message.strip()` half was never exercised. This adds
a parametrized case passing an explicit empty (`""`) and whitespace-only (`"   "`)
`-m` value, asserting the commit is refused with no change to the index.

## Test plan
- [x] `uv run pytest tests/e2e/commit_test.py` (10 passed)
- [x] `make lint` (ruff format/check + ty clean)
