### PR TITLE
fix: surface a missing git executable as a clean CLI error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,5 +71,7 @@ and this project adheres to
   into a trailing subcommand, so `git-hunk -h stage src/foo.py` prints help
   without staging and `git-hunk -V list` prints the version without listing
   (#145).
+- Report a clean `error:` message instead of a raw `FileNotFoundError`
+  traceback when the `git` executable is not found on `PATH` (#122).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -90,8 +90,11 @@ class CliGroup(click.Group):
 
 
 def _require_git_repo() -> None:
-    if not is_git_repo():
-        raise CliError("not a git repository")
+    try:
+        if not is_git_repo():
+            raise CliError("not a git repository")
+    except RuntimeError as exc:
+        raise CliError(str(exc)) from exc
 
 
 def _echo_json(data: object) -> None:

--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -9,11 +9,14 @@ def run_git(*args: str, input: str | None = None, check: bool = True) -> str:
     # Git output and input may contain bytes that are not valid UTF-8 (e.g. a
     # Latin-1 source file). surrogateescape round-trips those bytes losslessly
     # so a rebuilt patch hands git back exactly what it emitted.
-    result = subprocess.run(
-        ["git", "-c", "core.quotePath=false"] + list(args),
-        capture_output=True,
-        input=input.encode(errors="surrogateescape") if input is not None else None,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "-c", "core.quotePath=false"] + list(args),
+            capture_output=True,
+            input=input.encode(errors="surrogateescape") if input is not None else None,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("git executable not found on PATH") from exc
     if check and result.returncode != 0:
         stderr = result.stderr.decode(errors="surrogateescape").strip()
         raise RuntimeError(f"git {' '.join(args)} failed: {stderr}")

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -1,9 +1,26 @@
 from collections import Counter
 from pathlib import Path
 
+import pytest
+
 from tests.conftest import GitRepo
 
 from .conftest import GitHunkCLI
+
+
+def test_missing_git_binary_reports_clean_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty_bin = tmp_path / "bin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+
+    repo = GitRepo(str(tmp_path))
+    cli = GitHunkCLI(repo)
+    r = cli.run("list")
+    assert r.returncode != 0
+    assert "git executable not found" in r.stderr
+    assert "Traceback" not in r.stderr
 
 
 def test_not_a_git_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
When `git` is not on `PATH`, every `git-hunk` command crashed with a raw
`FileNotFoundError` traceback: `run_git` shelled out via
`subprocess.run(["git", ...])` with no handling for the binary being absent, so
the failure escaped before `_require_git_repo` could report its own styled
error. This converts that case into the tool's normal `error:` message.

`run_git` now translates the `FileNotFoundError` into the same `RuntimeError`
the git layer already raises for git failures, and `_require_git_repo` wraps its
`is_git_repo()` probe to surface it as a `CliError` (matching the existing
`RuntimeError -> CliError` translation used at the other call sites). Because
`is_git_repo()` is the first git call in every command, this covers all
subcommands.

Verified by driving the real CLI with `git` removed from `PATH`:

```
$ PATH=<empty> python -m git_hunk list
error: git executable not found on PATH   (exit 1)
```

`stage`, `show`, `commit`, and `list --json` all print the same clean error.

Scope note (deliberate): this fixes the missing-binary case only. A different
git failure (e.g. an unreadable `.git/index`) can still reach `get_diff` /
`get_untracked_files` on the `list`/`show`/`commit` paths, which are not wrapped
in `RuntimeError -> CliError`, so those surface as raw tracebacks today. Reviews
suggested centralizing the translation in `CliGroup.invoke` to close that class
of gap and remove the per-call-site duplication; that is a broader
error-handling change and left as a follow-up rather than folded into this
surgical fix.

## Test plan
- [x] Added `tests/e2e/error_test.py::test_missing_git_binary_reports_clean_error` (fails with a raw traceback before the fix, green after)
- [x] `make lint` (ruff format/check, ty, taplo, mdformat, yamlfix, typos)
- [x] `uv run pytest` (265 passed)
- [x] Drove the real CLI with `git` off `PATH`: clean `error:`, exit 1, no traceback
