### PR TITLE
refactor: drop dead empty-lines guard in _body_lines

### DIFF
--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -73,8 +73,7 @@ def _body_lines(diff: str) -> list[dict[str, Any]]:
     lines: list[dict[str, Any]] = []
     for line in body:
         if is_no_newline_marker(line):
-            if lines:
-                lines[-1]["no_newline"] = True
+            lines[-1]["no_newline"] = True
             continue
         lines.append(
             {"n": len(lines) + 1, "op": line[:1], "content": _byte_safe(line[1:])}


### PR DESCRIPTION
`_body_lines` guards `lines[-1]["no_newline"] = True` with `if lines:`, but that
false branch is unreachable: git's unified-diff output only ever emits
`\ No newline at end of file` immediately after the content line it describes, so
`lines` is never empty when the marker is seen. Both producers of `Hunk.diff`
(`parse_diff` and `_render_body_lines`) preserve that invariant. Drop the guard as
error handling for an impossible scenario, matching the precedent of #116 and #121.

## Test plan
- [x] `uv run pytest -q` (264 passed) — the suite stays green, proving no valid input hit the removed branch
- [x] `uv run pytest --cov=git_hunk --cov-branch` — the `_hunk.py 76->78` partial branch is gone
- [x] `uv run ruff check git_hunk` / `uv run ty check git_hunk`
