### PR TITLE
refactor: dedup the list/show status+json option block into a helper

### DIFF
--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -3,6 +3,7 @@ import os
 import posixpath
 import re
 import stat
+from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import replace
 from typing import Final
@@ -373,11 +374,22 @@ def _collect_hunks(
     return hunks
 
 
+def _add_status_json_options(
+    command: Callable[..., None],
+) -> Callable[..., None]:
+    options = [
+        click.option("--staged", is_flag=True),
+        click.option("--unstaged", is_flag=True),
+        click.option("--json", "force_json", is_flag=True),
+        click.option("-h", "--help", "show_help", is_flag=True),
+    ]
+    for option in reversed(options):
+        command = option(command)
+    return command
+
+
 @cli.command("list", add_help_option=False)
-@click.option("--staged", is_flag=True)
-@click.option("--unstaged", is_flag=True)
-@click.option("--json", "force_json", is_flag=True)
-@click.option("-h", "--help", "show_help", is_flag=True)
+@_add_status_json_options
 @click.argument("files", nargs=-1)
 def cmd_list(
     staged: bool,
@@ -410,10 +422,7 @@ def cmd_list(
 
 
 @cli.command("show", add_help_option=False)
-@click.option("--staged", is_flag=True)
-@click.option("--unstaged", is_flag=True)
-@click.option("--json", "force_json", is_flag=True)
-@click.option("-h", "--help", "show_help", is_flag=True)
+@_add_status_json_options
 @click.argument("ids", nargs=-1)
 def cmd_show(
     staged: bool,


### PR DESCRIPTION
`cmd_list` and `cmd_show` carried a byte-for-byte identical stack of four
`click.option` decorators (`--staged`, `--unstaged`, `--json`, `-h/--help`).
Extract it into `_add_status_json_options` so the shared flag set lives in one
place. The options are applied in reversed order, which preserves the exact
click parameter order, so `--help` text and argument parsing are unchanged.

Scoped to `list`/`show` only. `stage`/`unstage`/`discard` share a *different*
five/six-option set (that duplication is a separate concern, cf. #106), and
`skills` shares only a subset, so neither is folded in here.

## Test plan
- [x] `uv run pytest -q` (264 passed)
- [x] `uv run ruff check` + `uv run ty check` clean
- [x] verified click param order is identical for both commands after the change
- [x] smoke: `list`, `list --json`, `list --staged`, `show <id>`, `list -h` all render as before
