### PR TITLE
docs: include type changes in the whole-file-hunk definition

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,11 +4,12 @@
 
 - **Hunk** — the atomic, addressable unit of git-hunk. A contiguous change a user can
   `stage` / `show` / `discard` by `id`. Usually one `@@` section of a unified diff; for
-  binary or mode-only changes it is a synthetic **whole-file hunk** (no `@@` range). The
-  top-level object in `--json` (the tool is hunk-centric, not file-centric).
+  binary, mode-only, or type changes it is a synthetic **whole-file hunk** (no `@@` range).
+  The top-level object in `--json` (the tool is hunk-centric, not file-centric).
 
-- **Whole-file hunk** — a hunk with no `@@` text range: a binary change, or a mode-only
-  (chmod) change. Has `header: null` and (in `show --json`) `lines: []`.
+- **Whole-file hunk** — a hunk with no `@@` text range: a binary change, a mode-only
+  (chmod) change, or a type change (e.g. file ↔ symlink). Has `header: null` and (in
+  `show --json`) `lines: []`.
 
 - **change_kind** — the git status letter for the hunk's file: `A` added, `D` deleted,
   `M` modified, `T` typechange. Always present. `R` (rename) / `C` (copy) are reserved,

--- a/docs/adr/0001-json-v2-hunk-schema.md
+++ b/docs/adr/0001-json-v2-hunk-schema.md
@@ -73,7 +73,7 @@ mode-only one (both have empty bodies). Do not infer binary-ness from an empty b
 
 `header`: for a text hunk, the **bare** `@@ -a,b +c,d @@` range with git's trailing
 section heading stripped (#50). The section heading lives only in `context_before`.
-For a whole-file hunk (binary or mode-only — no `@@` range), `header` is `null`.
+For a whole-file hunk (binary, mode-only, or type change — no `@@` range), `header` is `null`.
 
 The internal `Hunk.diff` attribute used to build patches for `git apply` keeps git's
 original `@@` line **verbatim** (including the section heading); only the JSON `header`


### PR DESCRIPTION
`CONTEXT.md` and ADR 0001 §5 defined a whole-file hunk as only a binary or
mode-only change, but `parse_diff` also emits a **type change** (`change_kind`
`"T"`, e.g. file ↔ symlink) as a whole-file hunk via the same `_whole_file_hunk`
constructor (`header: null`, empty body). `README.md` already lists all three
cases; this aligns the domain docs (which agents are told to treat as
authoritative) with the code and README.

## Test plan
- [x] Cross-checked against `git_hunk/_hunk.py` `_whole_file_hunk` call sites (type/binary/mode-only all constructed identically) and the existing `test_typechange_stage_unstage_discard` behavioral witness
