### PR TITLE
test: ignore an inherited git environment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,20 @@ class GitRepo:
         return filepath
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _scrubbed_git_env() -> Generator[None]:
+    # git exports GIT_DIR, GIT_INDEX_FILE, and friends to the commands it runs:
+    # `rebase --exec`, hooks, `filter-branch`, `bisect run`. Those beat cwd, so
+    # every git subprocess the suite starts (the fixtures' own, and the ones
+    # git_hunk spawns) would target the outer repository instead of the
+    # temporary one, and the tests would commit into the repository under test.
+    # Nothing here wants an inherited git environment, so drop all of it.
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        for name in [n for n in os.environ if n.startswith("GIT_")]:
+            monkeypatch.delenv(name)
+        yield
+
+
 @pytest.fixture
 def git_repo() -> Generator[GitRepo]:
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import tempfile
 from collections.abc import Generator
+from typing import Final
 
 import pytest
 
@@ -41,10 +42,14 @@ def _scrubbed_git_env() -> Generator[None]:
     # every git subprocess the suite starts (the fixtures' own, and the ones
     # git_hunk spawns) would target the outer repository instead of the
     # temporary one, and the tests would commit into the repository under test.
-    # Nothing here wants an inherited git environment, so drop all of it.
+    # Drop all of it, except the config overrides a caller may set to shield
+    # the suite from the machine's gitconfig (e.g. GIT_CONFIG_GLOBAL=/dev/null
+    # in CI); those improve hermeticity rather than break it.
+    KEEP: Final = {"GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM"}
     with pytest.MonkeyPatch.context() as monkeypatch:
-        for name in [n for n in os.environ if n.startswith("GIT_")]:
-            monkeypatch.delenv(name)
+        for name in list(os.environ):
+            if name.startswith("GIT_") and name not in KEEP:
+                monkeypatch.delenv(name)
         yield
 
 

--- a/tests/git_env_test.py
+++ b/tests/git_env_test.py
@@ -7,10 +7,9 @@ from pathlib import Path
 def test_suite_ignores_an_inherited_git_environment(tmp_path: Path) -> None:
     """The suite must not write to whatever repository GIT_DIR names.
 
-    `git rebase --exec`, hooks, `filter-branch`, and `bisect run` all export
-    GIT_DIR and GIT_INDEX_FILE to the command they run. Those beat cwd, so a
-    suite that inherited them would commit into the repository under test.
-    Point them at a decoy repository and assert it stays empty.
+    Point GIT_DIR and friends at a decoy repository, run a slice of the suite,
+    and assert the decoy stays empty. `_scrubbed_git_env` in conftest.py
+    explains why the scrub exists.
     """
     decoy = tmp_path / "decoy"
     decoy.mkdir()

--- a/tests/git_env_test.py
+++ b/tests/git_env_test.py
@@ -40,9 +40,10 @@ def test_suite_ignores_an_inherited_git_environment(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
 
-    decoy_log = subprocess.run(
-        ["git", "-C", str(decoy), "log", "--oneline"],
+    decoy_commits = subprocess.run(
+        ["git", "-C", str(decoy), "rev-list", "--all", "--count"],
         capture_output=True,
         text=True,
+        check=True,
     )
-    assert decoy_log.stdout == ""
+    assert decoy_commits.stdout.strip() == "0"

--- a/tests/git_env_test.py
+++ b/tests/git_env_test.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_suite_ignores_an_inherited_git_environment(tmp_path: Path) -> None:
+    """The suite must not write to whatever repository GIT_DIR names.
+
+    `git rebase --exec`, hooks, `filter-branch`, and `bisect run` all export
+    GIT_DIR and GIT_INDEX_FILE to the command they run. Those beat cwd, so a
+    suite that inherited them would commit into the repository under test.
+    Point them at a decoy repository and assert it stays empty.
+    """
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=decoy, check=True)
+
+    repo_root = Path(__file__).resolve().parent.parent
+    env = dict(os.environ)
+    env["GIT_DIR"] = str(decoy / ".git")
+    env["GIT_INDEX_FILE"] = str(decoy / ".git" / "index")
+    env["GIT_WORK_TREE"] = str(decoy)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/e2e/stage_test.py",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    decoy_log = subprocess.run(
+        ["git", "-C", str(decoy), "log", "--oneline"],
+        capture_output=True,
+        text=True,
+    )
+    assert decoy_log.stdout == ""


### PR DESCRIPTION
Running the suite from inside `git rebase --exec` commits each fixture's setup
into the repository under test. I hit this verifying a branch commit-by-commit;
it injected ~56 fixture commits before the rebase aborted.

`GitRepo.run` passes `cwd=`, but git exports `GIT_DIR` and `GIT_INDEX_FILE` to
the commands it runs, and those beat `cwd`. Hooks, `filter-branch`, and
`bisect run` export them too.

Two non-obvious bits:

1. The scrub is session-scoped rather than a per-call `env=` on `GitRepo.run`,
   because the leak also reaches the git subprocesses `git_hunk` itself spawns.
   Fixing it at the fixture would have meant threading an env through
   production code for a test concern.

2. It drops all of `GIT_*` rather than a denylist; a denylist misses
   `GIT_OBJECT_DIRECTORY`, `GIT_COMMON_DIR`, `GIT_NAMESPACE`, and the
   `GIT_AUTHOR_*` / `GIT_COMMITTER_*` values `rebase` also exports. The one
   exception is the config overrides a caller may set to shield the suite from
   the machine's gitconfig (`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM`,
   `GIT_CONFIG_NOSYSTEM`); those improve hermeticity, so the scrub keeps them.

`tests/git_env_test.py` points a decoy `GIT_DIR` at a throwaway repo and asserts
its commit count stays zero (`git rev-list --all --count`, which also exits
non-zero if the decoy path is wrong). A bare "no `GIT_*` in `os.environ`"
assertion would have passed in a normal local run and given a false green.

## Test plan

- [x] `git rebase --exec 'make test' main` completes clean at every commit, HEAD unchanged
- [x] full suite under poisoned `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE`:
      358 passed, repository untouched
- [x] suite passes with `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_NOSYSTEM=1`
      kept through the scrub, decoy `GIT_DIR` still dropped
- [x] regression test fails with the fixture removed
- [x] `make test` (358 passed) and `make lint`
