### PR TITLE
chore: run eval with Sonnet 5 on latest Claude Code

### DIFF
--- a/eval/config.py
+++ b/eval/config.py
@@ -1,7 +1,7 @@
 from typing import Final
 
-CLAUDE_CODE_VERSION: Final = "2.1.222"
-MODEL: Final = "claude-opus-4-8"
+CLAUDE_CODE_VERSION: Final = "2.1.224"
+MODEL: Final = "claude-sonnet-5"
 TASK_SCHEMA_VERSION: Final = 1
 TASK_NAMES: Final = (
     "split_refactor_vs_feature",

--- a/tests/eval/environment_test.py
+++ b/tests/eval/environment_test.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from eval.config import CLAUDE_CODE_VERSION
 from eval.environment import _require_current_skill
 from eval.environment import _run
 from eval.environment import require_claude_version
@@ -10,12 +11,12 @@ from eval.repo import init_repo
 
 
 def test_accepts_exact_claude_code_version() -> None:
-    require_claude_version(version_output="2.1.222 (Claude Code)")
+    require_claude_version(version_output=f"{CLAUDE_CODE_VERSION} (Claude Code)")
 
 
 def test_rejects_claude_code_version_mismatch() -> None:
-    with pytest.raises(RuntimeError, match="must be 2.1.222"):
-        require_claude_version(version_output="2.1.223 (Claude Code)")
+    with pytest.raises(RuntimeError, match="must be "):
+        require_claude_version(version_output="0.0.0 (Claude Code)")
 
 
 def test_git_commands_ignore_inherited_repository(

--- a/tests/eval/model_test.py
+++ b/tests/eval/model_test.py
@@ -6,7 +6,6 @@ from typing import NoReturn
 
 import pytest
 
-from eval.config import CLAUDE_CODE_VERSION
 from eval.config import MODEL
 from eval.model import build_command
 from eval.model import build_prompt
@@ -59,11 +58,6 @@ def _write_trace(*, trace_path: Path, events: list[dict[str, Any]]) -> None:
         "".join(f"{json.dumps(event)}\n" for event in events),
         encoding="utf-8",
     )
-
-
-def test_model_pins_are_exact() -> None:
-    assert CLAUDE_CODE_VERSION == "2.1.222"
-    assert MODEL == "claude-opus-4-8"
 
 
 def test_prompt_loads_both_bundled_skills() -> None:


### PR DESCRIPTION
Swaps the agent eval model from Opus 4.8 to Sonnet 5 (`claude-sonnet-5`) and bumps the pinned Claude Code install to 2.1.224, the latest release on npm.

Also removes `test_model_pins_are_exact`, a change-detector that only mirrored the config constants, and rewrites the `require_claude_version` tests against `CLAUDE_CODE_VERSION` so future pin bumps no longer break tests.

## Test plan
- [x] `make eval` — qualifying run, 4/4 tasks passed in 98s total (split_refactor_vs_feature 23s, separate_mixed_hunks 18s, drop_debug_lines 21s, protect_unrelated_work 36s)
- [x] `uv run pytest tests/eval/` — 53 passed