### PR TITLE
docs: correct stale-id claim for partial-stage leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,5 +97,8 @@ and this project adheres to
   restoring "from HEAD" when it restores from the index: discarding an unstaged
   hunk reverts it to the staged content, leaving a staged sibling edit intact
   (#109).
+- Correct the skill guide and README's claim that a partially staged hunk's
+  leftover keeps the same id, so the guide now says to re-run `git-hunk list` to
+  get the leftover's new id (#149).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/README.md
+++ b/README.md
@@ -218,8 +218,9 @@ renaming, removing, or changing the type of an existing field bumps it. (Before
 3. For staging: reconstructs a minimal patch and pipes it through `git apply --cached`
 4. For discarding: reconstructs a reverse patch and applies it to the working tree
 
-IDs are stable across partial staging -- they are derived from the changed lines,
-not the `@@` line numbers that shift as you stage hunks.
+IDs are derived from the changed lines, not the `@@` line numbers that shift as
+you stage other hunks -- so an unrelated hunk keeps its id, while staging only
+part of a hunk gives the leftover a new one.
 
 ## Contributing
 

--- a/git_hunk/_hunk.py
+++ b/git_hunk/_hunk.py
@@ -95,7 +95,7 @@ def strip_trailing_empty_lines(lines: list[str]) -> list[str]:
 
 
 def _body_id(filepath: str, diff_content: str) -> str:
-    """Stable across partial staging: ignores @@ headers that shift."""
+    """Ignore @@ line numbers so a hunk's id survives other hunks being staged."""
     body = "\n".join(
         line for line in diff_content.split("\n") if not line.startswith("@@")
     )
@@ -111,7 +111,7 @@ def _full_id(filepath: str, diff_content: str) -> str:
 
 
 def _with_stable_ids(hunks: list[Hunk]) -> list[Hunk]:
-    # Pass 1: body-only IDs (stable across staging).
+    # Pass 1: body-only IDs, stable while other hunks are staged.
     # Pass 2: for colliding IDs, upgrade to full IDs to disambiguate.
     with_body_ids = [replace(h, id=_body_id(h.file, h.diff)) for h in hunks]
 

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -26,8 +26,9 @@ git commit -m "<message>"     # 4. commit it
 git-hunk list                 # 5. repeat until nothing is left behind
 ```
 
-IDs are content-based hashes. They're stable across partial staging and support
-prefix matching, so a 7-char prefix like `d161935` is enough.
+IDs are content-based hashes and support prefix matching, so a 7-char prefix like
+`d161935` is enough. They stay stable as you stage other hunks in the file, but
+staging only part of a hunk gives the leftover a new id.
 
 `stage`, `unstage`, and `discard` also accept a file path as shorthand for every
 hunk in that file, so you don't have to enumerate IDs:
@@ -81,8 +82,9 @@ git-hunk stage d161935 -l ^3,^5-7   # include everything except lines 3 and 5-7
 ```
 
 Line numbers are the 1-based positions shown by `git-hunk show <id>`. After a
-partial stage, the rest of the hunk stays in the working tree with the same ID;
-stage it into a later commit, or drop it.
+partial stage, the leftover stays in the working tree under a new id (the id
+hashes the hunk body, which the partial stage changed); re-run `git-hunk list`
+to get that id before staging the leftover into a later commit or dropping it.
 
 Select by content instead of line number with `--include-matching` /
 `--exclude-matching` (no `show` round trip, and stable if the hunk shifts):


### PR DESCRIPTION
The bundled agent skill guide, the README, and `_body_id`'s docstring/comment all
claimed a hunk's id is stable "across partial staging" and that a partially staged
hunk's leftover "keeps the same ID." That conflates two different cases:

- Staging *other* hunks leaves this hunk's id alone -- the id strips the `@@` line
  numbers that shift, so its body-hash is unchanged. This is the true claim.
- Staging only *part* of a hunk (via `-l`, or `--include-matching` /
  `--exclude-matching`) changes the leftover's body, so its content-hashed id
  changes. This is what the old wording got wrong.

An agent following the doc literally would reuse the original id on the leftover
and hit `error: hunk '<id>' not found`. Verified against the live CLI: a hunk
`85321a9`, after `stage 85321a9 -l 1`, leaves the leftover under a new id
`f130bce`, not `85321a9`.

This rewords every claim to say a partial stage gives the leftover a new id
(method-agnostic phrasing, since `--include-matching` behaves the same), and
points agents at `git-hunk list` to fetch it. The `_body_id` docstring and the
`_with_stable_ids` Pass-1 comment are corrected to match, so a contributor reading
the source doesn't reintroduce the claim.

**Deferred (conscious, not an oversight):** the two SKILL.md workflow examples
("Surgically drop debug lines" and "Separate a refactor from a feature") also reuse
a stale id after a partial stage and remain broken. "Surgically drop debug lines"
overlaps in-flight #109 on the exact `discard` line it edits, and fixing both needs
an example rewrite better done alongside #109, so they are left for a follow-up.

## Test plan
- [x] `make lint` and full suite (264 passed) green; docs/docstring-only, no behavior change
- [x] Corrected claim verified empirically against the `git-hunk` CLI (leftover gets a new id)
