### PR TITLE
test: pin _ui.py's untracked spacing and show's inter-hunk rule

### DIFF
--- a/tests/e2e/list_test.py
+++ b/tests/e2e/list_test.py
@@ -272,3 +272,20 @@ def test_list_context_before_field_in_json_matches_display(cli: GitHunkCLI) -> N
     assert hunks[0]["context_before"] == {"text": "def foo():"}
     # Parity: the field equals the function context shown in the human display.
     assert "def foo():" in cli.run_ok("list")
+
+
+def test_list_plaintext_untracked_paths_are_not_separated_by_blank_lines(
+    cli: GitHunkCLI,
+) -> None:
+    # The tracked sections put a blank line between file groups; the untracked
+    # section is a flat inventory instead, so its paths stay consecutive.
+    cli.repo.write_file("f.py", "init\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+
+    cli.repo.write_file("a.py", "new\n")
+    cli.repo.write_file("b.py", "new\n")
+
+    blocks = cli.run_ok("list").strip("\n").split("\n\n")
+    assert len(blocks) == 1
+    assert blocks[0].splitlines() == ["untracked:", "a.py", "b.py"]

--- a/tests/e2e/show_test.py
+++ b/tests/e2e/show_test.py
@@ -122,3 +122,24 @@ def test_show_renders_no_newline_marker_unnumbered(cli: GitHunkCLI) -> None:
     assert marker_line.strip() == NO_NEWLINE_MARKER
 
     assert "+cX" in r.stdout
+
+
+def test_show_puts_exactly_one_rule_between_consecutive_hunks(
+    cli: GitHunkCLI,
+) -> None:
+    # The rule divides hunks, so it appears between them and never leads the
+    # output: N hunks render N-1 rules. Three files rather than two, so that a
+    # rule firing once and never again stays distinguishable from the contract.
+    paths = ["a.py", "b.py", "c.py"]
+    for path in paths:
+        cli.repo.write_file(path, "old\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    for path in paths:
+        cli.repo.write_file(path, "new\n")
+
+    lines = cli.run_ok("show").splitlines()
+    rules = [i for i, line in enumerate(lines) if set(line.strip()) == {"─"}]
+    headers = [i for i, line in enumerate(lines) if line.split(" ")[0] in paths]
+    assert len(rules) == len(paths) - 1
+    assert headers[0] < rules[0] < headers[1] < rules[1] < headers[2]


### PR DESCRIPTION
Closes #174.

Follow-up to #173, which pinned the untracked section for a single file. Two
neighbouring branches of `_ui.py`'s plaintext render path were still executed by
the suite but never asserted, so either could be broken without turning a test
red:

- `_print_status_section`'s `show_hunks=False` branch emits no blank line between
  untracked paths, unlike the tracked branches that separate file groups. #173
  only exercised N=1, so the asymmetry was unpinned.
- `print_hunk_diffs`' inter-hunk rule could be deleted, doubled, moved before the
  first hunk, or reduced to a single rule after the first hunk with no test
  noticing.

The show test renders three hunks rather than two. At N=2 the contract "a rule
between each pair" is indistinguishable from "one rule, ever", so two files would
have reproduced the same N=1 blind spot this PR exists to close.

## Test plan
- [x] tests added: `tests/e2e/list_test.py`, `tests/e2e/show_test.py`
- [x] mutation-checked each guard against the full suite, each mutation failing only the new test:
  - untracked branch: adding a blank-line separator fails the list test
  - inter-hunk rule: deleting it, doubling it, moving it before the first hunk, or firing it only once (`if i == 1`) each fail the show test
- [x] `make test` (326 passed), `make lint`
