### PR TITLE
docs: changelog the typed v2 --json schema (ADR 0001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,18 @@ and this project adheres to
 ### Changed
 
 - **Breaking:** `list --json` now wraps its output in a versioned envelope,
-  `{"schema_version": 1, "hunks": [...]}`, instead of a bare array, so consumers
+  `{"schema_version": 2, "hunks": [...]}`, instead of a bare array, so consumers
   can depend on a documented, versioned shape (#23).
+- **Breaking:** `--json` output is now the typed v2 hunk schema defined in
+  ADR 0001, so consumers read typed fields instead of regex-parsing free text:
+  the file-level fields `change_kind`, `a_mode`, `b_mode`, and `binary` are
+  stamped on every hunk; `file`, `context_before`, and each line's `content` are
+  byte-safe `{"text": ...}` / `{"bytes": ...}` objects (`context_before` is
+  `null` when the hunk has no section heading); `header` is the bare `@@` range
+  and is `null` for a whole-file (binary, mode-only, or type change) hunk;
+  `show --json`
+  carries a structured per-line `lines[]` body (each `{n, op, content}`, with an
+  optional `no_newline`) and the raw `diff` string is dropped (#67).
 - README image paths are rewritten to absolute URLs so they render on PyPI.
 - The `core` skill documents the tool only. Guidance on grouping and ordering
   commits moved to the new `logical-commits` skill, and the conventional-commits


### PR DESCRIPTION
The v2 typed `--json` hunk schema (ADR 0001, #67, shipped by #72) merged without
a `CHANGELOG.md` entry, and the existing envelope bullet still showed
`schema_version: 1` while the code ships `2` (`JSON_SCHEMA_VERSION = 2`). This
corrects the stale version literal and documents the shipped v2 schema — typed
per-hunk fields, byte-safe `{text|bytes}` fields, a bared/nullable `header`, the
structured `show --json` `lines[]` body, and the dropped raw `diff` string —
matching `docs/adr/0001-json-v2-hunk-schema.md`.

## Test plan
- [x] Every claim in the new entry cross-checked against `git_hunk/_hunk.py`
      (`to_dict`, `_body_lines`, `_byte_safe`) and ADR 0001
- [x] `make lint` passes
