### PR TITLE
test: cover the type-change merge path guard for a delete + unrelated add

### DIFF
--- a/tests/unit/_hunk/parse_diff_test.py
+++ b/tests/unit/_hunk/parse_diff_test.py
@@ -208,3 +208,34 @@ def test_typechange_from_binary_is_marked_binary() -> None:
     assert hunks[0].binary is True
     assert hunks[0].a_mode == "100644"
     assert hunks[0].b_mode == "120000"
+
+
+def test_delete_then_unrelated_add_is_not_merged_as_typechange() -> None:
+    # The type-change merge only fires when the add block shares the delete's
+    # path. A delete followed by an add for a *different* file (git sorts diff
+    # blocks by path, so this is a real ordering) must stay two hunks, not merge
+    # into a bogus "T".
+    diff = (
+        "diff --git a/a.txt b/a.txt\n"
+        "deleted file mode 100644\n"
+        "index ce01362..0000000\n"
+        "--- a/a.txt\n"
+        "+++ /dev/null\n"
+        "@@ -1 +0,0 @@\n"
+        "-gone\n"
+        "diff --git a/b.txt b/b.txt\n"
+        "new file mode 100644\n"
+        "index 0000000..1de5659\n"
+        "--- /dev/null\n"
+        "+++ b/b.txt\n"
+        "@@ -0,0 +1 @@\n"
+        "+fresh\n"
+    )
+    hunks = parse_diff(diff)
+    assert len(hunks) == 2
+    assert hunks[0].file == "a.txt"
+    assert hunks[0].change_kind == "D"
+    assert hunks[0].deletions == 1
+    assert hunks[1].file == "b.txt"
+    assert hunks[1].change_kind == "A"
+    assert hunks[1].additions == 1


### PR DESCRIPTION
`parse_diff` merges a delete block immediately followed by an add block for the
*same* path into one synthetic type-change (`"T"`) hunk. The same-path check
(`extract_file_path(next_diff) == filepath`, `_hunk.py:262`) is what stops an
unrelated delete + add pair from collapsing into a bogus `"T"` hunk, but its
false branch (`262->275`) had no test — every existing type-change test uses the
same path on both blocks.

This adds one unit test: a delete of `a.txt` followed by an add of `b.txt` (git
sorts diff blocks by path, so this ordering is real) must stay two hunks (`D` and
`A`), not merge. Removing the guard collapses it into a single `T` hunk, so the
test kills a real regression rather than asserting the status quo.

## Test plan
- [x] `make test` (265 passed; the new test closes branch `_hunk.py 262->275`)
- [x] `make lint`
