### PR TITLE
test: pin shared CLI guards for every verb that reaches them

### DIFF
--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -135,6 +135,40 @@ def test_empty_hunk_id_rejected(cli: GitHunkCLI) -> None:
     assert cli.repo.git("diff").strip() != ""
 
 
+@pytest.fixture
+def unstaged_change(cli: GitHunkCLI) -> GitHunkCLI:
+    cli.repo.write_file("f.py", "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.py", "new\n")
+    return cli
+
+
+# `stage`, `unstage`, `discard` and `commit` all resolve targets through the
+# same empty-argument guard, so each must refuse to touch its own state.
+def test_empty_hunk_id_rejected_on_stage(unstaged_change: GitHunkCLI) -> None:
+    r = unstaged_change.run("stage", "")
+    assert r.returncode != 0
+    assert "must not be empty" in r.stderr
+    assert unstaged_change.repo.git("diff", "--cached").strip() == ""
+
+
+def test_empty_hunk_id_rejected_on_unstage(unstaged_change: GitHunkCLI) -> None:
+    unstaged_change.repo.git("add", ".")
+    r = unstaged_change.run("unstage", "")
+    assert r.returncode != 0
+    assert "must not be empty" in r.stderr
+    assert unstaged_change.repo.git("diff", "--cached").strip() != ""
+
+
+def test_empty_hunk_id_rejected_on_commit(unstaged_change: GitHunkCLI) -> None:
+    head = unstaged_change.repo.git("rev-parse", "HEAD")
+    r = unstaged_change.run("commit", "-m", "msg", "")
+    assert r.returncode != 0
+    assert "must not be empty" in r.stderr
+    assert unstaged_change.repo.git("rev-parse", "HEAD") == head
+
+
 def test_empty_hunk_id_rejected_on_show(cli: GitHunkCLI) -> None:
     cli.repo.write_file("f.py", "old\n")
     cli.repo.git("add", ".")

--- a/tests/e2e/pattern_selection_test.py
+++ b/tests/e2e/pattern_selection_test.py
@@ -168,3 +168,40 @@ def test_empty_include_matching_is_rejected(added_lines: GitHunkCLI) -> None:
     assert r.returncode != 0
     assert "empty match pattern" in r.stderr
     assert added_lines.repo.git("show", ":f.txt") == "keep\n"
+
+
+# `stage`, `unstage` and `discard` share one selection-flag validator, so the
+# rejections above must hold for the reverse verbs too.
+_conflicting_flags = pytest.mark.parametrize(
+    "flags, message",
+    [
+        (["-l", "2", "--include-matching", "DEBUG"], "choose one of"),
+        (
+            ["--include-matching", "DEBUG", "--exclude-matching", "FEATURE"],
+            "choose one of",
+        ),
+        (["--regex"], "--regex requires"),
+    ],
+    ids=["line-spec-and-include", "include-and-exclude", "regex-alone"],
+)
+
+
+@_conflicting_flags
+def test_unstage_rejects_conflicting_selection_flags(
+    added_lines: GitHunkCLI, flags: list[str], message: str
+) -> None:
+    added_lines.run_ok("stage", _only_id(added_lines, "--unstaged"))
+    r = added_lines.run("unstage", _only_id(added_lines, "--staged"), *flags)
+    assert r.returncode != 0
+    assert message in r.stderr
+    assert added_lines.repo.git("show", ":f.txt") == "keep\nDEBUG line\nFEATURE line\n"
+
+
+@_conflicting_flags
+def test_discard_rejects_conflicting_selection_flags(
+    added_lines: GitHunkCLI, flags: list[str], message: str
+) -> None:
+    r = added_lines.run("discard", _only_id(added_lines, "--unstaged"), *flags)
+    assert r.returncode != 0
+    assert message in r.stderr
+    assert _working(added_lines) == "keep\nDEBUG line\nFEATURE line\n"


### PR DESCRIPTION
Two shared guards in `_cli.py` are reached by several verbs but were asserted
through only one verb each, so a regression on any other verb's path would have
gone unnoticed:

- `_build_selection`'s mutual-exclusion checks (`choose one of -l,
  --include-matching, or --exclude-matching`, and `--regex requires ...`):
  shared by `stage`, `unstage` and `discard`, asserted only via `stage`.
- `_select_hunks`' empty-argument guard (`hunk id or file path must not be
  empty or whitespace`): shared by `stage`, `unstage`, `discard` and `commit`,
  asserted only via `discard`.

Each new test pins both halves of the contract: the error is raised, and the
verb's own state is left untouched (index for `stage`/`unstage`, working tree
for `discard`, `HEAD` for `commit`).

One correction to the issue text: it lists `commit` as reaching the
mutual-exclusion guard, but `cmd_commit` builds its `_Selection` directly and
exposes no `-l`/`--include-matching`/`--exclude-matching`/`--regex` flags, so it
never calls `_build_selection`. That test is not writable, and its absence here
is deliberate.

No `CHANGELOG.md` entry: test-only, no user-facing change (matching #96).

Closes #170

## Test plan

- [x] Mutation-tested both guards: patching out `sum(mechanisms) > 1` fails all
  6 new `unstage`/`discard` cases, and removing the `not arg.strip()` check
  fails all 3 new `stage`/`unstage`/`commit` cases. Both reverted, suite green.
- [x] `uv run pytest -q`: 273 passed
- [x] `make lint`
- [x] Each commit independently lints, type-checks and passes the suite in a
  detached checkout
