### PR TITLE
fix: scope the single-hunk help note to all line-selection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,5 +110,9 @@ and this project adheres to
 - Report a git failure while checking for already-staged changes in `commit`
   (e.g. a corrupt index) as a clean `error:` message instead of crashing with a
   raw Python traceback (#124).
+- Scope the "requires exactly one hunk" note in `--help` to all line-selection
+  options, so `--include-matching` / `--exclude-matching` no longer read as
+  working across multiple hunks when they share the same single-hunk
+  constraint as `-l` (#155).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -219,14 +219,21 @@ def print_version(version: str) -> None:
     _err().print(f"git-hunk [dim]{version}[/dim]")
 
 
-_LINE_SELECT_ROW = """\
+_LINE_SELECT_EXAMPLE = """\
+             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""
+
+# `commit` accepts -l as its only line-selection option, so the constraint rides
+# on the -l row itself; the multi-option block below states it once for the group.
+_LINE_SELECT_ROW = f"""\
   [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk (requires exactly one hunk)
-             e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""  # noqa: E501
+{_LINE_SELECT_EXAMPLE}"""  # noqa: E501
 
 _LINE_OPT_ROW = f"""\
-{_LINE_SELECT_ROW}
+  [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk
+{_LINE_SELECT_EXAMPLE}
   [bold cyan]--include-matching[/bold cyan] [cyan]<pattern>[/cyan]  Select changed lines containing <pattern> (repeatable, OR'd)
   [bold cyan]--exclude-matching[/bold cyan] [cyan]<pattern>[/cyan]  Select every changed line except those matching (repeatable, OR'd)
+             Line selection (-l, --include-matching, --exclude-matching) requires exactly one hunk.
   [bold cyan]--regex[/bold cyan]    Treat matching patterns as regular expressions (default: literal substring)"""  # noqa: E501
 
 _LINE_OPTS = f"""\

--- a/tests/e2e/path_shorthand_test.py
+++ b/tests/e2e/path_shorthand_test.py
@@ -100,6 +100,14 @@ def test_line_selection_rejected_for_multi_hunk_path(
     assert "exactly one hunk" in r.stderr
 
 
+def test_matching_selection_rejected_for_multi_hunk_path(
+    multi_hunk_repo: GitHunkCLI,
+) -> None:
+    r = multi_hunk_repo.run("stage", "big.py", "--include-matching", "L")
+    assert r.returncode != 0
+    assert "exactly one hunk" in r.stderr
+
+
 def test_unknown_path_errors_clearly(multi_hunk_repo: GitHunkCLI) -> None:
     # A non-hex argument can only be a path, so the error names the file.
     r = multi_hunk_repo.run("stage", "does-not-exist.py")


### PR DESCRIPTION
The `-l`, `--include-matching`, and `--exclude-matching` flags all share the
same single-hunk constraint (`_apply_line_filter` rejects any active selection
when more than one hunk is targeted), but `--help` attached the
"(requires exactly one hunk)" note only to the `-l` row. Since this help block
is shared across `stage`, `unstage`, `discard`, and `commit`, the omission read,
on four screens, as if pattern-based selection worked across multiple hunks.

Move the note to a group-level line covering all three options, placed after
`--exclude-matching` and before `--regex` (which is validated separately and
does not carry the constraint). Also add an e2e test asserting
`--include-matching` is rejected on a multi-hunk path selection; previously only
`-l` was covered.

## Test plan
- [x] `tests/e2e/path_shorthand_test.py::test_matching_selection_rejected_for_multi_hunk_path`
- [x] Rendered `git-hunk {stage,unstage,discard,commit} --help`; all four show the group-scoped note
- [x] `uv run pytest -q` (265 passed), `ruff check`, `ruff format --check`, `ty check`
