### PR TITLE
docs: distinguish untracked inventory entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,8 @@ and this project adheres to
   hunk as carrying a usable `id`: an `untracked` entry's `id` is empty, so no
   git-hunk command can address it, and plain `list` renders it as a bare path
   (#162).
+- Document that an `untracked` inventory entry has `header: null` and
+  `context_before: null` without classifying it as a whole-file hunk (#202).
 - Report untracked files with Repository paths, matching tracked Hunks,
   so running `git-hunk` from a subdirectory no longer emits an untracked `file`
   on a different path basis than the staged/unstaged hunks beside it (#103).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,6 +13,9 @@
   hunk** with no `@@` range. It is the top-level object in `--json` because the tool is
   hunk-centric, not file-centric.
 
+- **Untracked inventory entry**: a record for an untracked file in `list` output. It
+  is not a Hunk and has no Hunk ID, so no git-hunk command can address it.
+
 - **Hunk ID**: The deterministic address of one Hunk in the combined staged and
   unstaged inventory.
 
@@ -32,7 +35,7 @@
   deletions, and one-for-one replacements. A larger grouped replacement is selected
   as a whole or not selected.
 
-- **Whole-file hunk**: a hunk with no `@@` text range: a binary change, a mode-only
+- **Whole-file hunk**: a tracked Hunk with no `@@` text range: a binary change, a mode-only
   (chmod) change, a type change (e.g. file to symlink), or an empty tracked addition
   or deletion. Has `header: null` and, in `show --json`, `lines: []`.
 
@@ -46,13 +49,14 @@
   A mode change is `a_mode != b_mode`.
 
 - **header** — for a text hunk, the **bare** `@@ -a,b +c,d @@` range, with git's trailing
-  section heading stripped. `null` for a whole-file hunk. Distinct from the internal
-  patch text, which keeps git's full `@@` line verbatim.
+  section heading stripped. `null` for a whole-file hunk or an untracked inventory
+  entry. Distinct from the internal patch text, which keeps git's full `@@` line
+  verbatim.
 
 - **context_before** — the function/section heading git appends after the `@@` range
   (e.g. `def foo():`). The single source of that heading (it is *not* duplicated into
-  `header`). `null` when the hunk has no heading (absence is uniformly `null`, like
-  `header`).
+  `header`). `null` for a text hunk without a heading, a whole-file hunk, or an
+  untracked inventory entry (absence is uniformly `null`, like `header`).
 
 - **lines[]** (`show --json` only) — the structured per-line hunk body. Each entry is
   `{n, op, content, no_newline?}`. `list --json` carries no body (it is an inventory view).

--- a/README.md
+++ b/README.md
@@ -226,23 +226,23 @@ body; `show --json` adds a structured `lines` array. A `show --json` hunk
 }
 ```
 
-| Field            | Type           | Description                                                                                                                                                   |
-| ---------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `schema_version` | int            | Envelope version; bumped on any incompatible change to the shape below.                                                                                       |
-| `hunks`          | array          | The hunks (empty array when there are no changes).                                                                                                            |
-| `id`             | string         | Full canonical SHA-256 Hunk ID; empty for an `untracked` entry, which no command can address. Human output uses a unique prefix of at least seven characters. |
-| `id_stability`   | string         | `stable` or `conditional`. An untracked inventory entry reports `stable`, but its empty `id` remains unaddressable.                                           |
-| `file`           | union          | Repository path of the changed file, as a byte-safe `{text\|bytes}` union (see below).                                                                        |
-| `status`         | string         | One of `staged`, `unstaged`, `untracked`.                                                                                                                     |
-| `change_kind`    | string         | Git status letter: `A` added, `D` deleted, `M` modified, `T` typechange (`R`/`C` reserved and currently rejected). Always present.                            |
-| `a_mode`         | string \| null | 6-digit octal git mode on the pre-image side; `null` when that side does not exist.                                                                           |
-| `b_mode`         | string \| null | 6-digit octal git mode on the post-image side; `null` when that side does not exist.                                                                          |
-| `binary`         | bool           | Whether the change is binary. Always present.                                                                                                                 |
-| `header`         | string \| null | The hunk's bare `@@ -a,b +c,d @@` range; `null` for a whole-file (binary, mode-only, type, or empty tracked file) change.                                     |
-| `context_before` | union \| null  | The function/section git names after the `@@` header, as a `{text\|bytes}` union; `null` when there is none.                                                  |
-| `additions`      | int            | Number of added lines.                                                                                                                                        |
-| `deletions`      | int            | Number of removed lines.                                                                                                                                      |
-| `lines`          | array          | `show --json` only. The structured body; `[]` for a whole-file hunk. See below.                                                                               |
+| Field            | Type           | Description                                                                                                                                                                            |
+| ---------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schema_version` | int            | Envelope version; bumped on any incompatible change to the shape below.                                                                                                                |
+| `hunks`          | array          | The hunks (empty array when there are no changes).                                                                                                                                     |
+| `id`             | string         | Full canonical SHA-256 Hunk ID; empty for an `untracked` entry, which no command can address. Human output uses a unique prefix of at least seven characters.                          |
+| `id_stability`   | string         | `stable` or `conditional`. An untracked inventory entry reports `stable`, but its empty `id` remains unaddressable.                                                                    |
+| `file`           | union          | Repository path of the changed file, as a byte-safe `{text\|bytes}` union (see below).                                                                                                 |
+| `status`         | string         | One of `staged`, `unstaged`, `untracked`.                                                                                                                                              |
+| `change_kind`    | string         | Git status letter: `A` added, `D` deleted, `M` modified, `T` typechange (`R`/`C` reserved and currently rejected). Always present.                                                     |
+| `a_mode`         | string \| null | 6-digit octal git mode on the pre-image side; `null` when that side does not exist.                                                                                                    |
+| `b_mode`         | string \| null | 6-digit octal git mode on the post-image side; `null` when that side does not exist.                                                                                                   |
+| `binary`         | bool           | Whether the change is binary. Always present.                                                                                                                                          |
+| `header`         | string \| null | The bare `@@ -a,b +c,d @@` range for a text hunk; `null` for a whole-file hunk (binary, mode-only, type, or empty tracked file change) or an `untracked` inventory entry.              |
+| `context_before` | union \| null  | The function/section name after a text hunk's `@@` header, as a `{text\|bytes}` union; `null` for a text hunk without a heading, a whole-file hunk, or an `untracked` inventory entry. |
+| `additions`      | int            | Number of added lines.                                                                                                                                                                 |
+| `deletions`      | int            | Number of removed lines.                                                                                                                                                               |
+| `lines`          | array          | `show --json` only. The structured body; `[]` for a whole-file hunk. See below.                                                                                                        |
 
 A `lines` entry is `{ "n", "op", "content", "no_newline"? }`:
 


### PR DESCRIPTION
> *This was generated by AI.*

Closes #163. The JSON schema table documented `header: null` only for whole-file hunks, but untracked inventory entries also use `null` and have no addressable Hunk ID. This keeps whole-file hunk as the tracked, addressable term and documents the untracked case separately.

## Test plan

- [x] `uv run mdformat --check CONTEXT.md README.md`; `uv run typos CONTEXT.md README.md`; focused JSON tests (`41 passed`)
