### PR TITLE
refactor: dedup the two-column padding formula in _ui into _column_gap

### DIFF
--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -35,6 +35,11 @@ def _safe(text: str) -> str:
     return text.encode("utf-8", errors="backslashreplace").decode("utf-8")
 
 
+def _column_gap(text: str, width: int) -> str:
+    GUTTER: Final = 2
+    return " " * (width - len(text) + GUTTER)
+
+
 def _whole_file_label(hunk: Hunk) -> str:
     # Human label for a hunk with no @@ range, derived from its typed fields
     # (the data layer no longer stores the label string).
@@ -159,8 +164,8 @@ def print_skill_list(skills: list[Skill]) -> None:
     width = max(len(skill.name) for skill in skills)
     for skill in skills:
         summary = skill.description.split("\n", 1)[0]
-        pad = " " * (width - len(skill.name) + 2)
-        line = Text.assemble(Text(skill.name, style="cyan"), Text(pad + summary, "dim"))
+        gap = _column_gap(skill.name, width)
+        line = Text.assemble(Text(skill.name, style="cyan"), Text(gap + summary, "dim"))
         out.print(line, no_wrap=True, overflow="ellipsis")
 
 
@@ -242,8 +247,8 @@ def _format_examples(rows: list[tuple[str, str]]) -> str:
     width = max(len(command) for command, _ in rows)
     lines = ["[bold green]Examples:[/bold green]"]
     for command, comment in rows:
-        pad = " " * (width - len(command) + 2)
-        lines.append(f"  [cyan]{command}[/cyan]{pad}[dim]# {comment}[/dim]")
+        gap = _column_gap(command, width)
+        lines.append(f"  [cyan]{command}[/cyan]{gap}[dim]# {comment}[/dim]")
     return "\n".join(lines)
 
 

--- a/tests/unit/_ui/column_gap_test.py
+++ b/tests/unit/_ui/column_gap_test.py
@@ -1,0 +1,15 @@
+from git_hunk._ui import _column_gap
+
+
+def test_widest_entry_gets_the_bare_gutter() -> None:
+    assert _column_gap("stage", 5) == "  "
+
+
+def test_shorter_entry_is_padded_to_align_the_next_column() -> None:
+    assert _column_gap("show", 6) == "    "
+
+
+def test_text_plus_gap_reaches_the_same_column_offset() -> None:
+    width = 8
+    for text in ["a", "commit", "discard!"]:
+        assert len(text) + len(_column_gap(text, width)) == width + 2


### PR DESCRIPTION
`print_skill_list` and `_format_examples` independently aligned a two-column
layout with the same `" " * (width - len(x) + 2)` expression, duplicating both
the formula and the 2-space gutter. Extract it into a single `_column_gap`
helper (naming the gutter constant) so the alignment logic lives in one place.
Output is byte-identical; this is an internal refactor with no user-facing
change, so no CHANGELOG entry.

## Test plan
- [x] Added `tests/unit/_ui/column_gap_test.py` (mirrors the one-file-per-helper
      layout of the sibling `_ui` unit tests): boundary, padded, and invariant cases
- [x] `uv run pytest -q` (267 passed), `uv run ruff check .`, `uv run ty check`
- [x] Verified `git-hunk --help` and `git-hunk skills list` render byte-identically
      to `origin/main` (diff empty)
