### PR TITLE
docs: correct that untracked entries carry no addressable hunk id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,5 +100,9 @@ and this project adheres to
 - Correct the skill guide and README's claim that a partially staged hunk's
   leftover keeps the same id, so the guide now says to re-run `git-hunk list` to
   get the leftover's new id (#149).
+- Correct the README JSON table and skill docs, which described every listed
+  hunk as carrying a usable `id`: an `untracked` entry's `id` is empty, so no
+  git-hunk command can address it, and plain `list` renders it as a bare path
+  (#162).
 
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD

--- a/README.md
+++ b/README.md
@@ -168,22 +168,22 @@ body; `show --json` adds a structured `lines` array. A `show --json` hunk
 }
 ```
 
-| Field            | Type           | Description                                                                                                  |
-| ---------------- | -------------- | ------------------------------------------------------------------------------------------------------------ |
-| `schema_version` | int            | Envelope version; bumped on any incompatible change to the shape below.                                      |
-| `hunks`          | array          | The hunks (empty array when there are no changes).                                                           |
-| `id`             | string         | Stable, content-based hunk id (7-char SHA-256 prefix); accepts prefixes.                                     |
-| `file`           | union          | Path of the changed file, as a byte-safe `{text\|bytes}` union (see below).                                  |
-| `status`         | string         | One of `staged`, `unstaged`, `untracked`.                                                                    |
-| `change_kind`    | string         | Git status letter: `A` added, `D` deleted, `M` modified, `T` typechange (`R`/`C` reserved). Always present.  |
-| `a_mode`         | string \| null | 6-digit octal git mode on the pre-image side; `null` when that side does not exist.                          |
-| `b_mode`         | string \| null | 6-digit octal git mode on the post-image side; `null` when that side does not exist.                         |
-| `binary`         | bool           | Whether the change is binary. Always present.                                                                |
-| `header`         | string \| null | The hunk's bare `@@ -a,b +c,d @@` range; `null` for a whole-file (binary, mode-only, or type) change.        |
-| `context_before` | union \| null  | The function/section git names after the `@@` header, as a `{text\|bytes}` union; `null` when there is none. |
-| `additions`      | int            | Number of added lines.                                                                                       |
-| `deletions`      | int            | Number of removed lines.                                                                                     |
-| `lines`          | array          | `show --json` only. The structured body; `[]` for a whole-file hunk. See below.                              |
+| Field            | Type           | Description                                                                                                                            |
+| ---------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `schema_version` | int            | Envelope version; bumped on any incompatible change to the shape below.                                                                |
+| `hunks`          | array          | The hunks (empty array when there are no changes).                                                                                     |
+| `id`             | string         | Stable, content-based hunk id (7-char SHA-256 prefix); accepts prefixes; empty for an `untracked` entry, which no command can address. |
+| `file`           | union          | Path of the changed file, as a byte-safe `{text\|bytes}` union (see below).                                                            |
+| `status`         | string         | One of `staged`, `unstaged`, `untracked`.                                                                                              |
+| `change_kind`    | string         | Git status letter: `A` added, `D` deleted, `M` modified, `T` typechange (`R`/`C` reserved). Always present.                            |
+| `a_mode`         | string \| null | 6-digit octal git mode on the pre-image side; `null` when that side does not exist.                                                    |
+| `b_mode`         | string \| null | 6-digit octal git mode on the post-image side; `null` when that side does not exist.                                                   |
+| `binary`         | bool           | Whether the change is binary. Always present.                                                                                          |
+| `header`         | string \| null | The hunk's bare `@@ -a,b +c,d @@` range; `null` for a whole-file (binary, mode-only, or type) change.                                  |
+| `context_before` | union \| null  | The function/section git names after the `@@` header, as a `{text\|bytes}` union; `null` when there is none.                           |
+| `additions`      | int            | Number of added lines.                                                                                                                 |
+| `deletions`      | int            | Number of removed lines.                                                                                                               |
+| `lines`          | array          | `show --json` only. The structured body; `[]` for a whole-file hunk. See below.                                                        |
 
 A `lines` entry is `{ "n", "op", "content", "no_newline"? }`:
 

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -159,11 +159,15 @@ git-hunk discard d161935 --dry-run   # preview the restore, change nothing
 ## Reading the output
 
 In `list` (see Quickstart), hunks group under `staged`, `unstaged`, and
-`untracked` (new files git isn't tracking yet). Each hunk line is `id`, the `@@`
-header with its enclosing context, then `+N -N`. A binary, mode-only, or type
-change has no `@@` line; it shows a `Binary file (modified|added|deleted)`,
-`Mode <old> -> <new>`, or `Type change (<old> -> <new>)` label instead and is
-staged whole (no `-l`).
+`untracked` (new files git isn't tracking yet). Each staged or unstaged hunk
+line is `id`, the `@@` header with its enclosing context, then `+N -N`. A binary,
+mode-only, or type change has no `@@` line; it shows a
+`Binary file (modified|added|deleted)`, `Mode <old> -> <new>`, or
+`Type change (<old> -> <new>)` label instead and is staged whole (no `-l`).
+
+The `untracked` group is inventory only: it lists bare paths, and an untracked
+file has no hunk id (`""` in `--json`), so no git-hunk command can address it.
+Stage those with `git add <file>`.
 
 ## Useful flags
 


### PR DESCRIPTION
`git-hunk list` groups changes under `staged`, `unstaged`, and `untracked`, but
only the first two are addressable. The docs did not say so:

- README's JSON field table described `id` as, unconditionally, a "stable,
  content-based hunk id ... accepts prefixes".
- SKILL.md's "Reading the output" introduced all three groups and then said
  "Each hunk line is `id`, the `@@` header with its enclosing context, then
  `+N -N`."

Untracked entries have none of that. `_get_untracked_entries` builds them with
`id=""`, `print_hunk_list` renders that group with `show_hunks=False` so only
bare paths print, and `stage`/`unstage`/`discard`/`commit` never load untracked
entries at all (they source hunks from `_get_hunks`, which is diff-based). So an
agent following the skill doc looks for an id that does not exist, then falls
back to the path and hits `error: no changed file matches '<path>'`. This
corrects both docs to describe the `untracked` group as inventory only and
points at `git add` as the way in.

Docs only -- no behavior change. Staging untracked files remains #22.

Deliberately out of scope: README's `header` row also lists only "(binary,
mode-only, or type)" as the causes of `null`, though untracked entries carry
`header: null` too. Adding "untracked" there would imply an untracked entry is a
whole-file hunk, which contradicts the `CONTEXT.md` glossary that #147 is
currently amending -- worth a separate look once #147 lands.

## Test plan
- [x] Verified all three claims against a scratch repo: plain `list` prints
      untracked entries as bare paths; `list --json` emits `"id": ""`; and
      `stage`/`unstage`/`discard`/`commit`/`show` all reject an untracked path
- [x] `make lint` (mdformat re-flowed the README table's column padding after
      the `id` cell grew)
