### PR TITLE
refactor: raise on unparsable header in _extract_context_before

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -182,7 +182,10 @@ def _bare_header(at_line: str) -> str:
 def _extract_context_before(header: str) -> str | None:
     match = re.search(r"@@.*?@@\s*(.*)", header)
     if not match:
-        return None
+        # Unreachable for real input: parse_diff only ever passes a real git @@
+        # hunk header, which always closes its range with a second @@. Raise
+        # rather than silently drop the heading if that invariant is ever broken.
+        raise ValueError(f"cannot parse hunk header: {header}")
     return match.group(1).strip() or None
 
 

--- a/tests/unit/_hunk/extract_context_before_test.py
+++ b/tests/unit/_hunk/extract_context_before_test.py
@@ -1,3 +1,5 @@
+import pytest
+
 from git_hunk._hunk import _extract_context_before
 
 
@@ -22,5 +24,6 @@ def test_none_when_trailing_context_is_whitespace_only() -> None:
     assert _extract_context_before("@@ -1,3 +1,4 @@   ") is None
 
 
-def test_none_when_header_does_not_match() -> None:
-    assert _extract_context_before("diff --git a/f.py b/f.py") is None
+def test_raises_when_header_does_not_match() -> None:
+    with pytest.raises(ValueError, match="cannot parse hunk header"):
+        _extract_context_before("diff --git a/f.py b/f.py")


### PR DESCRIPTION
The no-match branch in `_extract_context_before` is unreachable for real input: `parse_diff` only ever passes a real git `@@` hunk header, which always closes its range with a second `@@`. Converting the silent `return None` fallback into a `raise ValueError` fails loud if that invariant is ever broken, instead of silently dropping the section heading. Mirrors the fail-loud treatment PR #116 proposes for the sibling `_bare_header` helper.

## Test plan
- [x] `extract_context_before_test.py::test_raises_when_header_does_not_match` (updated from the old `is None` assertion)
- [x] `uv run pytest tests/` — 264 passed
- [x] `make lint` — ruff + ty clean
