### PR TITLE
test: cover filter_hunk_lines' unparsable hunk-header guard

### DIFF
--- a/tests/unit/_lines/filter_test.py
+++ b/tests/unit/_lines/filter_test.py
@@ -51,6 +51,13 @@ def test_out_of_range_errors(make_hunk: Callable[[str], Hunk]) -> None:
         filter_hunk_lines(hunk, {99}, exclude=False)
 
 
+def test_unparsable_header_errors(make_hunk: Callable[[str], Hunk]) -> None:
+    diff = "@@ -bad +bad @@ def foo():\n ctx1\n+add1\n ctx2"
+    hunk = make_hunk(diff)
+    with pytest.raises(ValueError, match="cannot parse hunk header"):
+        filter_hunk_lines(hunk, {2}, exclude=False)
+
+
 def test_header_recalculated(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,4 +1,5 @@ def foo():\n ctx1\n-del1\n+add1\n+add2\n ctx2"
     hunk = make_hunk(diff)


### PR DESCRIPTION
`filter_hunk_lines` guards against a malformed `@@` header by raising `ValueError("cannot parse hunk header: ...")` (`git_hunk/_lines.py:221`), but no test exercised that branch — it was the only uncovered line in `_lines.py`. This adds a test that drives a hunk whose first line fails the header regex, mirroring the sibling `test_out_of_range_errors` / `test_no_changes_remain_errors` error tests.

## Test plan
- [x] `uv run pytest tests/unit/_lines/filter_test.py -q` (13 passed)
- [x] branch coverage confirms `_lines.py:221` now hit; full suite `uv run pytest -q` green (265 passed)
- [x] `uv run ruff check` / `uv run ty check` clean