### PR TITLE
refactor: write agent eval runs to temp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ __pycache__/
 
 # Tools
 /.claude/
-/log/
 
 # Worktrees
 /.wt/

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -92,8 +92,8 @@ grader.
 
 `eval/config.py` contains the two pins:
 
-- Claude Code `2.1.222`
-- Model `claude-opus-4-8`
+- Claude Code `2.1.224`
+- Model `claude-sonnet-5`
 
 The runner has no model override. It rejects a Claude Code version mismatch
 before it builds a task. It also requires the reported stream model to match the

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -21,11 +21,12 @@ semantics and ADR 0003 for durable Hunk identity.
 
 ## Decision
 
-### Keep the evaluation in the repository
+### Keep the evaluation code in the repository
 
 The evaluation code is in `eval/`. Its deterministic tests are in
-`tests/eval/`. Raw model runs are in the ignored
-`log/agent-eval/<run-id>/` directory.
+`tests/eval/`. Each raw model run is in a unique system temporary directory.
+Its name includes the UTC start time and Git commit. The evaluator prints the
+path and leaves the directory available for diagnosis.
 
 The installed package has no eval entry point or runtime dependency. A package
 content test builds the wheel and source distribution. It requires both
@@ -129,6 +130,8 @@ after all deterministic, lint, package, and pinned model gates pass.
 ## Consequences
 
 - Normal tests stay deterministic and model-free.
+- Raw model runs do not modify the checkout. Their temporary directories are
+  diagnostic data, not durable evidence.
 - Release artifacts cannot include evaluator code or run data.
 - A line-set collision cannot hide an incorrect final tree.
 - Staged, tracked, and untracked leftovers have separate diagnoses.

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -3,8 +3,8 @@ import datetime
 import hashlib
 import json
 import sys
+import tempfile
 import time
-import uuid
 from pathlib import Path
 from typing import Any
 
@@ -60,9 +60,10 @@ def _run_scenarios(
 ) -> int:
     started_at = datetime.datetime.now(datetime.timezone.utc)
     started_clock = time.monotonic()
-    run_id = _make_run_id(started_at=started_at, commit=environment.commit)
-    run_dir = environment.checkout / "log" / "agent-eval" / run_id
-    run_dir.mkdir(parents=True)
+    run_directory_prefix = (
+        f"git-hunk-agent-eval-{started_at:%Y%m%dT%H%M%SZ}-{environment.commit[:7]}-"
+    )
+    run_dir = Path(tempfile.mkdtemp(prefix=run_directory_prefix))
     results: list[tuple[Scenario, Result, Path]] = []
 
     for index, scenario in enumerate(scenarios, start=1):
@@ -165,12 +166,6 @@ def _is_run_qualifying(
     results: tuple[Result, ...],
 ) -> bool:
     return not selected_run and complete and all(result.passed for result in results)
-
-
-def _make_run_id(*, started_at: datetime.datetime, commit: str) -> str:
-    timestamp = started_at.strftime("%Y%m%dT%H%M%SZ")
-    suffix = uuid.uuid4().hex[:8]
-    return f"{timestamp}-{commit[:7]}-{suffix}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> *This was generated by AI.*

Raw evaluator traces are diagnostic artifacts, so they should not affect repository cleanliness or require a project ignore rule. The evaluator now leaves each run in a unique system temporary directory and continues to print its path for inspection.

The ADR also records the current Claude Code and model pins.

## Test plan

- [x] `make lint`
- [x] `make test PYTEST_ARGS=-q` (695 passed)