### PR TITLE
feat: add make eval target and fix eval preflight pycache failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifneq ($(OS),Windows_NT)
 	SHELL := bash
 endif
 
-.PHONY: help setup format lint test coverage
+.PHONY: help setup format lint test coverage eval
 .DEFAULT_GOAL := help
 
 PYTEST_ARGS ?= --numprocesses=auto
@@ -39,3 +39,10 @@ test:  # Run tests
 
 coverage:  # Run tests with coverage
 	$(MAKE) test PYTEST_ARGS="--cov=git_hunk --cov-report=term-missing"
+
+eval:  # Run the agent eval with pinned Claude Code (spends real model usage)
+	@set -eu; \
+	pin=$$(uv run --no-sync python -c "from eval.config import CLAUDE_CODE_VERSION; print(CLAUDE_CODE_VERSION)"); \
+	prefix="$$HOME/.cache/git-hunk/claude-$$pin"; \
+	test -x "$$prefix/node_modules/.bin/claude" || npm install --prefix "$$prefix" "@anthropic-ai/claude-code@$$pin"; \
+	PATH="$$prefix/node_modules/.bin:$$PATH" uv run python -m eval $(EVAL_ARGS)


### PR DESCRIPTION
> *This was generated by AI.*

Running the eval on a fresh machine failed before the model phase: the preflight saw `__pycache__` as untracked because only the global gitconfig ignored it (#206), and the Claude Code 2.1.222 pin required a manual `npm install` plus PATH setup. The `__pycache__/` gitignore rule landed on `main` directly (c794cba). This PR adds the `make eval` target: it reads the pin from `eval/config.py`, installs that version once under `~/.cache/git-hunk/`, and runs `python -m eval` with it on PATH. The recipe starts with `set -eu` so a failed pin read aborts instead of letting `npm install` fall back to an unpinned latest.

`make eval EVAL_ARGS="--task drop_debug_lines"` runs a single-task smoke; plain `make eval` runs the full qualifying set.

## Test plan

- [x] `make eval EVAL_ARGS=--help` resolves the pin, reuses the cached install under `~/.cache/git-hunk/claude-2.1.222`, and reaches the runner
- [x] pinned `claude --version` reports `2.1.222 (Claude Code)`
- [x] simulated pin-read failure aborts the recipe before `npm install` runs
- [x] `make lint` and `make test` (696 passed)

Closes #206
