### PR TITLE
refactor: dedup the whole-file-hunk predicate into _hunk

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -19,6 +19,7 @@ from ._git import is_git_repo
 from ._git import stage_files
 from ._git import unstage_files
 from ._hunk import Hunk
+from ._hunk import is_whole_file_hunk
 from ._hunk import parse_diff
 from ._lines import filter_hunk_lines
 from ._lines import parse_line_spec
@@ -228,7 +229,7 @@ def _apply_line_filter(
         return hunks
     if len(hunks) != 1:
         raise CliError("line selection requires exactly one hunk")
-    if _is_whole_file_hunk(hunks[0]):
+    if is_whole_file_hunk(hunks[0]):
         raise CliError(
             "line selection is not supported for binary, mode, or type changes"
         )
@@ -237,12 +238,6 @@ def _apply_line_filter(
         return [filter_hunk_lines(hunks[0], lines, exclude=exclude, reverse=reverse)]
     except ValueError as exc:
         raise CliError(str(exc)) from exc
-
-
-def _is_whole_file_hunk(hunk: Hunk) -> bool:
-    # Binary and mode-only changes carry no text diff and are applied by staging
-    # the whole file rather than by a patch.
-    return not hunk.diff
 
 
 def _apply_selection(
@@ -266,8 +261,8 @@ def _apply_selection(
     selected = _select_hunks(hunks, args)
     selected = _apply_line_filter(selected, selection, reverse=reverse)
 
-    whole_file = [h for h in selected if _is_whole_file_hunk(h)]
-    text = [h for h in selected if not _is_whole_file_hunk(h)]
+    whole_file = [h for h in selected if is_whole_file_hunk(h)]
+    text = [h for h in selected if not is_whole_file_hunk(h)]
 
     try:
         if text:

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -65,6 +65,12 @@ class Hunk:
         return data
 
 
+def is_whole_file_hunk(hunk: Hunk) -> bool:
+    # Binary and mode-only changes carry no text diff and are applied by staging
+    # the whole file rather than by a patch.
+    return not hunk.diff
+
+
 def _body_lines(diff: str) -> list[dict[str, Any]]:
     if not diff:
         return []

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -17,6 +17,7 @@ from rich.text import Text
 
 from ._hunk import Hunk
 from ._hunk import is_no_newline_marker
+from ._hunk import is_whole_file_hunk
 from ._skills import Skill
 
 
@@ -134,7 +135,7 @@ def print_hunk_list(hunks: list[Hunk]) -> None:
 
 def _print_hunk_diff(out: Console, hunk: Hunk) -> None:
     out.print(f"[bold]{_safe_escape(hunk.file)}[/bold]  [dim]{escape(hunk.id)}[/dim]")
-    if not hunk.diff:
+    if is_whole_file_hunk(hunk):
         out.print(Text(_safe(_header_text(hunk)), style="dim"))
         return
     line_num = 0


### PR DESCRIPTION
Both `_cli` (`_apply_line_filter` / `_apply_selection`) and `_ui._print_hunk_diff` independently encoded the same "a binary/mode/type change has no text diff" check — one as a named, commented `_is_whole_file_hunk` helper, the other as a bare inline `not hunk.diff`. Consolidate them into a single public `is_whole_file_hunk` predicate in `_hunk`, next to the `Hunk` dataclass that owns the field, mirroring the existing `is_no_newline_marker` convention.

Pure internal refactor, no behavior change.

## Test plan
- [x] `make lint` (ruff format + check)
- [x] `uv run ty check` clean
- [x] `uv run pytest` — 264 passed, unchanged
