### PR TITLE
chore: pin lint workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
       - run: make lint


### PR DESCRIPTION
Pin `actions/checkout` and `astral-sh/setup-uv` in `lint.yml` to the same vetted commit SHAs already used in `test.yml` and `publish.yml`, so a mutable major-version tag cannot swap action code under CI. This was the one workflow still on floating `@v7` tags. Dependabot already watches the `github-actions` ecosystem and will keep the pins current.

## Test plan
- [x] `make lint` green (yamlfix validates the edited workflow)
- [x] SHAs verified to resolve to `v7.0.0` (checkout) and `v7.6.0` (setup-uv), byte-identical to the existing pins in `test.yml`/`publish.yml`
