### PR TITLE
test: assert the success banners and empty-state lines the suite never checked

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -16,7 +16,9 @@ class GitHunkCLI:
         self.repo = repo
 
     def run(self, *args: str) -> subprocess.CompletedProcess[str]:
-        runner = CliRunner()
+        # rich sizes its output from COLUMNS; pin it so the lines tests assert
+        # verbatim do not wrap when the suite runs in a narrow terminal.
+        runner = CliRunner(env={"COLUMNS": "200"})
         old_cwd = os.getcwd()
         try:
             os.chdir(self.repo.path)

--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -221,6 +221,16 @@ def test_empty_new_file_is_not_a_bogus_mode_hunk(cli: GitHunkCLI) -> None:
     assert "Mode None" not in cli.run_ok("list", "--staged")
 
 
+def test_no_hunks_message_goes_to_stderr(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.py", "x\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    r = cli.run("list")
+    assert r.returncode == 0
+    assert "No hunks." in r.stderr
+
+
 def test_list_unstaged_filter(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "old\n")
     cli.repo.git("add", ".")

--- a/tests/e2e/show_test.py
+++ b/tests/e2e/show_test.py
@@ -92,6 +92,23 @@ def test_show_no_args_shows_all(cli: GitHunkCLI) -> None:
     assert "+unstaged" in r.stdout
 
 
+def test_show_excludes_untracked_files_that_list_includes(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("tracked.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("tracked.py", "new\n")
+    cli.repo.write_file("fresh.py", "fresh\n")
+
+    listed = cli.run_list_json("list", "--json")
+    untracked = [h for h in listed if h["status"] == "untracked"]
+    assert [h["file"]["text"] for h in untracked] == ["fresh.py"]
+
+    r = cli.run("show")
+    assert r.returncode == 0
+    assert "tracked.py" in r.stdout
+    assert "fresh.py" not in r.stdout
+
+
 def test_show_staged_and_unstaged_together_errors(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "old\n")
     cli.repo.git("add", ".")

--- a/tests/e2e/skills_test.py
+++ b/tests/e2e/skills_test.py
@@ -116,11 +116,13 @@ def test_list_rejects_arguments(cli: GitHunkCLI) -> None:
     assert "takes no arguments" in result.stderr
 
 
-def test_list_empty_skills_dir_exits_zero(
+def test_list_empty_skills_dir_exits_zero_and_says_no_skills(
     cli: GitHunkCLI, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("GIT_HUNK_SKILLS_DIR", str(tmp_path))
-    assert cli.run("skills", "list").returncode == 0
+    r = cli.run("skills", "list")
+    assert r.returncode == 0
+    assert "No skills." in r.stderr
     assert cli.run_json("skills", "list", "--json") == []
 
 

--- a/tests/e2e/success_banner_test.py
+++ b/tests/e2e/success_banner_test.py
@@ -1,0 +1,86 @@
+from collections.abc import Callable
+
+import pytest
+
+from .conftest import GitHunkCLI
+
+
+def _unstaged_hunk_id(cli: GitHunkCLI) -> str:
+    cli.repo.write_file("f.txt", "a\nb\nc\n")
+    cli.repo.git("add", "f.txt")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "aX\nb\nc\n")
+    return cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
+
+
+def _staged_hunk_id(cli: GitHunkCLI) -> str:
+    cli.run_ok("stage", _unstaged_hunk_id(cli))
+    return cli.run_list_json("list", "--staged", "--json")[0]["id"]
+
+
+def _two_unstaged_hunk_ids(cli: GitHunkCLI) -> list[str]:
+    cli.repo.write_file("a.txt", "a\n")
+    cli.repo.write_file("b.txt", "b\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("a.txt", "aX\n")
+    cli.repo.write_file("b.txt", "bX\n")
+    ids = [h["id"] for h in cli.run_list_json("list", "--unstaged", "--json")]
+    assert len(ids) == 2
+    return ids
+
+
+@pytest.mark.parametrize(
+    ("command", "verb", "make_hunk_id"),
+    [
+        ("stage", "staged", _unstaged_hunk_id),
+        ("unstage", "unstaged", _staged_hunk_id),
+        ("discard", "discarded", _unstaged_hunk_id),
+    ],
+    ids=["stage", "unstage", "discard"],
+)
+def test_banner_reports_verb_id_file_header_and_stats(
+    cli: GitHunkCLI,
+    command: str,
+    verb: str,
+    make_hunk_id: Callable[[GitHunkCLI], str],
+) -> None:
+    hunk_id = make_hunk_id(cli)
+    r = cli.run(command, hunk_id)
+    assert r.returncode == 0
+    assert r.stderr.splitlines() == [
+        f"  {verb} {hunk_id}  f.txt  @@ -1,3 +1,3 @@  +1 -1"
+    ]
+
+
+def test_banner_reports_one_line_per_selected_hunk(cli: GitHunkCLI) -> None:
+    ids = _two_unstaged_hunk_ids(cli)
+
+    r = cli.run("stage", *ids)
+    assert r.returncode == 0
+    assert r.stderr.splitlines() == [
+        f"  staged {ids[0]}  a.txt  @@ -1 +1 @@  +1 -1",
+        f"  staged {ids[1]}  b.txt  @@ -1 +1 @@  +1 -1",
+    ]
+
+
+def test_commit_banner_reports_singular_count_and_subject(cli: GitHunkCLI) -> None:
+    hunk_id = _unstaged_hunk_id(cli)
+    r = cli.run("commit", hunk_id, "-m", "fix: change a")
+    assert r.returncode == 0
+    assert r.stderr.splitlines() == ["  committed 1 hunk  fix: change a"]
+
+
+def test_commit_banner_reports_only_the_message_subject(cli: GitHunkCLI) -> None:
+    hunk_id = _unstaged_hunk_id(cli)
+    r = cli.run("commit", hunk_id, "-m", "fix: change a\n\nwhy a had to change\n")
+    assert r.returncode == 0
+    assert r.stderr.splitlines() == ["  committed 1 hunk  fix: change a"]
+
+
+def test_commit_banner_pluralizes_multiple_hunks(cli: GitHunkCLI) -> None:
+    ids = _two_unstaged_hunk_ids(cli)
+
+    r = cli.run("commit", *ids, "-m", "fix: change both")
+    assert r.returncode == 0
+    assert r.stderr.splitlines() == ["  committed 2 hunks  fix: change both"]


### PR DESCRIPTION
## Summary

Pins user-facing output contracts the suite already executed but never asserted, so a regression in any of them stayed green:

- The real (non-dry-run) `staged` / `unstaged` / `discarded` banners and the `committed N hunk[s] <subject>` banner, all on stderr. Only the `would ...` dry-run text was asserted before. The new tests pin the whole rendered line — indent, verb, hunk id, file, `@@` header, `+N -N` stats — one line per selected hunk, and the commit banner in the singular, plural, and multi-line-message (subject only) directions.
- The `No hunks.` and `No skills.` empty-state lines, both on stderr. `list_test.py::test_empty_new_file_is_not_a_bogus_mode_hunk` reached the `No hunks.` branch but asserted only on stdout, so it passed vacuously. Per the brief, the `No skills.` assertion extends the existing empty-skills-dir test rather than adding a duplicate scenario.
- That `show` omits untracked entries which `list` reports (`include_untracked=False` vs `True`). The precondition is checked through `list --json` carrying `"status": "untracked"`.

These are the suite's first verbatim full-line stderr assertions, and rich sizes its output from `COLUMNS`, so the banner lines wrapped and the tests failed under a narrow terminal. The first commit pins the e2e console width in `GitHunkCLI.run`, which keeps the exact assertions honest without weakening them.

No file under `git_hunk/` is modified, so there is no CHANGELOG entry (matching precedent for test-only changes).

Closes #166

## Mutation checks

Each assertion was mutation-checked: the corresponding string or branch was broken in the renderer, the affected test confirmed failing, then reverted. `git_hunk/` is unmodified at HEAD.

| # | Mutation | Result |
| --- | --- | --- |
| 1 | `print_applied`: swap hunk-id and file order | KILLED |
| 2 | `print_applied`: drop the `+N/-N` stats | KILLED |
| 3 | `print_applied`: uppercase the verb | KILLED |
| 4 | `print_committed`: drop the plural `s` | KILLED (pluralize test) |
| 5 | `print_committed`: rename `committed` to `commit` | KILLED (singular test) |
| 6 | `print_hunk_list`: silence `No hunks.` | KILLED |
| 7 | `print_skill_list`: silence `No skills.` | KILLED |
| 8 | `cmd_show`: `include_untracked=True` | KILLED |
| 9 | `print_applied`: report only the first hunk (`for hunk in hunks[:1]`) | KILLED (one-line-per-hunk test) |
| 10 | `print_committed`: use the whole message, not `splitlines()[0]` | KILLED (subject-only test) |
| 11 | `print_applied` / `print_committed`: drop the two-space indent | KILLED (all banner tests) |

Mutations 9 and 10 survived the whole suite before this round: nothing pinned the per-hunk banner loop or the subject extraction.

## Test plan

- [x] `uv run pytest -q` — 336 passed
- [x] `COLUMNS=40 uv run pytest -q` — 336 passed (3 banner tests failed here before the width pin)
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check` — clean
- [x] Each of the four commits independently green (lint, format, typecheck, full suite) in a detached checkout
- [x] Rebased on current `main`
