### PR TITLE
test: cover print_error's usage block and --help hint

### DIFF
--- a/tests/unit/_ui/print_error_test.py
+++ b/tests/unit/_ui/print_error_test.py
@@ -11,3 +11,12 @@ def test_escapes_brackets_in_message(capsys: pytest.CaptureFixture[str]) -> None
 def test_escapes_brackets_in_tip(capsys: pytest.CaptureFixture[str]) -> None:
     print_error("not found", tip="try [foo] instead")
     assert "[foo]" in capsys.readouterr().err
+
+
+def test_usage_block_renders_with_help_hint(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    print_error("unrecognized subcommand", usage="Usage: git-hunk <COMMAND>")
+    err = capsys.readouterr().err
+    assert "Usage: git-hunk <COMMAND>" in err
+    assert "For more information, try '--help'." in err


### PR DESCRIPTION
## Summary
- `print_error`'s `usage` branch (rendering the usage block plus the "try '--help'" hint) was untested; add a unit test covering it.

## Test plan
- [x] `uv run pytest tests/unit/_ui/print_error_test.py -q`
- [x] `uv run pytest -q` (full suite)
- [x] `uv run ruff check .`
- [x] `uv run ty check`