### PR TITLE
test: cover untracked executable file reporting mode 100755

### DIFF
--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -231,6 +232,17 @@ def test_list_untracked_symlink_reports_symlink_mode(cli: GitHunkCLI) -> None:
     assert untracked[0]["change_kind"] == "A"
     assert untracked[0]["a_mode"] is None
     assert untracked[0]["b_mode"] == "120000"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="git does not track the executable bit on Windows"
+)
+def test_list_untracked_executable_reports_executable_mode(cli: GitHunkCLI) -> None:
+    os.chmod(cli.repo.write_file("run.sh", "echo hi\n"), 0o755)
+
+    [hunk] = cli.run_list_json("list", "--json")
+    assert hunk["status"] == "untracked"
+    assert hunk["b_mode"] == "100755"
 
 
 def test_empty_new_file_is_not_a_bogus_mode_hunk(cli: GitHunkCLI) -> None:


### PR DESCRIPTION
`_working_tree_mode` derives an untracked file's would-be added mode from the
working tree via `os.lstat`, returning `100755` when the owner-execute bit is
set and `100644` otherwise. The `100644` path is exercised by
`test_list_default_shows_untracked` and the `120000` symlink path by #108, but
nothing pinned the executable `100755` branch — the existing `chmod` tests
drive the *tracked* `_block_modes` path, not `_working_tree_mode`. This adds the
missing sibling case.

## Test plan
- [x] `test_list_untracked_executable_reports_executable_mode` passes; full suite green (`uv run pytest`)
- [x] `uv run ruff check` / `ruff format --check` / `ty check`
