### PR TITLE
test: pin submodule gitlink pointer changes as patchable text hunks

### DIFF
--- a/tests/e2e/submodule_test.py
+++ b/tests/e2e/submodule_test.py
@@ -1,0 +1,79 @@
+import pytest
+
+from .conftest import GitHunkCLI
+
+
+def _bump_submodule(cli: GitHunkCLI, content: str) -> None:
+    cli.repo.write_file("sub/f", content)
+    cli.repo.git("-C", "sub", "add", "f")
+    cli.repo.git("-C", "sub", "commit", "-m", content)
+
+
+@pytest.fixture
+def bumped_submodule(cli: GitHunkCLI) -> GitHunkCLI:
+    # An embedded repository, not a .gitmodules-registered submodule: git records
+    # both as a mode 160000 gitlink and emits the same "Subproject commit" diff,
+    # and git-hunk never reads .gitmodules, so this skips `git submodule add` and
+    # the protocol.file.allow override a local-path submodule would need on CI.
+    cli.repo.git("init", "sub")
+    cli.repo.git("-C", "sub", "config", "user.email", "test@test.com")
+    cli.repo.git("-C", "sub", "config", "user.name", "Test")
+    _bump_submodule(cli, "one")
+    cli.repo.git("add", "sub")
+    cli.repo.git("commit", "-m", "init")
+    _bump_submodule(cli, "two")
+    return cli
+
+
+def test_list_reports_a_gitlink_bump_as_a_text_hunk(
+    bumped_submodule: GitHunkCLI,
+) -> None:
+    hunks = bumped_submodule.run_list_json("list", "--unstaged", "--json")
+    assert len(hunks) == 1
+    hunk = hunks[0]
+    assert hunk["file"]["text"] == "sub"
+    assert hunk["change_kind"] == "M"
+    assert hunk["a_mode"] == "160000"
+    assert hunk["b_mode"] == "160000"
+    # A moved submodule pointer is a one-line "Subproject commit" diff, so it is
+    # a patchable text hunk rather than a whole-file one despite the odd mode.
+    assert hunk["binary"] is False
+    assert hunk["header"] == "@@ -1 +1 @@"
+    assert hunk["additions"] == 1
+    assert hunk["deletions"] == 1
+
+
+def test_list_plaintext_gives_a_gitlink_no_whole_file_label(
+    bumped_submodule: GitHunkCLI,
+) -> None:
+    out = bumped_submodule.run_ok("list", "--unstaged")
+    assert "@@ -1 +1 @@" in out
+    # The whole-file labels are reserved for hunks with no @@ range; a gitlink
+    # bump has one, so it renders like any other text hunk.
+    assert "Mode " not in out
+    assert "Type change" not in out
+    assert "Binary file" not in out
+
+
+def test_show_renders_the_subproject_commit_body(
+    bumped_submodule: GitHunkCLI,
+) -> None:
+    hunks = bumped_submodule.run_list_json("list", "--unstaged", "--json")
+    assert len(hunks) == 1
+    out = bumped_submodule.run_ok("show", hunks[0]["id"])
+    assert "-Subproject commit " in out
+    assert "+Subproject commit " in out
+
+
+def test_stage_then_unstage_round_trips_a_gitlink_bump(
+    bumped_submodule: GitHunkCLI,
+) -> None:
+    cli = bumped_submodule
+    unstaged = cli.run_list_json("list", "--unstaged", "--json")
+    assert len(unstaged) == 1
+    cli.run_ok("stage", unstaged[0]["id"])
+    assert cli.repo.git("diff", "--cached", "--name-only").split() == ["sub"]
+    staged = cli.run_list_json("list", "--staged", "--json")
+    assert len(staged) == 1
+    cli.run_ok("unstage", staged[0]["id"])
+    assert cli.repo.git("diff", "--cached").strip() == ""


### PR DESCRIPTION
A moved submodule pointer reaches git-hunk as a one-line `Subproject commit` diff carrying mode `160000` on both sides. Nothing in the suite exercised a gitlink, so all of its handling was unasserted — and it is handled entirely by fallthrough: `git_hunk/_hunk.py` has no `160000` branch at all, so a gitlink lands in the ordinary text-hunk path only because `a_mode == b_mode` keeps it out of the whole-file (chmod) branch.

## Summary
- `list --json` reports `a_mode`/`b_mode` `"160000"`, `binary: false`, and a real `@@ -1 +1 @@` header, i.e. an ordinary text hunk rather than a whole-file hunk like a binary or mode-only change
- plaintext `list` renders it with no `Mode` / `Type change` / `Binary file` label, since those are reserved for hunks with no `@@` range
- `show` renders the `Subproject commit` body
- `stage` then `unstage` round-trips it cleanly

The fixture builds the gitlink with a nested `git init sub` plus one commit rather than `git submodule add`, so it needs no `.gitmodules` and no `protocol.file.allow=always` override that a local-path submodule would require on CI. git records both shapes as a mode `160000` gitlink and emits an identical diff, and git-hunk never reads `.gitmodules`.

## Test plan
- [x] tests added: `tests/e2e/submodule_test.py` (4 tests)
- [x] full suite green: 268 passed
- [x] `make lint` (ruff format/check, ty, taplo, mdformat, yamlfix, typos)
- [x] mutation-tested to confirm the tests are load-bearing, not vacuous: skipping `b_mode == "160000"` blocks in `parse_diff` fails exactly the 3 JSON/round-trip tests and nothing else; giving gitlinks a special label in `_ui._header_text` fails exactly the new plaintext test

## Follow-up (not addressed here)
Found while writing these tests, and left alone deliberately since it needs a product call: `git-hunk stage <gitlink-id> -l 1` leaks a raw git error rather than a clean `CliError`.

```console
$ git-hunk stage 2c987d7 -l 1
error: git apply --whitespace=nowarn --cached failed: error: corrupt patch for
submodule sub
```

Because a gitlink hunk has a non-empty `diff`, `_is_whole_file_hunk` is false, so `_apply_line_filter` lets `-l` through instead of raising the `"line selection is not supported for binary, mode, or type changes"` error that binary/mode/type hunks get. Whether `160000` should join that rejection list is a maintainer decision, so this PR neither fixes it nor pins the current behavior as correct.
