### PR TITLE
docs: correct changelog to say the sdist ships no tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,8 @@ and this project adheres to
   renders verbatim instead of being swallowed as markup (#14).
 - Reject empty or whitespace-only hunk ids, and report malformed `-l` ranges
   with a readable error (#15).
-- Constrain the source distribution to the package, tests, and metadata so it
-  no longer ships unrelated `tmp/` files (#16).
+- Constrain the source distribution to the package and metadata so it no longer
+  ships unrelated `tmp/` files (#16).
 - Split the no-newline last line when partial line-staging (`-l`) gives it a
   trailing newline, so staging only the addition no longer merges it with the
   added line and corrupts the file (#54).


### PR DESCRIPTION
The `## [Unreleased]` entry for #16 claims the sdist was constrained to "the
package, tests, and metadata", but the source distribution has never shipped
tests: `[tool.hatch.build.targets.sdist]` in `pyproject.toml` whitelists only
`/README.md` and `/git_hunk`, and the commit that closed #16 (823a635) scoped
the tarball to "only git_hunk and README.md". This drops the inaccurate "tests"
so the changelog matches what the build actually produces.

## Test plan
- [x] `uv build --sdist` on this branch yields a tarball containing `git_hunk/`,
  `README.md`, and metadata only (no `tests/`)
