### PR TITLE
fix: surface a git failure in commit's staged-change check as a clean CLI error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,5 +107,8 @@ and this project adheres to
 - Report untracked files with repo-root-relative paths, matching tracked hunks,
   so running `git-hunk` from a subdirectory no longer emits an untracked `file`
   on a different path basis than the staged/unstaged hunks beside it (#103).
+- Report a git failure while checking for already-staged changes in `commit`
+  (e.g. a corrupt index) as a clean `error:` message instead of crashing with a
+  raw Python traceback (#124).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -637,7 +637,11 @@ def cmd_commit(
         raise CliError("commit requires a message (-m)", usage=USAGE_COMMIT)
 
     _require_git_repo()
-    if get_diff(staged=True).strip():
+    try:
+        already_staged = get_diff(staged=True).strip()
+    except RuntimeError as exc:
+        raise CliError(str(exc)) from exc
+    if already_staged:
         raise CliError(
             "cannot commit: changes are already staged",
             tip="commit them with 'git commit', or unstage with 'git-hunk unstage'",

--- a/tests/e2e/commit_test.py
+++ b/tests/e2e/commit_test.py
@@ -140,3 +140,16 @@ def test_commit_aborts_when_index_already_has_staged_changes(cli: GitHunkCLI) ->
     assert _commit_count(cli) == before
     # The pre-staged change is untouched; nothing new was committed or staged.
     assert cli.repo.git("diff", "--cached", "--name-only").strip() == "a.txt"
+
+
+def test_commit_reports_clean_error_when_staged_diff_fails(cli: GitHunkCLI) -> None:
+    # A git failure while checking for already-staged changes must surface as a
+    # clean CLI error, not a raw Python traceback. A corrupt index makes
+    # `git diff --cached` fail while the repo still looks like a work tree.
+    _init(cli, {"f.txt": "a\n"})
+    cli.repo.write_file("f.txt", "AAA\n")
+    (Path(cli.repo.path) / ".git" / "index").write_bytes(b"garbage")
+
+    r = cli.run("commit", "deadbeef", "-m", "fix: x")
+    assert r.returncode != 0
+    assert r.stderr.startswith("error:")


### PR DESCRIPTION
`cmd_commit`'s already-staged guard called `get_diff(staged=True)` without wrapping the `RuntimeError` that `run_git` raises on a non-zero git exit. A git failure there (e.g. a corrupt `.git/index`, which still lets `git rev-parse --is-inside-work-tree` succeed) therefore crashed with a raw Python traceback instead of git-hunk's normal `error:` message. This wraps that one call in the same `RuntimeError -> CliError` idiom already used elsewhere in the file.

Scoped deliberately to the commit-specific `get_diff(staged=True)` call. The shared `_get_hunks` `get_diff` (used by `list`/`show`/`stage`/`unstage`/`discard`) has the same unguarded pattern, but that is the call site #107 already targets, so it is left to that PR. A broader fix (centralizing `RuntimeError -> CliError` at the top-level CLI dispatch, which would make several per-site wraps redundant) is worth a maintainer decision but is out of scope here.

## Test plan
- [x] `test_commit_reports_clean_error_when_staged_diff_fails` (corrupts `.git/index`, asserts a clean `error:` line and non-zero exit); confirmed it fails with a raw traceback on the unfixed code
- [x] drove the real `git-hunk commit` against a corrupt index -> `error: git diff -U3 --cached -- failed: fatal: .git/index: index file smaller than expected`, exit 1
- [x] `make lint` and full `pytest` green (265 passed)
