### PR TITLE
refactor: dedup hunk body-splitting into split_diff_body helper

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -72,12 +72,8 @@ def is_whole_file_hunk(hunk: Hunk) -> bool:
 
 
 def _body_lines(diff: str) -> list[dict[str, Any]]:
-    if not diff:
-        return []
-    _, *body = diff.split("\n")
-    body = strip_trailing_empty_lines(body)
     lines: list[dict[str, Any]] = []
-    for line in body:
+    for line in split_diff_body(diff=diff):
         if is_no_newline_marker(line):
             if lines:
                 lines[-1]["no_newline"] = True
@@ -94,10 +90,11 @@ def count_changes(lines: list[str]) -> tuple[int, int]:
     return additions, deletions
 
 
-def strip_trailing_empty_lines(lines: list[str]) -> list[str]:
-    while lines and lines[-1] == "":
-        lines = lines[:-1]
-    return lines
+def split_diff_body(diff: str) -> list[str]:
+    body_lines = diff.split("\n")[1:]
+    while body_lines and body_lines[-1] == "":
+        body_lines.pop()
+    return body_lines
 
 
 def _hash_id(payload: str) -> str:
@@ -324,8 +321,8 @@ def parse_diff(diff_output: str) -> list[Hunk]:
         # separates changes more than 6 context lines apart into their own @@
         # section, so there is nothing finer to split here (use -l for that).
         for part in parts[1:]:
-            header_line, *body_lines = part.split("\n")
-            body_lines = strip_trailing_empty_lines(body_lines)
+            header_line = part.split("\n", 1)[0]
+            body_lines = split_diff_body(diff=part)
 
             additions, deletions = count_changes(body_lines)
             hunks.append(

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -7,7 +7,7 @@ from ._hunk import NO_NEWLINE_MARKER
 from ._hunk import Hunk
 from ._hunk import count_changes
 from ._hunk import is_no_newline_marker
-from ._hunk import strip_trailing_empty_lines
+from ._hunk import split_diff_body
 
 
 def _parse_line_number(token: str) -> int:
@@ -116,10 +116,6 @@ def _render_body_lines(kept: list[_BodyLine]) -> list[str]:
     return rendered
 
 
-def _body_lines(hunk: Hunk) -> list[str]:
-    return strip_trailing_empty_lines(hunk.diff.split("\n")[1:])
-
-
 def resolve_matching_lines(
     hunk: Hunk, patterns: Sequence[str], *, regex: bool
 ) -> set[int]:
@@ -145,7 +141,7 @@ def resolve_matching_lines(
 
     selected: set[int] = set()
     line_num = 0
-    for line in _body_lines(hunk):
+    for line in split_diff_body(diff=hunk.diff):
         if is_no_newline_marker(line):
             continue
         line_num += 1
@@ -191,7 +187,7 @@ def filter_hunk_lines(
     NEW content the index or working tree already holds.
     """
     header = hunk.diff.split("\n", 1)[0]
-    body = _body_lines(hunk)
+    body = split_diff_body(diff=hunk.diff)
 
     total = sum(1 for line in body if not is_no_newline_marker(line))
 


### PR DESCRIPTION
> *This was generated by AI.*

Removes the thin forwarding helpers while keeping one shared hunk body operation. `split_diff_body` now owns both header removal and trailing empty-line removal.

## Test plan
- [x] `make test` (324 passed)
- [x] `make lint`