### PR TITLE
feat: make agent eval runs observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Agent evals stream composed prompts and Bash calls, report normalized token
+  and cost usage, and write human-readable transcripts (#215).
 - `skills` subcommand (`git-hunk skills list|get|path`) serving the bundled,
   version-matched core usage guide for AI agents.
 - Examples section in `--help` for every subcommand.

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -99,8 +99,8 @@ The runner accepts the installed Claude Code version so automatic updates do not
 block an eval run. It records the version in the run manifest.
 
 The runner resolves the git-hunk executable, imported package, and both skill
-paths. All paths must be inside the clean current checkout. It records the Git
-commit and SHA-256 for both skill files.
+paths. All paths must be inside the current checkout. It records the Git commit,
+whether the checkout is dirty, and SHA-256 for both skill files.
 
 Claude runs with Bash as its only tool. The allowed Bash commands are
 `git-hunk` and `git`. The permission mode is `dontAsk`. Safe mode, no session
@@ -109,21 +109,32 @@ required.
 
 Each task writes a structured JSONL trace. The trace contains the Claude stream
 events and one eval metadata event with UTC start time, duration, and exit code.
+The runner prints the exact composed prompt, then prints each Bash command as an
+indented bullet under a `tool calls` section as events arrive, so a human or
+agent can inspect the prompt and tool-use sequence while the task is running. It
+writes the same view to a human-readable task transcript; tool results stay in
+the complete JSONL trace rather than cluttering the concise live view. The
+grader outcome and usage summary appear together under a `result` section.
+
 Validation requires assistant turns, Bash inputs, tool results, one successful
-result event, and the pinned reported model. Usage and cost fields stay in the
-trace when Claude reports them. The grader never reads the trace.
+result event, and the pinned reported model. When Claude reports usage and cost,
+the runner prints compact per-task summaries and, for multi-task invocations, an
+aggregate summary. Usage durations come from Claude's task results; the run
+manifest separately records whole-run wall time. The runner copies normalized
+metrics, including the per-model breakdown, into the run manifest. The original
+fields remain in the trace. The grader never reads the trace.
 
 The runner exits nonzero for a failed task, solver error, environment mismatch,
-missing or malformed trace, or incomplete task selection. A selected-task run
-can help diagnosis, but it cannot qualify.
+or missing or malformed trace. Each selected task is an independent eval run;
+passing it does not depend on running any other task in the same invocation.
 
 ### Keep this ADR Proposed in the integration ticket
 
-This integration adds the deterministic evaluation and the model-pinned runner. It
-does not claim a model result. A later release qualification must run all four
-tasks once, without retry, on one clean commit. That work must add redacted run
-evidence under `docs/eval/runs/<run-id>/` and change this ADR to Accepted only
-after all deterministic, lint, package, and pinned model gates pass.
+This integration adds the deterministic evaluation and the model-pinned runner.
+It does not claim a model result. A later evaluation study can archive redacted
+evidence for independently run tasks under `docs/eval/runs/<run-id>/` and change
+this ADR to Accepted after its deterministic, lint, package, and pinned model
+gates pass.
 
 ## Consequences
 

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import dataclasses
 import datetime
 import hashlib
 import json
@@ -9,54 +10,60 @@ from pathlib import Path
 from typing import Any
 
 from eval.config import MODEL
-from eval.config import TASK_NAMES
 from eval.config import TASK_SCHEMA_VERSION
 from eval.environment import EvalEnvironment
 from eval.environment import resolve_environment
 from eval.grader import Result
 from eval.harness import run_and_grade
+from eval.model import TraceUsage
+from eval.model import TranscriptReporter
+from eval.model import aggregate_usage
 from eval.model import build_command_flags
+from eval.model import format_usage
 from eval.model import make_claude_solver
+from eval.model import read_trace_usage
 from eval.scenario import Scenario
 from eval.tasks import SCENARIOS
 
 
+@dataclasses.dataclass(frozen=True)
+class TaskRun:
+    scenario: Scenario
+    result: Result
+    trace_path: Path
+    transcript_path: Path
+    usage: TraceUsage | None
+
+
 def main(argv: list[str] | None = None) -> int:
+    task_names = tuple(scenario.task.name for scenario in SCENARIOS)
     parser = argparse.ArgumentParser(prog="python -m eval")
     parser.add_argument(
         "--task",
         action="append",
-        choices=TASK_NAMES,
+        choices=task_names,
         metavar="NAME",
-        help="run one named task; a selected-task run is nonqualifying",
+        help="run one named task",
     )
     args = parser.parse_args(argv)
 
-    if tuple(scenario.task.name for scenario in SCENARIOS) != TASK_NAMES:
-        print("error: the configured task set is incomplete", file=sys.stderr)
-        return 2
     try:
         environment = resolve_environment()
     except RuntimeError as error:
         print(f"error: {error}", file=sys.stderr)
         return 2
 
-    selected_names = set(args.task or TASK_NAMES)
+    selected_names = set(args.task or task_names)
     selected = tuple(
         scenario for scenario in SCENARIOS if scenario.task.name in selected_names
     )
-    return _run_scenarios(
-        environment=environment,
-        scenarios=selected,
-        selected_run=args.task is not None,
-    )
+    return _run_scenarios(environment=environment, scenarios=selected)
 
 
 def _run_scenarios(
     *,
     environment: EvalEnvironment,
     scenarios: tuple[Scenario, ...],
-    selected_run: bool,
 ) -> int:
     started_at = datetime.datetime.now(datetime.timezone.utc)
     started_clock = time.monotonic()
@@ -64,74 +71,115 @@ def _run_scenarios(
         f"git-hunk-agent-eval-{started_at:%Y%m%dT%H%M%SZ}-{environment.commit[:7]}-"
     )
     run_dir = Path(tempfile.mkdtemp(prefix=run_directory_prefix))
-    results: list[tuple[Scenario, Result, Path]] = []
+    print(
+        f"eval: model={MODEL} "
+        f"claude={environment.claude_code_version.split()[0]} "
+        f"commit={environment.commit[:7]} dirty={str(environment.dirty).lower()}",
+        flush=True,
+    )
+    results: list[TaskRun] = []
+    multiple_tasks = len(scenarios) > 1
 
     for index, scenario in enumerate(scenarios, start=1):
         name = scenario.task.name
-        print(f"running {index}/{len(scenarios)}: {name}", flush=True)
+        progress = f" {index}/{len(scenarios)}" if multiple_tasks else ""
+        print(f"running{progress}: {name}", flush=True)
         trace_path = run_dir / f"{name}.jsonl"
-        solver = make_claude_solver(task=scenario.task, trace_path=trace_path)
+        transcript_path = run_dir / f"{name}.transcript.txt"
+        solver = make_claude_solver(
+            task=scenario.task,
+            trace_path=trace_path,
+            transcript_path=transcript_path,
+        )
         result = run_and_grade(task=scenario.task, solver=solver)
-        results.append((scenario, result, trace_path))
+        usage = read_trace_usage(trace_path=trace_path)
         mark = "PASS" if result.passed else "FAIL"
         detail = f": {result.reason}: {result.detail}" if result.detail else ""
-        print(f"{mark} {name}{detail}", flush=True)
+        result_line = f"{mark} {name}{detail}"
+        usage_line = (
+            format_usage(usage=usage) if usage is not None else "usage: unavailable"
+        )
+        with transcript_path.open("a", encoding="utf-8") as transcript:
+            TranscriptReporter(transcript=transcript).report_result(
+                result_line=result_line,
+                usage_line=usage_line,
+            )
+        results.append(
+            TaskRun(
+                scenario=scenario,
+                result=result,
+                trace_path=trace_path,
+                transcript_path=transcript_path,
+                usage=usage,
+            )
+        )
 
-    complete = tuple(scenario.task.name for scenario in scenarios) == TASK_NAMES
-    qualifying = _is_run_qualifying(
-        selected_run=selected_run,
-        complete=complete,
-        results=tuple(result for _, result, _ in results),
-    )
-    exit_code = 0 if qualifying else 1
+    passed = sum(run.result.passed for run in results)
+    run_passed = passed == len(results)
+    exit_code = 0 if run_passed else 1
     duration_seconds = time.monotonic() - started_clock
+    reported_usages = tuple(run.usage for run in results if run.usage is not None)
+    total_usage = aggregate_usage(usages=reported_usages)
     manifest = _make_manifest(
         environment=environment,
         results=results,
         started_at=started_at,
         duration_seconds=duration_seconds,
         exit_code=exit_code,
-        complete=complete,
-        selected_run=selected_run,
-        qualifying=qualifying,
+        passed=run_passed,
+        usage=total_usage,
     )
     (run_dir / "run.json").write_text(
         f"{json.dumps(manifest, indent=2, sort_keys=True)}\n",
         encoding="utf-8",
     )
-    print(f"overall: {sum(result.passed for _, result, _ in results)}/{len(results)}")
-    if selected_run:
-        print("selected-task run cannot qualify", file=sys.stderr)
-    elif not complete:
-        print("run is incomplete and cannot qualify", file=sys.stderr)
-    print(f"raw run: {run_dir}")
+    if multiple_tasks:
+        overall_mark = "PASS" if run_passed else "FAIL"
+        print(f"overall: {overall_mark} {passed}/{len(results)}")
+        if total_usage is None:
+            print("usage: unavailable")
+        else:
+            total_usage_line = format_usage(usage=total_usage)
+            if len(reported_usages) != len(results):
+                total_usage_line += (
+                    f" ({len(reported_usages)}/{len(results)} tasks reported)"
+                )
+            print(total_usage_line)
+    print(f"artifacts: {run_dir}")
     return exit_code
 
 
 def _make_manifest(
     *,
     environment: EvalEnvironment,
-    results: list[tuple[Scenario, Result, Path]],
+    results: list[TaskRun],
     started_at: datetime.datetime,
     duration_seconds: float,
     exit_code: int,
-    complete: bool,
-    selected_run: bool,
-    qualifying: bool,
+    passed: bool,
+    usage: TraceUsage | None,
 ) -> dict[str, Any]:
     task_results = []
-    for scenario, result, trace_path in results:
+    for run in results:
         trace_hash = None
-        if trace_path.exists():
-            trace_hash = hashlib.sha256(trace_path.read_bytes()).hexdigest()
+        if run.trace_path.exists():
+            trace_hash = hashlib.sha256(run.trace_path.read_bytes()).hexdigest()
+        transcript_hash = None
+        if run.transcript_path.exists():
+            transcript_hash = hashlib.sha256(
+                run.transcript_path.read_bytes()
+            ).hexdigest()
         task_results.append(
             {
-                "name": scenario.task.name,
-                "passed": result.passed,
-                "reason": result.reason,
-                "detail": result.detail,
-                "trace": trace_path.name,
+                "name": run.scenario.task.name,
+                "passed": run.result.passed,
+                "reason": run.result.reason,
+                "detail": run.result.detail,
+                "usage": run.usage.to_dict() if run.usage is not None else None,
+                "trace": run.trace_path.name,
                 "trace_sha256": trace_hash,
+                "transcript": run.transcript_path.name,
+                "transcript_sha256": transcript_hash,
             }
         )
     return {
@@ -139,7 +187,7 @@ def _make_manifest(
         "started_at": started_at.isoformat().replace("+00:00", "Z"),
         "duration_seconds": duration_seconds,
         "commit": environment.commit,
-        "clean_worktree": True,
+        "clean_worktree": not environment.dirty,
         "git_hunk_executable": str(environment.git_hunk_executable),
         "imported_package": str(environment.imported_package),
         "skill_paths": {
@@ -150,22 +198,11 @@ def _make_manifest(
         "requested_model": MODEL,
         "command_flags": build_command_flags(),
         "permission_policy": "Bash only; git-hunk and git commands only",
-        "complete": complete,
-        "selected_run": selected_run,
-        "qualifying": qualifying,
-        "retried": False,
+        "passed": passed,
+        "usage": usage.to_dict() if usage is not None else None,
         "tasks": task_results,
         "exit_code": exit_code,
     }
-
-
-def _is_run_qualifying(
-    *,
-    selected_run: bool,
-    complete: bool,
-    results: tuple[Result, ...],
-) -> bool:
-    return not selected_run and complete and all(result.passed for result in results)
 
 
 if __name__ == "__main__":

--- a/eval/config.py
+++ b/eval/config.py
@@ -2,9 +2,3 @@ from typing import Final
 
 MODEL: Final = "claude-sonnet-5"
 TASK_SCHEMA_VERSION: Final = 1
-TASK_NAMES: Final = (
-    "split_refactor_vs_feature",
-    "separate_mixed_hunks",
-    "drop_debug_lines",
-    "protect_unrelated_work",
-)

--- a/eval/environment.py
+++ b/eval/environment.py
@@ -12,6 +12,7 @@ from eval.repo import make_subprocess_env
 class EvalEnvironment:
     checkout: Path
     commit: str
+    dirty: bool
     git_hunk_executable: Path
     imported_package: Path
     skill_paths: dict[str, Path]
@@ -25,8 +26,6 @@ def resolve_environment() -> EvalEnvironment:
         command=["git", "status", "--porcelain=v1", "--untracked-files=all"],
         cwd=checkout,
     )
-    if status.stdout:
-        raise RuntimeError("the eval checkout must be clean")
     commit = _run(command=["git", "rev-parse", "HEAD"], cwd=checkout).stdout.strip()
 
     executable_name = shutil.which("git-hunk")
@@ -66,6 +65,7 @@ def resolve_environment() -> EvalEnvironment:
     return EvalEnvironment(
         checkout=checkout,
         commit=commit,
+        dirty=bool(status.stdout.strip()),
         git_hunk_executable=executable,
         imported_package=imported_package,
         skill_paths=skill_paths,

--- a/eval/model.py
+++ b/eval/model.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import json
 import math
@@ -6,12 +7,84 @@ import time
 from pathlib import Path
 from typing import Any
 from typing import Final
+from typing import TextIO
 from typing import cast
 
 from eval.config import MODEL
 from eval.repo import GitRepo
 from eval.scenario import Solver
 from eval.task import Task
+
+
+@dataclasses.dataclass(frozen=True)
+class TokenUsage:
+    input_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+    output_tokens: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "input": self.input_tokens,
+            "cache_creation_input": self.cache_creation_input_tokens,
+            "cache_read_input": self.cache_read_input_tokens,
+            "output": self.output_tokens,
+        }
+
+    @classmethod
+    def total(cls, usages: list["TokenUsage"]) -> "TokenUsage":
+        return cls(
+            input_tokens=sum(usage.input_tokens for usage in usages),
+            cache_creation_input_tokens=sum(
+                usage.cache_creation_input_tokens for usage in usages
+            ),
+            cache_read_input_tokens=sum(
+                usage.cache_read_input_tokens for usage in usages
+            ),
+            output_tokens=sum(usage.output_tokens for usage in usages),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class ModelUsage:
+    tokens: TokenUsage
+    web_search_requests: int
+    cost_usd: float
+    context_window: int
+    max_output_tokens: int
+    canonical_model: str | None
+    provider: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tokens": self.tokens.to_dict(),
+            "web_search_requests": self.web_search_requests,
+            "cost_usd": self.cost_usd,
+            "context_window": self.context_window,
+            "max_output_tokens": self.max_output_tokens,
+            "canonical_model": self.canonical_model,
+            "provider": self.provider,
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class TraceUsage:
+    duration_seconds: float
+    api_duration_seconds: float
+    turns: int
+    cost_usd: float
+    tokens: TokenUsage
+    models: dict[str, ModelUsage]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "duration_seconds": self.duration_seconds,
+            "api_duration_seconds": self.api_duration_seconds,
+            "turns": self.turns,
+            "cost_usd": self.cost_usd,
+            "tokens": self.tokens.to_dict(),
+            "models": {name: usage.to_dict() for name, usage in self.models.items()},
+        }
 
 
 def build_prompt(*, task_prompt: str) -> str:
@@ -52,41 +125,60 @@ def build_command(*, prompt: str) -> list[str]:
     return ["claude", "-p", prompt, *build_command_flags()]
 
 
-def make_claude_solver(*, task: Task, trace_path: Path) -> Solver:
+def make_claude_solver(
+    *, task: Task, trace_path: Path, transcript_path: Path
+) -> Solver:
     prompt = build_prompt(task_prompt=task.prompt)
 
     def solve(repo: GitRepo) -> None:
-        run_claude(repo=repo, prompt=prompt, trace_path=trace_path)
+        run_claude(
+            repo=repo,
+            prompt=prompt,
+            trace_path=trace_path,
+            transcript_path=transcript_path,
+        )
 
     return solve
 
 
-def run_claude(*, repo: GitRepo, prompt: str, trace_path: Path) -> None:
+def run_claude(
+    *,
+    repo: GitRepo,
+    prompt: str,
+    trace_path: Path,
+    transcript_path: Path,
+) -> None:
     MODEL_TIMEOUT_SECONDS: Final = 30 * 60
     started_at = datetime.datetime.now(datetime.timezone.utc)
     started_clock = time.monotonic()
-    try:
-        result = repo.run(
-            *build_command(prompt=prompt),
-            timeout_seconds=MODEL_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired as error:
-        duration_seconds = time.monotonic() - started_clock
-        raw_trace = error.stdout or ""
-        if isinstance(raw_trace, bytes):
-            raw_trace = raw_trace.decode(errors="replace")
-        raw_trace, incomplete_output = _separate_trace_output(raw_trace=raw_trace)
-        _write_trace(
-            trace_path=trace_path,
-            raw_trace=raw_trace,
-            started_at=started_at,
-            duration_seconds=duration_seconds,
-            exit_code=124,
-            incomplete_output=incomplete_output,
-        )
-        raise RuntimeError(
-            f"claude timed out after {MODEL_TIMEOUT_SECONDS} seconds"
-        ) from error
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    with transcript_path.open("w", encoding="utf-8") as transcript:
+        reporter = TranscriptReporter(transcript=transcript)
+        reporter.report_prompt(prompt=prompt)
+        reporter.report_tool_calls_header()
+        try:
+            result = repo.run_stream(
+                *build_command(prompt=prompt),
+                timeout_seconds=MODEL_TIMEOUT_SECONDS,
+                on_stdout_line=reporter.consume_line,
+            )
+        except subprocess.TimeoutExpired as error:
+            duration_seconds = time.monotonic() - started_clock
+            raw_trace = error.stdout or ""
+            if isinstance(raw_trace, bytes):
+                raw_trace = raw_trace.decode(errors="replace")
+            raw_trace, incomplete_output = _separate_trace_output(raw_trace=raw_trace)
+            _write_trace(
+                trace_path=trace_path,
+                raw_trace=raw_trace,
+                started_at=started_at,
+                duration_seconds=duration_seconds,
+                exit_code=124,
+                incomplete_output=incomplete_output,
+            )
+            raise RuntimeError(
+                f"claude timed out after {MODEL_TIMEOUT_SECONDS} seconds"
+            ) from error
 
     duration_seconds = time.monotonic() - started_clock
     _write_trace(
@@ -101,6 +193,250 @@ def run_claude(*, repo: GitRepo, prompt: str, trace_path: Path) -> None:
             f"claude exited {result.returncode}: {result.stderr.strip()}"
         )
     validate_trace(trace_path=trace_path)
+
+
+class TranscriptReporter:
+    def __init__(self, *, transcript: TextIO) -> None:
+        self._transcript = transcript
+
+    def report_prompt(self, *, prompt: str) -> None:
+        self._emit("prompt:")
+        for line in prompt.splitlines():
+            self._emit(f"  {line}")
+
+    def report_tool_calls_header(self) -> None:
+        self._emit("tool calls:")
+
+    def report_result(self, *, result_line: str, usage_line: str) -> None:
+        self._emit("result:")
+        self._emit(f"  {result_line}")
+        self._emit(f"  {usage_line}")
+
+    def consume_line(self, line: str) -> None:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(event, dict):
+            return
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return
+        content = message.get("content")
+        if not isinstance(content, list):
+            return
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") == "Bash"
+            ):
+                self._report_tool_use(block=block)
+
+    def _report_tool_use(self, *, block: dict[str, Any]) -> None:
+        tool_input = block.get("input")
+        command = tool_input.get("command") if isinstance(tool_input, dict) else None
+        if not isinstance(command, str):
+            return
+        command_lines = command.rstrip().splitlines()
+        if not command_lines:
+            return
+        self._emit(f"  - {command_lines[0]}")
+        for command_line in command_lines[1:]:
+            self._emit(f"    {command_line}")
+
+    def _emit(self, line: str) -> None:
+        print(line, flush=True)
+        self._transcript.write(f"{line}\n")
+        self._transcript.flush()
+
+
+def read_trace_usage(*, trace_path: Path) -> TraceUsage | None:
+    try:
+        events = [
+            json.loads(line)
+            for line in trace_path.read_text(encoding="utf-8").splitlines()
+        ]
+    except (OSError, json.JSONDecodeError):
+        return None
+    result_events = [
+        event
+        for event in events
+        if isinstance(event, dict) and event.get("type") == "result"
+    ]
+    if len(result_events) != 1:
+        return None
+    return _parse_trace_usage(result_event=result_events[0])
+
+
+def _parse_trace_usage(*, result_event: dict[str, Any]) -> TraceUsage | None:
+    duration_ms = _nonnegative_number(result_event.get("duration_ms"))
+    api_duration_ms = _nonnegative_number(result_event.get("duration_api_ms"))
+    turns = _nonnegative_int(result_event.get("num_turns"))
+    cost_usd = _nonnegative_number(result_event.get("total_cost_usd"))
+    raw_usage = result_event.get("usage")
+    if (
+        duration_ms is None
+        or api_duration_ms is None
+        or turns is None
+        or cost_usd is None
+        or not isinstance(raw_usage, dict)
+    ):
+        return None
+    tokens = _parse_token_usage(
+        raw_usage=cast("dict[str, Any]", raw_usage),
+        input_key="input_tokens",
+        cache_creation_key="cache_creation_input_tokens",
+        cache_read_key="cache_read_input_tokens",
+        output_key="output_tokens",
+    )
+    if tokens is None:
+        return None
+    models = _parse_model_usage(result_event.get("modelUsage"))
+    return TraceUsage(
+        duration_seconds=duration_ms / 1000,
+        api_duration_seconds=api_duration_ms / 1000,
+        turns=turns,
+        cost_usd=cost_usd,
+        tokens=tokens,
+        models=models,
+    )
+
+
+def _parse_token_usage(
+    *,
+    raw_usage: dict[str, Any],
+    input_key: str,
+    cache_creation_key: str,
+    cache_read_key: str,
+    output_key: str,
+) -> TokenUsage | None:
+    input_tokens = _nonnegative_int(raw_usage.get(input_key))
+    cache_creation_input_tokens = _nonnegative_int(raw_usage.get(cache_creation_key))
+    cache_read_input_tokens = _nonnegative_int(raw_usage.get(cache_read_key))
+    output_tokens = _nonnegative_int(raw_usage.get(output_key))
+    if (
+        input_tokens is None
+        or cache_creation_input_tokens is None
+        or cache_read_input_tokens is None
+        or output_tokens is None
+    ):
+        return None
+    return TokenUsage(
+        input_tokens=input_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+def _parse_model_usage(raw_models: object) -> dict[str, ModelUsage]:
+    if not isinstance(raw_models, dict):
+        return {}
+    models: dict[str, ModelUsage] = {}
+    for name, raw_model_usage in cast("dict[object, object]", raw_models).items():
+        if not isinstance(name, str) or not isinstance(raw_model_usage, dict):
+            continue
+        raw_usage = cast("dict[str, Any]", raw_model_usage)
+        tokens = _parse_token_usage(
+            raw_usage=raw_usage,
+            input_key="inputTokens",
+            cache_creation_key="cacheCreationInputTokens",
+            cache_read_key="cacheReadInputTokens",
+            output_key="outputTokens",
+        )
+        web_search_requests = _nonnegative_int(raw_usage.get("webSearchRequests"))
+        cost_usd = _nonnegative_number(raw_usage.get("costUSD"))
+        context_window = _nonnegative_int(raw_usage.get("contextWindow"))
+        max_output_tokens = _nonnegative_int(raw_usage.get("maxOutputTokens"))
+        canonical_model = raw_usage.get("canonicalModel")
+        provider = raw_usage.get("provider")
+        if (
+            tokens is None
+            or web_search_requests is None
+            or cost_usd is None
+            or context_window is None
+            or max_output_tokens is None
+            or (canonical_model is not None and not isinstance(canonical_model, str))
+            or (provider is not None and not isinstance(provider, str))
+        ):
+            continue
+        models[name] = ModelUsage(
+            tokens=tokens,
+            web_search_requests=web_search_requests,
+            cost_usd=cost_usd,
+            context_window=context_window,
+            max_output_tokens=max_output_tokens,
+            canonical_model=canonical_model,
+            provider=provider,
+        )
+    return models
+
+
+def _nonnegative_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _nonnegative_number(value: object) -> float | None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+    ):
+        return None
+    return float(value)
+
+
+def format_usage(*, usage: TraceUsage) -> str:
+    duration = usage.duration_seconds
+    tokens = usage.tokens
+    return (
+        f"usage: {duration:.1f}s · {usage.turns} turns · tokens "
+        f"{_format_token_count(tokens.input_tokens)} input / "
+        f"{_format_token_count(tokens.cache_creation_input_tokens)} cache-write / "
+        f"{_format_token_count(tokens.cache_read_input_tokens)} cache-read / "
+        f"{_format_token_count(tokens.output_tokens)} output · ${usage.cost_usd:.4f}"
+    )
+
+
+def _format_token_count(count: int) -> str:
+    if count >= 1_000_000:
+        return f"{count / 1_000_000:.1f}m"
+    if count >= 1_000:
+        return f"{count / 1_000:.1f}k"
+    return str(count)
+
+
+def aggregate_usage(*, usages: tuple[TraceUsage, ...]) -> TraceUsage | None:
+    if not usages:
+        return None
+    model_names = {name for usage in usages for name in usage.models}
+    models: dict[str, ModelUsage] = {}
+    for name in sorted(model_names):
+        model_usages = [usage.models[name] for usage in usages if name in usage.models]
+        first = model_usages[0]
+        models[name] = ModelUsage(
+            tokens=TokenUsage.total([usage.tokens for usage in model_usages]),
+            web_search_requests=sum(
+                usage.web_search_requests for usage in model_usages
+            ),
+            cost_usd=sum(usage.cost_usd for usage in model_usages),
+            context_window=first.context_window,
+            max_output_tokens=first.max_output_tokens,
+            canonical_model=first.canonical_model,
+            provider=first.provider,
+        )
+    return TraceUsage(
+        duration_seconds=sum(usage.duration_seconds for usage in usages),
+        api_duration_seconds=sum(usage.api_duration_seconds for usage in usages),
+        turns=sum(usage.turns for usage in usages),
+        cost_usd=sum(usage.cost_usd for usage in usages),
+        tokens=TokenUsage.total([usage.tokens for usage in usages]),
+        models=models,
+    )
 
 
 def _write_trace(

--- a/eval/repo.py
+++ b/eval/repo.py
@@ -1,7 +1,14 @@
+import ctypes
 import os
+import queue
+import signal
 import stat
 import subprocess
+import threading
+import time
+from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 
 class GitRepo:
@@ -30,6 +37,113 @@ class GitRepo:
             env=make_subprocess_env(),
         )
 
+    def run_stream(
+        self,
+        *args: str,
+        timeout_seconds: float,
+        on_stdout_line: Callable[[str], None],
+    ) -> subprocess.CompletedProcess[str]:
+        command = list(args)
+        creationflags = 0
+        if os.name == "nt":
+            creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            creationflags |= getattr(subprocess, "CREATE_SUSPENDED", 0x00000004)
+        process = subprocess.Popen(
+            command,
+            cwd=self.path,
+            env=make_subprocess_env(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=os.name != "nt",
+            creationflags=creationflags,
+        )
+        stdout = process.stdout
+        stderr = process.stderr
+        if stdout is None or stderr is None:
+            raise RuntimeError("streaming subprocess pipes are unavailable")
+        try:
+            windows_job = (
+                _WindowsJob.create_for_suspended_process(process=process)
+                if os.name == "nt"
+                else None
+            )
+        except BaseException:
+            process.kill()
+            process.wait()
+            raise
+
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+        stdout_queue: queue.Queue[str | None] = queue.Queue()
+
+        def read_stdout() -> None:
+            try:
+                for line in stdout:
+                    stdout_queue.put(line)
+            finally:
+                stdout_queue.put(None)
+
+        def read_stderr() -> None:
+            stderr_lines.extend(stderr)
+
+        stdout_thread = threading.Thread(target=read_stdout, daemon=True)
+        stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+        stdout_thread.start()
+        stderr_thread.start()
+        deadline = time.monotonic() + timeout_seconds
+
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise queue.Empty
+                line = stdout_queue.get(timeout=remaining)
+                if line is None:
+                    break
+                stdout_lines.append(line)
+                on_stdout_line(line)
+            process.wait(timeout=max(0, deadline - time.monotonic()))
+            for reader_thread in (stdout_thread, stderr_thread):
+                reader_thread.join(timeout=max(0, deadline - time.monotonic()))
+                if reader_thread.is_alive():
+                    raise subprocess.TimeoutExpired(command, timeout_seconds)
+        except (queue.Empty, subprocess.TimeoutExpired) as error:
+            _stop_process_tree(
+                process=process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                windows_job=windows_job,
+            )
+            while not stdout_queue.empty():
+                line = stdout_queue.get_nowait()
+                if line is not None:
+                    stdout_lines.append(line)
+                    on_stdout_line(line)
+            raise subprocess.TimeoutExpired(
+                cmd=command,
+                timeout=timeout_seconds,
+                output="".join(stdout_lines),
+                stderr="".join(stderr_lines),
+            ) from error
+        except BaseException:
+            _stop_process_tree(
+                process=process,
+                stdout_thread=stdout_thread,
+                stderr_thread=stderr_thread,
+                windows_job=windows_job,
+            )
+            raise
+
+        if windows_job is not None:
+            windows_job.close()
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=process.returncode,
+            stdout="".join(stdout_lines),
+            stderr="".join(stderr_lines),
+        )
+
     def git(self, *args: str) -> str:
         result = self.run("git", *args)
         if result.returncode != 0:
@@ -52,6 +166,217 @@ class GitRepo:
         file_path.write_bytes(data)
         if executable:
             file_path.chmod(file_path.stat().st_mode | stat.S_IXUSR)
+
+
+class _WindowsJob:
+    def __init__(self, *, kernel32: ctypes.CDLL, handle: int) -> None:
+        self._kernel32 = kernel32
+        self._handle: int | None = handle
+
+    @classmethod
+    def create_for_suspended_process(
+        cls, *, process: subprocess.Popen[str]
+    ) -> "_WindowsJob | None":
+        from ctypes import wintypes
+
+        class IoCounters(ctypes.Structure):
+            _fields_ = [
+                ("read_operation_count", ctypes.c_ulonglong),
+                ("write_operation_count", ctypes.c_ulonglong),
+                ("other_operation_count", ctypes.c_ulonglong),
+                ("read_transfer_count", ctypes.c_ulonglong),
+                ("write_transfer_count", ctypes.c_ulonglong),
+                ("other_transfer_count", ctypes.c_ulonglong),
+            ]
+
+        class BasicLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("per_process_user_time_limit", ctypes.c_longlong),
+                ("per_job_user_time_limit", ctypes.c_longlong),
+                ("limit_flags", wintypes.DWORD),
+                ("minimum_working_set_size", ctypes.c_size_t),
+                ("maximum_working_set_size", ctypes.c_size_t),
+                ("active_process_limit", wintypes.DWORD),
+                ("affinity", ctypes.c_size_t),
+                ("priority_class", wintypes.DWORD),
+                ("scheduling_class", wintypes.DWORD),
+            ]
+
+        class ExtendedLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("basic_limit_information", BasicLimitInformation),
+                ("io_info", IoCounters),
+                ("process_memory_limit", ctypes.c_size_t),
+                ("job_memory_limit", ctypes.c_size_t),
+                ("peak_process_memory_used", ctypes.c_size_t),
+                ("peak_job_memory_used", ctypes.c_size_t),
+            ]
+
+        class ThreadEntry32(ctypes.Structure):
+            _fields_ = [
+                ("size", wintypes.DWORD),
+                ("usage_count", wintypes.DWORD),
+                ("thread_id", wintypes.DWORD),
+                ("owner_process_id", wintypes.DWORD),
+                ("base_priority", wintypes.LONG),
+                ("priority_delta", wintypes.LONG),
+                ("flags", wintypes.DWORD),
+            ]
+
+        kernel32 = cast(
+            ctypes.CDLL,
+            getattr(ctypes, "WinDLL")("kernel32", use_last_error=True),
+        )
+        kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+        kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+        kernel32.SetInformationJobObject.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+        ]
+        kernel32.SetInformationJobObject.restype = wintypes.BOOL
+        kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+        kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+        kernel32.OpenProcess.argtypes = [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+        kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+        kernel32.Thread32First.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(ThreadEntry32),
+        ]
+        kernel32.Thread32First.restype = wintypes.BOOL
+        kernel32.Thread32Next.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(ThreadEntry32),
+        ]
+        kernel32.Thread32Next.restype = wintypes.BOOL
+        kernel32.OpenThread.argtypes = [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        kernel32.OpenThread.restype = wintypes.HANDLE
+        kernel32.ResumeThread.argtypes = [wintypes.HANDLE]
+        kernel32.ResumeThread.restype = wintypes.DWORD
+        kernel32.TerminateJobObject.argtypes = [wintypes.HANDLE, wintypes.UINT]
+        kernel32.TerminateJobObject.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+
+        job: _WindowsJob | None = None
+        handle = kernel32.CreateJobObjectW(None, None)
+        if handle:
+            information = ExtendedLimitInformation()
+            information.basic_limit_information.limit_flags = 0x00002000
+            configured = kernel32.SetInformationJobObject(
+                handle,
+                9,
+                ctypes.byref(information),
+                ctypes.sizeof(information),
+            )
+            process_handle = kernel32.OpenProcess(
+                0x00000101,
+                False,
+                process.pid,
+            )
+            assigned = bool(
+                process_handle
+                and kernel32.AssignProcessToJobObject(handle, process_handle)
+            )
+            if process_handle:
+                kernel32.CloseHandle(process_handle)
+            if configured and assigned:
+                job = cls(kernel32=kernel32, handle=handle)
+            else:
+                kernel32.CloseHandle(handle)
+
+        if not cls._resume_process(
+            kernel32=kernel32,
+            process_id=process.pid,
+            thread_entry_type=ThreadEntry32,
+        ):
+            if job is not None:
+                job.close()
+            raise RuntimeError("failed to resume the streaming subprocess")
+        return job
+
+    @staticmethod
+    def _resume_process(
+        *, kernel32: ctypes.CDLL, process_id: int, thread_entry_type: type
+    ) -> bool:
+        snapshot = kernel32.CreateToolhelp32Snapshot(0x00000004, 0)
+        if snapshot == ctypes.c_void_p(-1).value:
+            return False
+        try:
+            entry = thread_entry_type()
+            entry.size = ctypes.sizeof(entry)
+            has_entry = bool(kernel32.Thread32First(snapshot, ctypes.byref(entry)))
+            while has_entry:
+                if entry.owner_process_id == process_id:
+                    thread_handle = kernel32.OpenThread(0x0002, False, entry.thread_id)
+                    if not thread_handle:
+                        return False
+                    try:
+                        return kernel32.ResumeThread(thread_handle) != 0xFFFFFFFF
+                    finally:
+                        kernel32.CloseHandle(thread_handle)
+                has_entry = bool(kernel32.Thread32Next(snapshot, ctypes.byref(entry)))
+            return False
+        finally:
+            kernel32.CloseHandle(snapshot)
+
+    def terminate(self) -> bool:
+        return bool(self._kernel32.TerminateJobObject(self._handle, 1))
+
+    def close(self) -> None:
+        if self._handle is not None:
+            self._kernel32.CloseHandle(self._handle)
+            self._handle = None
+
+
+def _stop_process_tree(
+    *,
+    process: subprocess.Popen[str],
+    stdout_thread: threading.Thread,
+    stderr_thread: threading.Thread,
+    windows_job: _WindowsJob | None,
+) -> None:
+    _kill_process_tree(process=process, windows_job=windows_job)
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+    stdout_thread.join(timeout=1)
+    stderr_thread.join(timeout=1)
+    if windows_job is not None:
+        windows_job.close()
+
+
+def _kill_process_tree(
+    *, process: subprocess.Popen[str], windows_job: _WindowsJob | None
+) -> None:
+    if os.name == "nt":
+        if windows_job is not None and windows_job.terminate():
+            return
+        result = subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0 and process.poll() is None:
+            process.kill()
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
 
 
 def init_repo(path: str | Path) -> GitRepo:

--- a/tests/eval/model_test.py
+++ b/tests/eval/model_test.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from typing import NoReturn
@@ -7,8 +8,11 @@ from typing import NoReturn
 import pytest
 
 from eval.config import MODEL
+from eval.model import aggregate_usage
 from eval.model import build_command
 from eval.model import build_prompt
+from eval.model import format_usage
+from eval.model import read_trace_usage
 from eval.model import run_claude
 from eval.model import validate_trace
 from eval.repo import GitRepo
@@ -222,14 +226,221 @@ def test_run_claude_writes_partial_trace_on_timeout(
         )
 
     repo = GitRepo(tmp_path)
-    monkeypatch.setattr(repo, "run", raise_timeout)
+    monkeypatch.setattr(repo, "run_stream", raise_timeout)
     trace_path = tmp_path / "trace.jsonl"
+    transcript_path = tmp_path / "transcript.txt"
 
     with pytest.raises(RuntimeError, match="timed out after 1800 seconds"):
-        run_claude(repo=repo, prompt="Do the task", trace_path=trace_path)
+        run_claude(
+            repo=repo,
+            prompt="Do the task",
+            trace_path=trace_path,
+            transcript_path=transcript_path,
+        )
 
     events = [json.loads(line) for line in trace_path.read_text().splitlines()]
     assert events[0]["type"] == "assistant"
     assert events[-1]["type"] == "eval_metadata"
     assert events[-1]["exit_code"] == 124
     assert events[-1]["incomplete_output"] == '{"type":"assistant"'
+
+
+def test_run_claude_streams_tool_calls_without_results(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    trace_events: list[dict[str, Any]],
+) -> None:
+    trace_events[1]["message"]["content"][0].update(
+        {"content": "command output stays in JSONL", "is_error": True}
+    )
+    trace_events[2:2] = [
+        {
+            "type": "assistant",
+            "message": {
+                "model": MODEL,
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-2",
+                        "name": "Bash",
+                        "input": {"command": "git diff"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-2",
+                        "content": " \n\n",
+                    }
+                ]
+            },
+        },
+    ]
+    raw_trace = "".join(f"{json.dumps(event)}\n" for event in trace_events[:-1])
+
+    def run_stream(
+        *args: str,
+        timeout_seconds: float,
+        on_stdout_line: Callable[[str], None],
+    ) -> subprocess.CompletedProcess[str]:
+        del timeout_seconds
+        for line in raw_trace.splitlines(keepends=True):
+            on_stdout_line(line)
+        return subprocess.CompletedProcess(args, 0, raw_trace, "")
+
+    repo = GitRepo(tmp_path)
+    monkeypatch.setattr(repo, "run_stream", run_stream, raising=False)
+    trace_path = tmp_path / "trace.jsonl"
+    transcript_path = tmp_path / "transcript.txt"
+
+    run_claude(
+        repo=repo,
+        prompt="First line.\n\nSecond line.",
+        trace_path=trace_path,
+        transcript_path=transcript_path,
+    )
+
+    expected = "\n".join(
+        [
+            "prompt:",
+            "  First line.",
+            "  ",
+            "  Second line.",
+            "tool calls:",
+            "  - git status",
+            "  - git diff",
+        ]
+    )
+    assert capsys.readouterr().out.rstrip() == expected
+    assert transcript_path.read_text(encoding="utf-8").rstrip() == expected
+
+
+def test_trace_usage_has_stable_shape_and_compact_format(
+    tmp_path: Path, trace_events: list[dict[str, Any]]
+) -> None:
+    trace_events[2].update(
+        {
+            "duration_ms": 22670,
+            "duration_api_ms": 22618,
+            "num_turns": 8,
+            "total_cost_usd": 0.0891406,
+            "usage": {
+                "input_tokens": 16,
+                "cache_creation_input_tokens": 8434,
+                "cache_read_input_tokens": 59782,
+                "output_tokens": 1327,
+            },
+            "modelUsage": {
+                "claude-sonnet-5": {
+                    "inputTokens": 16,
+                    "cacheCreationInputTokens": 8434,
+                    "cacheReadInputTokens": 59782,
+                    "outputTokens": 1327,
+                    "webSearchRequests": 0,
+                    "costUSD": 0.0891406,
+                    "contextWindow": 1_000_000,
+                    "maxOutputTokens": 64_000,
+                    "canonicalModel": "claude-sonnet-5",
+                    "provider": "firstParty",
+                }
+            },
+        }
+    )
+    trace_path = tmp_path / "trace.jsonl"
+    _write_trace(trace_path=trace_path, events=trace_events)
+
+    usage = read_trace_usage(trace_path=trace_path)
+
+    assert usage is not None
+    assert usage.to_dict() == {
+        "duration_seconds": 22.67,
+        "api_duration_seconds": 22.618,
+        "turns": 8,
+        "cost_usd": 0.0891406,
+        "tokens": {
+            "input": 16,
+            "cache_creation_input": 8434,
+            "cache_read_input": 59782,
+            "output": 1327,
+        },
+        "models": {
+            "claude-sonnet-5": {
+                "tokens": {
+                    "input": 16,
+                    "cache_creation_input": 8434,
+                    "cache_read_input": 59782,
+                    "output": 1327,
+                },
+                "web_search_requests": 0,
+                "cost_usd": 0.0891406,
+                "context_window": 1_000_000,
+                "max_output_tokens": 64_000,
+                "canonical_model": "claude-sonnet-5",
+                "provider": "firstParty",
+            }
+        },
+    }
+    assert format_usage(usage=usage) == (
+        "usage: 22.7s · 8 turns · tokens 16 input / 8.4k cache-write / "
+        "59.8k cache-read / 1.3k output · $0.0891"
+    )
+
+    total = aggregate_usage(usages=(usage, usage))
+
+    assert total is not None
+    assert total.to_dict()["tokens"] == {
+        "input": 32,
+        "cache_creation_input": 16868,
+        "cache_read_input": 119564,
+        "output": 2654,
+    }
+    assert total.models["claude-sonnet-5"].cost_usd == pytest.approx(0.1782812)
+    assert format_usage(usage=total) == (
+        "usage: 45.3s · 16 turns · tokens 32 input / 16.9k cache-write / "
+        "119.6k cache-read / 2.7k output · $0.1783"
+    )
+
+
+def test_trace_usage_accepts_missing_optional_model_metadata(
+    tmp_path: Path, trace_events: list[dict[str, Any]]
+) -> None:
+    trace_events[2].update(
+        {
+            "duration_ms": 1000,
+            "duration_api_ms": 900,
+            "num_turns": 1,
+            "total_cost_usd": 0.01,
+            "usage": {
+                "input_tokens": 1,
+                "cache_creation_input_tokens": 2,
+                "cache_read_input_tokens": 3,
+                "output_tokens": 4,
+            },
+            "modelUsage": {
+                "claude-sonnet-5": {
+                    "inputTokens": 1,
+                    "cacheCreationInputTokens": 2,
+                    "cacheReadInputTokens": 3,
+                    "outputTokens": 4,
+                    "webSearchRequests": 0,
+                    "costUSD": 0.01,
+                    "contextWindow": 1_000_000,
+                    "maxOutputTokens": 64_000,
+                }
+            },
+        }
+    )
+    trace_path = tmp_path / "trace.jsonl"
+    _write_trace(trace_path=trace_path, events=trace_events)
+
+    usage = read_trace_usage(trace_path=trace_path)
+
+    assert usage is not None
+    assert usage.models["claude-sonnet-5"].canonical_model is None
+    assert usage.models["claude-sonnet-5"].provider is None

