### PR TITLE
test: cover that list --staged/--unstaged exclude untracked files

### DIFF
--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -189,6 +189,25 @@ def test_list_default_shows_untracked(cli: GitHunkCLI) -> None:
     assert untracked[0]["b_mode"] == "100644"
 
 
+def test_status_filters_exclude_untracked(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    cli.repo.write_file("f.py", "staged\n")
+    cli.repo.git("add", "f.py")
+    cli.repo.write_file("f.py", "unstaged\n")
+    cli.repo.write_file("untracked.py", "new\n")
+
+    staged = cli.run_list_json("list", "--staged", "--json")
+    assert len(staged) == 1
+    assert staged[0]["status"] == "staged"
+
+    unstaged = cli.run_list_json("list", "--unstaged", "--json")
+    assert len(unstaged) == 1
+    assert unstaged[0]["status"] == "unstaged"
+
+
 def test_empty_new_file_is_not_a_bogus_mode_hunk(cli: GitHunkCLI) -> None:
     # A staged empty new file has no @@ body and no mode change; it must not
     # surface as a whole-file hunk (which would render "Mode None -> ...").


### PR DESCRIPTION
`_collect_hunks` only adds untracked entries on the default (both-sides) path;
the `--staged` and `--unstaged` early-return branches deliberately exclude them.
That contract was documented but untested: none of the existing staged/unstaged
tests placed an untracked file in the repo, so a regression that leaked untracked
entries into a filtered listing would have gone undetected.

This adds `test_status_filters_exclude_untracked`, which puts a staged edit, an
unstaged edit, and a separate untracked file in the repo, then asserts each
filter returns exactly the one hunk of its own status.

## Test plan
- [x] `uv run pytest -q` (265 passed)
- [x] `uv run ruff check .`, `uv run ty check`
- [x] Mutated `_collect_hunks` to leak untracked into `--staged`; the new test fails as expected, then reverted
