### PR TITLE
test: pin list's plaintext untracked section as bare paths

### DIFF
--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -256,6 +256,23 @@ def test_list_plaintext_blank_lines_separate_sections_and_file_groups(
     assert "b.py" in blocks[2]
 
 
+def test_list_plaintext_untracked_section_lists_bare_paths(cli: GitHunkCLI) -> None:
+    # An untracked entry carries no addressable id, so its section is inventory
+    # only: one bare path per file, never a hunk line (which would render an
+    # empty id and a bogus "Mode None -> 100644" label).
+    cli.repo.write_file("f.py", "init\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    cli.repo.write_file("f.py", "changed\n")
+    cli.repo.write_file("untracked.py", "new\n")
+
+    blocks = cli.run_ok("list").strip("\n").split("\n\n")
+    assert len(blocks) == 2
+    assert blocks[0].startswith("unstaged:")
+    assert blocks[1].splitlines() == ["untracked:", "untracked.py"]
+
+
 def test_list_context_before_field_in_json_matches_display(cli: GitHunkCLI) -> None:
     body = ["def foo():"] + [f"    x{i} = {i}" for i in range(8)]
     cli.repo.write_file("f.py", "\n".join(body) + "\n")


### PR DESCRIPTION
`print_hunk_list` passes `show_hunks=False` for exactly one of its three sections
(untracked), which is why an untracked entry renders as a bare path instead of a
hunk line. That shape was unpinned: every untracked test reads `list --json`,
which bypasses this rendering path, and the one plaintext test that does reach it
(`markup_test.py::test_list_renders_bracketed_untracked_path_verbatim`) asserts
only that the path appears verbatim, not the section header, the bare-path-only
shape, or the absence of a hunk line.

Mutation-checked against the two ways the guard can break; both kept the full
suite green before this test:

1. `show_hunks=False` -> `True` for the untracked section: every untracked file
   gains a hunk line carrying an empty id and a bogus `Mode None -> 100644`
   label, since untracked entries have `id=""` and `a_mode=None`.
2. Renaming the `"untracked:"` section header: that string is unpinned, while
   `"staged:"` and `"unstaged:"` are already pinned by the sibling test directly
   above.

## Test plan

- [x] `uv run pytest -q`: 265 passed
- [x] both mutations above turn the new test red, then reverted
- [x] `make lint`