--- a/tests/eval/repo_test.py
+++ b/tests/eval/repo_test.py
@@ -1,0 +1,153 @@
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from eval.repo import GitRepo
+
+
+def _assert_descendant_stopped(*, marker_path: Path, sentinel_path: Path) -> None:
+    marker_path.write_text("check", encoding="utf-8")
+    time.sleep(1)
+    assert not sentinel_path.exists()
+
+
+def test_run_stream_drains_stdout_and_stderr_without_deadlock(tmp_path: Path) -> None:
+    stdout_lines: list[str] = []
+    script = "\n".join(
+        [
+            "import sys",
+            "print('first', flush=True)",
+            "sys.stderr.write('e' * 1_000_000)",
+            "sys.stderr.flush()",
+            "print('second', flush=True)",
+        ]
+    )
+
+    result = GitRepo(tmp_path).run_stream(
+        sys.executable,
+        "-c",
+        script,
+        timeout_seconds=5,
+        on_stdout_line=stdout_lines.append,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "first\nsecond\n"
+    assert len(result.stderr) == 1_000_000
+    assert stdout_lines == ["first\n", "second\n"]
+
+
+def test_run_stream_timeout_kills_descendants_holding_pipes(tmp_path: Path) -> None:
+    stdout_lines: list[str] = []
+    script = "\n".join(
+        [
+            "import subprocess",
+            "import sys",
+            "import time",
+            "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)'])",
+            "print('ready', flush=True)",
+            "time.sleep(60)",
+        ]
+    )
+    started_at = time.monotonic()
+
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
+        GitRepo(tmp_path).run_stream(
+            sys.executable,
+            "-c",
+            script,
+            timeout_seconds=1,
+            on_stdout_line=stdout_lines.append,
+        )
+
+    assert time.monotonic() - started_at < 5
+    assert caught.value.output == "ready\n"
+    assert stdout_lines == ["ready\n"]
+
+
+def test_run_stream_timeout_kills_descendant_holding_only_stderr(
+    tmp_path: Path,
+) -> None:
+    marker_path = tmp_path / "check-descendant"
+    sentinel_path = tmp_path / "descendant-survived"
+    descendant_script = "\n".join(
+        [
+            "import time",
+            "from pathlib import Path",
+            f"marker = Path({str(marker_path)!r})",
+            "while not marker.exists():",
+            "    time.sleep(0.01)",
+            f"Path({str(sentinel_path)!r}).write_text('alive')",
+        ]
+    )
+    script = "\n".join(
+        [
+            "import subprocess",
+            "import sys",
+            "subprocess.Popen(",
+            f"    [sys.executable, '-c', {descendant_script!r}],",
+            "    stdout=subprocess.DEVNULL,",
+            ")",
+        ]
+    )
+    started_at = time.monotonic()
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        GitRepo(tmp_path).run_stream(
+            sys.executable,
+            "-c",
+            script,
+            timeout_seconds=0.5,
+            on_stdout_line=lambda line: None,
+        )
+
+    assert time.monotonic() - started_at < 5
+    _assert_descendant_stopped(
+        marker_path=marker_path,
+        sentinel_path=sentinel_path,
+    )
+
+
+def test_run_stream_interrupt_kills_descendants(tmp_path: Path) -> None:
+    marker_path = tmp_path / "check-descendant"
+    sentinel_path = tmp_path / "descendant-survived"
+    descendant_script = "\n".join(
+        [
+            "import time",
+            "from pathlib import Path",
+            f"marker = Path({str(marker_path)!r})",
+            "while not marker.exists():",
+            "    time.sleep(0.01)",
+            f"Path({str(sentinel_path)!r}).write_text('alive')",
+        ]
+    )
+    script = "\n".join(
+        [
+            "import subprocess",
+            "import sys",
+            "import time",
+            f"subprocess.Popen([sys.executable, '-c', {descendant_script!r}])",
+            "print('ready', flush=True)",
+            "time.sleep(60)",
+        ]
+    )
+
+    def interrupt(line: str) -> None:
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        GitRepo(tmp_path).run_stream(
+            sys.executable,
+            "-c",
+            script,
+            timeout_seconds=5,
+            on_stdout_line=interrupt,
+        )
+
+    _assert_descendant_stopped(
+        marker_path=marker_path,
+        sentinel_path=sentinel_path,
+    )

--- a/tests/eval/runner_test.py
+++ b/tests/eval/runner_test.py
@@ -1,10 +1,18 @@
+import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
-from eval.__main__ import _is_run_qualifying
-from eval.config import TASK_NAMES
+import pytest
+
+import eval.__main__ as eval_main
+from eval.environment import EvalEnvironment
 from eval.grader import Result
+from eval.repo import GitRepo
+from eval.scenario import Solver
+from eval.task import Task
+from eval.tasks import SCENARIOS
 
 
 def test_runner_rejects_model_override_before_running_tasks() -> None:
@@ -20,11 +28,122 @@ def test_runner_rejects_model_override_before_running_tasks() -> None:
     assert "unrecognized arguments: --model opus" in result.stderr
 
 
-def test_selected_run_cannot_qualify_with_all_task_names() -> None:
-    results = tuple(Result(passed=True) for _ in TASK_NAMES)
+@pytest.mark.parametrize("scenario_count", [1, 2])
+def test_run_reports_context_usage_and_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scenario_count: int,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    result_event: dict[str, Any] = {
+        "type": "result",
+        "subtype": "success",
+        "duration_ms": 22670,
+        "duration_api_ms": 22618,
+        "num_turns": 8,
+        "total_cost_usd": 0.0891406,
+        "usage": {
+            "input_tokens": 16,
+            "cache_creation_input_tokens": 8434,
+            "cache_read_input_tokens": 59782,
+            "output_tokens": 1327,
+        },
+        "modelUsage": {},
+    }
 
-    assert not _is_run_qualifying(
-        selected_run=True,
-        complete=True,
-        results=results,
+    def make_solver(*, task: Task, trace_path: Path, transcript_path: Path) -> Solver:
+        del task
+
+        def solve(repo: GitRepo) -> None:
+            del repo
+            trace_path.write_text(
+                f"{json.dumps(result_event)}\n",
+                encoding="utf-8",
+            )
+            transcript_path.write_text("$ git status\n  clean\n", encoding="utf-8")
+
+        return solve
+
+    def run_and_grade(*, task: Task, solver: Solver) -> Result:
+        del task
+        solver(GitRepo(tmp_path))
+        return Result(passed=True)
+
+    monkeypatch.setattr(eval_main.tempfile, "mkdtemp", lambda **kwargs: str(run_dir))
+    monkeypatch.setattr(eval_main, "make_claude_solver", make_solver)
+    monkeypatch.setattr(eval_main, "run_and_grade", run_and_grade)
+    monotonic_values = iter((100.0, 122.67))
+    monkeypatch.setattr(eval_main.time, "monotonic", lambda: next(monotonic_values))
+    environment = EvalEnvironment(
+        checkout=tmp_path,
+        commit="61e2c1911d58abe1e6030b0d3e552c94dc067c39",
+        dirty=True,
+        git_hunk_executable=tmp_path / "git-hunk",
+        imported_package=tmp_path / "git_hunk/__init__.py",
+        skill_paths={},
+        skill_sha256={},
+        claude_code_version="2.1.226 (Claude Code)",
     )
+
+    exit_code = eval_main._run_scenarios(
+        environment=environment,
+        scenarios=SCENARIOS[:scenario_count],
+    )
+
+    expected_usage = (
+        "usage: 22.7s · 8 turns · tokens 16 input / 8.4k cache-write / "
+        "59.8k cache-read / 1.3k output · $0.0891"
+    )
+    output = capsys.readouterr()
+    assert exit_code == 0
+    assert output.err == ""
+    expected_lines = [
+        "eval: model=claude-sonnet-5 claude=2.1.226 commit=61e2c19 dirty=true",
+    ]
+    if scenario_count == 1:
+        expected_lines += [
+            "running: split_refactor_vs_feature",
+            "result:",
+            "  PASS split_refactor_vs_feature",
+            f"  {expected_usage}",
+        ]
+    else:
+        expected_lines += [
+            "running 1/2: split_refactor_vs_feature",
+            "result:",
+            "  PASS split_refactor_vs_feature",
+            f"  {expected_usage}",
+            "running 2/2: separate_mixed_hunks",
+            "result:",
+            "  PASS separate_mixed_hunks",
+            f"  {expected_usage}",
+            "overall: PASS 2/2",
+            "usage: 45.3s · 16 turns · tokens 32 input / 16.9k cache-write / "
+            "119.6k cache-read / 2.7k output · $0.1783",
+        ]
+    expected_lines.append(f"artifacts: {run_dir}")
+    assert output.out.splitlines() == expected_lines
+    manifest = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert manifest["clean_worktree"] is False
+    assert manifest["passed"] is True
+    assert "selected_run" not in manifest
+    assert "complete" not in manifest
+    assert "qualifying" not in manifest
+    assert "retried" not in manifest
+    assert len(manifest["tasks"]) == scenario_count
+    assert manifest["usage"]["cost_usd"] == pytest.approx(0.0891406 * scenario_count)
+    assert manifest["tasks"][0]["usage"]["tokens"]["output"] == 1327
+    assert manifest["tasks"][0]["transcript"] == (
+        "split_refactor_vs_feature.transcript.txt"
+    )
+    assert manifest["tasks"][0]["transcript_sha256"]
+    transcript = (run_dir / manifest["tasks"][0]["transcript"]).read_text(
+        encoding="utf-8"
+    )
+    assert transcript.splitlines()[-3:] == [
+        "result:",
+        "  PASS split_refactor_vs_feature",
+        f"  {expected_usage}",
+    ]


### PR DESCRIPTION
Agent evals previously exposed only the final grade, which made inefficient agent behavior hard to diagnose. This adds a concise live and persisted view of prompts, Bash calls, usage, and cost.

## Summary

- stream tool calls while keeping their output in the complete JSONL trace
- record human-readable transcripts and normalized usage in the run manifest
- allow dirty-checkout and selected-task runs to be used incrementally

## Test plan

- [x] each commit: `uv run pytest tests/eval tests/e2e/skills_test.py tests/package_content_test.py -q`
- [x] each commit: `uv run ty check`
- [x] each commit: `uv run ruff check .`
