### PR TITLE
fix: short-circuit global -h/-V so they don't run a trailing subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,5 +59,9 @@ and this project adheres to
   surfaces an untracked `foo.py` instead of silently dropping it, and path
   arguments resolve consistently across `list`/`stage`/`unstage`/`discard`
   regardless of the platform's path separator (#95).
+- Stop the global `-h`/`--help` and `-V`/`--version` flags from falling through
+  into a trailing subcommand, so `git-hunk -h stage src/foo.py` prints help
+  without staging and `git-hunk -V list` prints the version without listing
+  (#145).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -311,9 +311,10 @@ def _run_patch_command(
 def cli(ctx: click.Context, show_help: bool, show_version: bool) -> None:
     if show_version:
         print_version(__version__)
-        return
+        ctx.exit()
     if show_help or ctx.invoked_subcommand is None:
         print_help(HELP)
+        ctx.exit()
 
 
 def _working_tree_mode(path: str) -> str:

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -36,6 +36,30 @@ def test_help(cli: GitHunkCLI) -> None:
     assert "git-hunk stage d161935" in r.stderr
 
 
+def test_version_short_circuits_subcommand(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "one\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "CHANGED\n")
+
+    r = cli.run("-V", "list")
+    assert r.returncode == 0
+    assert "git-hunk" in r.stderr
+    assert "f.py" not in r.stdout
+
+
+def test_help_short_circuits_subcommand(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "one\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "CHANGED\n")
+
+    r = cli.run("-h", "stage", "f.py")
+    assert r.returncode == 0
+    assert "Examples:" in r.stderr
+    assert cli.repo.git("diff", "--cached").strip() == ""
+
+
 def test_unknown_command(cli: GitHunkCLI) -> None:
     r = cli.run("bogus")
     assert r.returncode != 0


### PR DESCRIPTION
The top-level `cli()` group callback printed help/version and then `return`ed,
so Click (with `invoke_without_command=True`) went on to resolve and invoke the
trailing subcommand anyway. As a result `git-hunk -h stage src/foo.py` printed
the help text and then **actually staged the file**, and `git-hunk -V list`
printed the version and then ran `list`. The same fall-through applied to the
destructive `discard`/`commit` subcommands.

Calling `ctx.exit()` (instead of `return`) after printing makes the global
`-h`/`-V` flags short-circuit before any subcommand runs. `ctx.exit()` raises
`click.exceptions.Exit`, which isn't caught by `CliGroup.invoke`'s
`CliError`/`KeyboardInterrupt` handlers, so it propagates to Click's top-level
`main()` and exits 0 without dispatching the subcommand.

## Test plan
- [x] `tests/e2e/error_test.py::test_help_short_circuits_subcommand` — `-h stage <file>` prints help and does not stage
- [x] `tests/e2e/error_test.py::test_version_short_circuits_subcommand` — `-V list` prints version and does not list
- [x] `uv run pytest -q` (266 passed), `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`
