### PR TITLE
refactor: dedup the file-group render line in _print_status_section

### DIFF
--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -93,12 +93,9 @@ def _print_status_section(
     for hunk in hunks:
         by_file[hunk.file].append(hunk)
     for i, (filepath, file_hunks) in enumerate(by_file.items()):
-        if show_hunks:
-            _print_file_group(out, filepath, file_hunks, color=color)
-            if i < len(by_file) - 1:
-                out.print()
-        else:
-            out.print(f"[{color}]{escape(_safe(filepath))}[/{color}]")
+        _print_file_group(out, filepath, file_hunks if show_hunks else [], color=color)
+        if show_hunks and i < len(by_file) - 1:
+            out.print()
 
 
 def print_hunk_list(hunks: list[Hunk]) -> None:


### PR DESCRIPTION
`_print_status_section` rendered the untracked (`show_hunks=False`) file line
with a byte-for-byte copy of the filepath line already emitted inside
`_print_file_group`, so the same Rich markup lived in two places and could
drift. Delegate that case to `_print_file_group` with an empty hunk list, and
gate the between-files blank separator on `show_hunks`. The filepath rendering
now lives in exactly one place; output is unchanged.

## Test plan
- [x] `make lint` and full suite green (264 passed)
- [x] Drove `git-hunk list` across staged/unstaged/untracked, untracked-only, and `--staged`-only; output is byte-identical to `main` (A/B diff against the pre-edit source)
