### PR TITLE
refactor: dedup the JSON hunk envelope into a shared _echo_hunks_json helper

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -104,6 +104,15 @@ def _echo_json(data: object) -> None:
     click.echo(json.dumps(data, indent=2))
 
 
+def _echo_hunks_json(hunks: list[Hunk], *, include_lines: bool = False) -> None:
+    _echo_json(
+        {
+            "schema_version": JSON_SCHEMA_VERSION,
+            "hunks": [h.to_dict(include_lines=include_lines) for h in hunks],
+        }
+    )
+
+
 def _get_hunks(staged: bool, files: list[str] | None = None) -> tuple[list[Hunk], str]:
     _require_git_repo()
     try:
@@ -406,11 +415,7 @@ def cmd_list(
     )
 
     if force_json:
-        envelope = {
-            "schema_version": JSON_SCHEMA_VERSION,
-            "hunks": [h.to_dict() for h in hunks],
-        }
-        _echo_json(envelope)
+        _echo_hunks_json(hunks)
     else:
         print_hunk_list(hunks)
 
@@ -446,11 +451,7 @@ def cmd_show(
         matched = hunks
 
     if force_json:
-        envelope = {
-            "schema_version": JSON_SCHEMA_VERSION,
-            "hunks": [h.to_dict(include_lines=True) for h in matched],
-        }
-        _echo_json(envelope)
+        _echo_hunks_json(matched, include_lines=True)
     else:
         print_hunk_diffs(matched)
 


### PR DESCRIPTION
`cmd_list` and `cmd_show` each built the identical `{"schema_version", "hunks"}`
JSON envelope, differing only in whether `to_dict` was passed `include_lines=True`.
Extract that into `_echo_hunks_json(hunks, *, include_lines=False)` next to
`_echo_json` so the envelope shape lives in one place. Follow-up to #92, which
centralized `_echo_json`.

Behavior-preserving: output bytes are identical, and the existing `list --json`
/ `show --json` e2e tests already exercise both call sites.

## Test plan
- [x] `uv run pytest` (264 passed)
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check`
- [x] smoked `git-hunk list --json` (no `lines`) and `show --json` (with `lines`) in a scratch repo
