### PR TITLE
feat: select commit lines by matching content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
   (literal substring by default, `--regex` for regular expressions; repeatable
   and OR'd), so an agent can drop a line by what it contains without a
   `show` round trip (#55).
+- `--include-matching` / `--exclude-matching` and `--regex` for `commit`, so an
+  agent can commit a content-selected part of one Hunk without a separate
+  staging command (#214).
 - `logical-commits` skill (`git-hunk skills get logical-commits`) covering how
   to group hunks into logical commits and order them so each is independently
   valid, kept separate from `core` so a project that already defines its own

--- a/README.md
+++ b/README.md
@@ -183,10 +183,12 @@ change, and selecting the mode Hunk does not apply text.
 ```bash
 git-hunk commit d161935 -m "fix: ..."      # stage a hunk and commit it in one step
 git-hunk commit d161935 -l 3,5-7 -m "..."  # stage specific lines and commit
+git-hunk commit d161935 --exclude-matching debug -m "..."  # commit all but matching lines
 ```
 
 `commit` aborts if anything is already staged, so the commit contains exactly
-the selected hunks.
+the selected hunks. It accepts the same `-l`, `--include-matching`,
+`--exclude-matching`, and `--regex` selection options as `stage`.
 
 ### JSON output
 

--- a/eval/tasks/drop_debug_lines.py
+++ b/eval/tasks/drop_debug_lines.py
@@ -38,12 +38,13 @@ def _commit_without_debug(repo: GitRepo) -> None:
     (hunk,) = list_hunks(repo, "a.py")
     run_git_hunk(
         repo,
-        "stage",
+        "commit",
         str(hunk["id"]),
         "--exclude-matching",
         DEBUG,
+        "-m",
+        "Double item totals",
     )
-    repo.git("commit", "-m", "Double item totals")
 
 
 def _golden(repo: GitRepo) -> None:

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -784,12 +784,18 @@ def cmd_discard(
 @cli.command("commit", add_help_option=False)
 @click.option("-m", "message", default=None)
 @click.option("-l", "line_spec", default=None)
+@click.option("--include-matching", "include_matching", multiple=True)
+@click.option("--exclude-matching", "exclude_matching", multiple=True)
+@click.option("--regex", "use_regex", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("targets", nargs=-1)
 def cmd_commit(
     targets: tuple[str, ...],
     message: str | None,
     line_spec: str | None,
+    include_matching: tuple[str, ...],
+    exclude_matching: tuple[str, ...],
+    use_regex: bool,
     show_help: bool,
 ) -> None:
     if show_help:
@@ -812,8 +818,12 @@ def cmd_commit(
             tip="commit them with 'git commit', or unstage with 'git-hunk unstage'",
         )
 
-    selection = _Selection(
-        line_spec=line_spec, include_matching=(), exclude_matching=(), regex=False
+    selection = _build_selection(
+        line_spec,
+        include_matching,
+        exclude_matching,
+        use_regex,
+        usage=USAGE_COMMIT,
     )
     selected = _apply_selection(
         commit_targets,

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -235,12 +235,6 @@ def print_version(version: str) -> None:
 _LINE_SELECT_EXAMPLE = """\
              e.g.: -l 3,5-7  (include)   -l ^3,^5-7  (exclude)"""
 
-# `commit` accepts -l as its only line-selection option, so the constraint rides
-# on the -l row itself; the multi-option block below states it once for the group.
-_LINE_SELECT_ROW = f"""\
-  [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk (requires exactly one hunk)
-{_LINE_SELECT_EXAMPLE}"""  # noqa: E501
-
 _LINE_OPT_ROW = f"""\
   [bold cyan]-l[/bold cyan] [cyan]<lines>[/cyan]  Select specific lines within a hunk
 {_LINE_SELECT_EXAMPLE}
@@ -322,6 +316,10 @@ _EXAMPLES_DISCARD: Final = [
 _EXAMPLES_COMMIT: Final = [
     ('git-hunk commit d161935 -m "fix: ..."', "Stage a hunk and commit it"),
     ('git-hunk commit src/foo.py -m "..."', "Commit every hunk in one Repository path"),
+    (
+        'git-hunk commit d161935 --exclude-matching debug -m "fix: ..."',
+        "Commit all but matching lines",
+    ),
 ]
 _EXAMPLES_SKILLS: Final = [
     ("git-hunk skills", "List available skills"),
@@ -433,7 +431,7 @@ can retry with [bold cyan]git commit[/bold cyan].
 
 [bold green]Options:[/bold green]
   [bold cyan]-m[/bold cyan] [cyan]<msg>[/cyan]    Commit message (required)
-{_LINE_SELECT_ROW}
+{_LINE_OPT_ROW}
 
 {_format_examples(_EXAMPLES_COMMIT)}"""  # noqa: E501
 

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -139,13 +139,12 @@ The default case. `list` to see everything, plan groups, `stage` + `commit` each
 
 ### Surgically drop debug lines
 
-Stage a hunk but leave its debug lines behind, then discard them:
+Commit a hunk but leave its debug lines behind, then discard them:
 
 ```bash
-git-hunk show d161935               # find the debug line numbers
-git-hunk stage d161935 -l ^4        # stage all but the debug line on line 4
-git-hunk list                        # get the remainder's new ID
-git-hunk discard b8e210a -l 4       # restore that line from the index
+git-hunk commit d161935 --exclude-matching 'print("DEBUG"' -m "fix total"
+git-hunk list                  # get the remainder's new ID
+git-hunk discard b8e210a       # restore that line from the index
 ```
 
 ### Separate a refactor from a feature

--- a/tests/e2e/commit_test.py
+++ b/tests/e2e/commit_test.py
@@ -61,6 +61,51 @@ def test_commit_partial_lines_leaves_remainder_unstaged(cli: GitHunkCLI) -> None
     assert "cX" in cli.repo.git("diff")
 
 
+def test_commit_exclude_matching_leaves_remainder_unstaged(cli: GitHunkCLI) -> None:
+    _init(
+        cli,
+        {
+            "f.py": (
+                "def process(items):\n"
+                "    total = 0\n"
+                "    for item in items:\n"
+                "        total += item\n"
+                "    return total\n"
+            )
+        },
+    )
+    cli.repo.write_file(
+        "f.py",
+        (
+            "def process(items):\n"
+            "    total = 0\n"
+            "    for item in items:\n"
+            '        print("DEBUG", item)\n'
+            "        total += item\n"
+            "    return total * 2\n"
+        ),
+    )
+
+    cli.run_ok(
+        "commit",
+        _unstaged_ids(cli)[0],
+        "--exclude-matching",
+        'print("DEBUG"',
+        "-m",
+        "Double item totals",
+    )
+
+    assert cli.repo.git("show", "HEAD:f.py") == (
+        "def process(items):\n"
+        "    total = 0\n"
+        "    for item in items:\n"
+        "        total += item\n"
+        "    return total * 2\n"
+    )
+    assert cli.repo.git("diff", "--cached") == ""
+    assert 'print("DEBUG", item)' in cli.repo.git("diff")
+
+
 def test_commit_by_file_path(cli: GitHunkCLI) -> None:
     _init(cli, {"a.txt": "a\n", "b.txt": "b\n"})
     cli.repo.write_file("a.txt", "A1\nA2\nA3\n")

--- a/tests/e2e/error_test.py
+++ b/tests/e2e/error_test.py
@@ -114,19 +114,14 @@ def test_help_short_circuits_subcommand(cli: GitHunkCLI) -> None:
     assert cli.repo.git("diff", "--cached").strip() == ""
 
 
-def test_commit_help_omits_unsupported_matching_options(cli: GitHunkCLI) -> None:
+def test_commit_help_advertises_matching_options(cli: GitHunkCLI) -> None:
     r = cli.run("commit", "--help")
     assert r.returncode == 0
     assert "-m" in r.stderr
     assert "-l" in r.stderr
-    assert "--include-matching" not in r.stderr
-    assert "--exclude-matching" not in r.stderr
-    assert "--regex" not in r.stderr
-
-
-def test_commit_rejects_matching_options(cli: GitHunkCLI) -> None:
-    r = cli.run("commit", "d161935", "--include-matching", "x", "-m", "msg")
-    assert r.returncode != 0
+    assert "--include-matching" in r.stderr
+    assert "--exclude-matching" in r.stderr
+    assert "--regex" in r.stderr
 
 
 def test_stage_help_advertises_matching_options(cli: GitHunkCLI) -> None:


### PR DESCRIPTION
> *This was generated by AI.*

The retained 4/4 Sonnet 5 evaluation exposed a command gap in
`drop_debug_lines`: the agent had to translate content to positional line
numbers, stage the selection, inspect it, and call Git commit separately.

`git-hunk commit` now accepts the same `--include-matching`,
`--exclude-matching`, and `--regex` selection options as `stage`. The updated
model smoke run passed and used the new workflow directly:

```bash
git-hunk commit cb2945c --exclude-matching 'print("DEBUG"' -m "process: double the returned total"
```

The unmatched debug line remained in the worktree for the existing discard
step. The deterministic golden solver and bundled core skill use the same
workflow.

## Test plan

- [x] `make lint`
- [x] `make test PYTEST_ARGS=-q` (695 passed)
- [x] `make eval EVAL_ARGS=--task=drop_debug_lines` (task passed and used the
  new command; selected-task runs are nonqualifying by design)
