### PR TITLE
fix: match hunk ids case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,5 +81,7 @@ and this project adheres to
   (#107).
 - Show a `Usage:` hint on the `--staged`/`--unstaged` conflict error for `list`
   and `show`, matching every other conflicting-flags error (#117).
+- Match hunk ids case-insensitively, so an uppercased id like `git-hunk show 713B7B9` resolves like git's own object-id lookup instead of failing with a
+  misleading "not found" / "no changed file matches" error (#150).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -120,7 +120,7 @@ def _find_hunks_by_ids(hunks: list[Hunk], ids: list[str]) -> list[Hunk]:
     for hunk_id in ids:
         if not hunk_id.strip():
             raise CliError("hunk id must not be empty or whitespace")
-        matches = [h for h in hunks if h.id.startswith(hunk_id)]
+        matches = [h for h in hunks if h.id.startswith(hunk_id.lower())]
         if len(matches) == 0:
             available = [h.id for h in hunks]
             tip = f"available hunk ids: {', '.join(available)}" if available else None
@@ -154,7 +154,7 @@ def _select_hunks(hunks: list[Hunk], args: list[str]) -> list[Hunk]:
         path = _normalize_path_arg(arg)
         if path in files:
             matches = [h for h in hunks if h.file == path]
-        elif re.fullmatch(r"[0-9a-f]+", arg):
+        elif re.fullmatch(r"[0-9a-fA-F]+", arg):
             matches = _find_hunks_by_ids(hunks, [arg])
         else:
             raise CliError(

--- a/tests/e2e/show_test.py
+++ b/tests/e2e/show_test.py
@@ -18,6 +18,21 @@ def test_show_hunk_by_full_id(cli: GitHunkCLI) -> None:
     assert "+new" in r.stdout
 
 
+def test_show_hunk_by_uppercase_id(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "new\n")
+
+    hunks = cli.run_list_json("list", "--json")
+    hunk_id = hunks[0]["id"]
+
+    r = cli.run("show", hunk_id.upper())
+    assert r.returncode == 0
+    assert "-old" in r.stdout
+    assert "+new" in r.stdout
+
+
 def test_show_hunk_by_prefix(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "old\n")
     cli.repo.git("add", ".")

--- a/tests/e2e/stage_test.py
+++ b/tests/e2e/stage_test.py
@@ -24,6 +24,19 @@ def test_stage_single_hunk(cli: GitHunkCLI) -> None:
     assert "CHANGED18" in unstaged
 
 
+def test_stage_hunk_by_uppercase_id(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "new\n")
+
+    hunks = cli.run_list_json("list", "--json")
+    cli.run_ok("stage", hunks[0]["id"].upper())
+
+    staged = cli.repo.git("diff", "--cached")
+    assert "+new" in staged
+
+
 def test_stage_multiple_hunks(cli: GitHunkCLI) -> None:
     lines = [f"line{i}" for i in range(1, 21)]
     cli.repo.write_file("f.py", "\n".join(lines) + "\n")

--- a/tests/unit/_cli/find_hunks_by_ids_test.py
+++ b/tests/unit/_cli/find_hunks_by_ids_test.py
@@ -34,6 +34,13 @@ def test_multiple_ids_resolve_in_order(hunks: list[Hunk]) -> None:
     assert _find_hunks_by_ids(hunks, ["ab12", "ab34"]) == [hunks[0], hunks[1]]
 
 
+@pytest.mark.parametrize("query", ["AB12", "Ab12", "AB12CD0"])
+def test_uppercase_prefix_resolves_case_insensitively(
+    hunks: list[Hunk], query: str
+) -> None:
+    assert _find_hunks_by_ids(hunks, [query]) == [hunks[0]]
+
+
 def test_ambiguous_prefix_raises_with_matches_tip(hunks: list[Hunk]) -> None:
     with pytest.raises(CliError) as exc_info:
         _find_hunks_by_ids(hunks, ["ab"])


### PR DESCRIPTION
An uppercased hunk id failed instead of resolving. Hunk ids are always
lowercase sha256 prefixes, but the CLI matched them case-sensitively, so
`git-hunk show 713B7B9` errored with a misleading "not found" and
`git-hunk stage 713B7B9` fell through to "no changed file matches" (the
uppercase arg failed the `[0-9a-f]+` shape check and was treated as a missing
path). git's own object-id lookup is case-insensitive (`git show DEADBEEF`
works), so this now mirrors that.

`_find_hunks_by_ids` lowercases the query before matching (used by `show`), and
`_select_hunks`' hex shape-check regex now accepts `A-F` so uppercase args route
to id-matching (used by stage/unstage/discard/commit). Error messages still echo
the user's original-case input.

## Test plan
- [x] unit: `_find_hunks_by_ids` resolves `AB12` / `Ab12` / `AB12CD0`
- [x] e2e: `show`/`stage` by uppercased id
- [x] `uv run pytest -q` (269 passed), `ruff check`, `ty check`
