### PR TITLE
test: pin --dry-run on whole-file hunks for discard and unstage

### DIFF
--- a/tests/e2e/dry_run_test.py
+++ b/tests/e2e/dry_run_test.py
@@ -57,19 +57,47 @@ def test_dry_run_line_selection_changes_nothing(cli: GitHunkCLI) -> None:
     assert cli.repo.git("diff", "--cached").strip() == ""
 
 
-def test_stage_dry_run_leaves_binary_unstaged(cli: GitHunkCLI) -> None:
+def _setup_binary_modified(cli: GitHunkCLI) -> tuple[Path, str]:
     path = Path(cli.repo.path) / "a.bin"
     path.write_bytes(b"\x00\x01bin\xff")
     cli.repo.git("add", ".")
     cli.repo.git("commit", "-m", "init")
     path.write_bytes(b"\x00\x02BIN\xfe")
+    hunks = cli.run_list_json("list", "--unstaged", "--json")
+    assert len(hunks) == 1
+    return path, hunks[0]["id"]
 
-    hunk_id = cli.run_list_json("list", "--unstaged", "--json")[0]["id"]
+
+def test_stage_dry_run_leaves_binary_unstaged(cli: GitHunkCLI) -> None:
+    _, hunk_id = _setup_binary_modified(cli)
+
     r = cli.run("stage", hunk_id, "--dry-run")
     assert r.returncode == 0
     assert "would stage" in r.stderr
 
     assert cli.repo.git("diff", "--cached").strip() == ""
+
+
+def test_discard_dry_run_leaves_binary_in_working_tree(cli: GitHunkCLI) -> None:
+    path, hunk_id = _setup_binary_modified(cli)
+
+    r = cli.run("discard", hunk_id, "--dry-run")
+    assert r.returncode == 0
+    assert "would discard" in r.stderr
+
+    assert path.read_bytes() == b"\x00\x02BIN\xfe"
+
+
+def test_unstage_dry_run_leaves_binary_staged(cli: GitHunkCLI) -> None:
+    _, hunk_id = _setup_binary_modified(cli)
+    cli.run_ok("stage", hunk_id)
+    staged_id = cli.run_list_json("list", "--staged", "--json")[0]["id"]
+
+    r = cli.run("unstage", staged_id, "--dry-run")
+    assert r.returncode == 0
+    assert "would unstage" in r.stderr
+
+    assert cli.repo.git("diff", "--cached").strip() != ""
 
 
 def test_dry_run_unknown_id_exits_nonzero(cli: GitHunkCLI) -> None:


### PR DESCRIPTION
`_apply_selection` guards the whole-file (binary / mode-only / type-change) branch with a
single shared `if whole_file and not dry_run` (`git_hunk/_cli.py:268`), but only the
`stage` direction of that guard was ever asserted. A regression that dropped it for
`discard` would irreversibly overwrite binary working-tree content during a `--dry-run`
call, and the suite would stay green.

Extracts the binary arrange block into `_setup_binary_modified` (now shared by three
tests) and pins the `discard` and `unstage` directions.

## Test plan
- [x] tests added: `tests/e2e/dry_run_test.py`
- [x] mutation check: replacing the guard with `if whole_file:` fails all three whole-file dry-run tests, including both new ones
- [x] `make lint` and `uv run pytest` (266 passed)
