### PR TITLE
test: pin the CLI exit-code contract (2 usage, 1 domain)

### DIFF
--- a/tests/e2e/exit_code_test.py
+++ b/tests/e2e/exit_code_test.py
@@ -1,0 +1,66 @@
+import pytest
+
+from .conftest import GitHunkCLI
+
+
+@pytest.fixture
+def cli_with_change(cli: GitHunkCLI) -> GitHunkCLI:
+    cli.repo.write_file("f.py", "a\nb\nc\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "A\nb\nC\n")
+    return cli
+
+
+# A caller that got the invocation wrong exits 2 and is shown how to invoke it;
+# a caller that invoked correctly but named something unresolvable exits 1. The
+# two halves are one decision in CliGroup.invoke, so they are pinned together.
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("bogus",),
+        ("stage",),
+        ("stage", "--regex"),
+        ("stage", "-l", "1", "--include-matching", "x"),
+        ("commit", "f.py"),
+    ],
+    ids=[
+        "unknown-subcommand",
+        "stage-without-target",
+        "regex-without-pattern",
+        "conflicting-selectors",
+        "commit-without-message",
+    ],
+)
+def test_usage_error_exits_2_with_usage_block(
+    cli: GitHunkCLI, args: tuple[str, ...]
+) -> None:
+    # These are rejected before any repo lookup, so a bare repo is enough.
+    r = cli.run(*args)
+    assert r.returncode == 2
+    assert "Usage:" in r.stderr
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("stage", "deadbee"),
+        ("stage", ""),
+        ("show", ""),
+        ("stage", "f.py", "-l", "1-2-3"),
+    ],
+    ids=[
+        "unknown-hunk-id",
+        "empty-target",
+        "empty-id-on-show",
+        "malformed-line-spec",
+    ],
+)
+def test_domain_error_exits_1_without_usage_block(
+    cli_with_change: GitHunkCLI, args: tuple[str, ...]
+) -> None:
+    r = cli_with_change.run(*args)
+    assert r.returncode == 1
+    assert "Usage:" not in r.stderr


### PR DESCRIPTION
`CliGroup.invoke` exits 2 when a `CliError` carries a usage block and 1 when it
does not, so a scripted caller can tell "you invoked this wrong" from "what you
named does not resolve". Nothing outside `tests/e2e/skills_test.py` pinned that
split: every other error test asserted only `returncode != 0`, so collapsing the
branch to a single exit code would have passed CI.

The new test asserts both halves together, because the exit code and the presence
of the usage block are one decision in `_cli.py`. Each parametrized case reaches a
distinct `raise CliError(...)` site, so a raise site that silently loses its
`usage=` argument fails here too — which a unit test on the `ctx.exit(...)` line
alone would not catch.

Test-only; no production code and no user-facing behavior changes, so no CHANGELOG entry.

## Test plan
- [x] `make test` — 273 passed
- [x] `make lint` — clean
- [x] mutation check: replacing `ctx.exit(2 if exc.usage else 1)` with `ctx.exit(1)` fails 5 of the 9 new cases
