### PR TITLE
docs: repair mangled stage + git commit sentence in core skill

### DIFF
--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -42,9 +42,8 @@ argument could be both.
 
 `git-hunk commit <id|file> ... -m "<message>"` collapses steps 3-4 (stage one
 group, then commit it) into a single call. It aborts if anything is already
-staged, so the commit holds exactly the selected hunks; use the separate `stage`
-
-- `git commit` when you want to inspect the staged diff in between.
+staged, so the commit holds exactly the selected hunks; use the separate
+`stage` + `git commit` when you want to inspect the staged diff in between.
 
 ## Quickstart
 


### PR DESCRIPTION
A stray blank line plus a `- ` marker in `git_hunk/skills/core/SKILL.md` split
the "use the separate `stage` + `git commit`" clause into a paragraph that
trailed off mid-sentence and an orphaned one-item bullet. Since this file is the
bundled agent guide printed verbatim by `git-hunk skills get core`, agents read
the broken, nonsensical split directly. Rewrapped so the sentence is continuous
and the `+` is never line-initial (avoiding a CommonMark/GFM list-marker reparse).

## Test plan
- [x] `git-hunk skills get core` now prints the clause as one continuous sentence
