### PR TITLE
feat: compare git-hunk with bare Git in evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- Agent evals run every task with git-hunk and bare Git from equivalent initial
+  state for direct workflow and cost comparison, and `--help` lists the
+  available tasks (#216).
 - Agent evals stream composed prompts and Bash calls, report normalized token
   and cost usage, and write human-readable transcripts (#215).
 - `skills` subcommand (`git-hunk skills list|get|path`) serving the bundled,

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -34,13 +34,30 @@ content test builds the wheel and source distribution. It requires both
 archives to contain only the tracked `git_hunk` package files and required
 distribution metadata.
 
-### Test both bundled skills
+### Compare git-hunk with bare Git
 
-Each model task starts with this instruction:
+Every selected task runs twice, first with `git-hunk` and then with bare Git.
+Both variants use the same initial Repository state, model, task-specific
+prompt, and grader. The task is built once, then its complete repository is
+copied back to the same temporary checkout path before each variant so Git
+metadata and the model-visible path are identical. Their composed prompts
+differ only in the tool instruction.
+The git-hunk variant says:
 
 ```text
 Run `git-hunk skills get core logical-commits` and follow both skills.
 ```
+
+The bare-Git variant says:
+
+```text
+Use only Git commands; do not use `git-hunk`.
+```
+
+The fixed order makes repeated runs easy to compare, but raw cost is subject to
+prompt-cache asymmetry: the first variant can create cache entries that the
+second variant reads. The manifest retains cache-creation and cache-read token
+counts separately, so cost comparisons must account for that warm-cache effect.
 
 The evaluator tests commit grouping and order. It does not require a
 Conventional Commit prefix. Commit message format is a project convention, and
@@ -102,18 +119,19 @@ The runner resolves the git-hunk executable, imported package, and both skill
 paths. All paths must be inside the current checkout. It records the Git commit,
 whether the checkout is dirty, and SHA-256 for both skill files.
 
-Claude runs with Bash as its only tool. The allowed Bash commands are
-`git-hunk` and `git`. The permission mode is `dontAsk`. Safe mode, no session
-persistence, no browser integration, and an empty strict MCP configuration are
-required.
+Claude runs with Bash as its only tool. The git-hunk variant allows `git-hunk`
+and `git`; the bare-Git variant allows only `git`. The permission mode is
+`dontAsk`. Safe mode, no session persistence, no browser integration, and an
+empty strict MCP configuration are required.
 
-Each task writes a structured JSONL trace. The trace contains the Claude stream
-events and one eval metadata event with UTC start time, duration, and exit code.
-The runner prints the exact composed prompt, then prints each Bash command as an
+Each task variant writes a structured JSONL trace and transcript whose filenames
+include the variant. The trace contains the Claude stream events and one eval
+metadata event with UTC start time, duration, and exit code. The runner prints
+the variant and exact composed prompt, then prints each Bash command as an
 indented bullet under a `tool calls` section as events arrive, so a human or
-agent can inspect the prompt and tool-use sequence while the task is running. It
-writes the same view to a human-readable task transcript; tool results stay in
-the complete JSONL trace rather than cluttering the concise live view. The
+agent can compare the prompt and tool-use sequence while the task is running.
+It writes the same view to a human-readable task transcript; tool results stay
+in the complete JSONL trace rather than cluttering the concise live view. The
 grader outcome and usage summary appear together under a `result` section.
 
 Validation requires assistant turns, Bash inputs, tool results, one successful
@@ -124,9 +142,10 @@ manifest separately records whole-run wall time. The runner copies normalized
 metrics, including the per-model breakdown, into the run manifest. The original
 fields remain in the trace. The grader never reads the trace.
 
-The runner exits nonzero for a failed task, solver error, environment mismatch,
-or missing or malformed trace. Each selected task is an independent eval run;
-passing it does not depend on running any other task in the same invocation.
+The runner exits nonzero for a failed task variant, solver error, environment
+mismatch, or missing or malformed trace. Each selected task is an independent
+paired comparison; passing it does not depend on running any other task in the
+same invocation.
 
 ### Keep this ADR Proposed in the integration ticket
 

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -14,7 +14,9 @@ from eval.config import TASK_SCHEMA_VERSION
 from eval.environment import EvalEnvironment
 from eval.environment import resolve_environment
 from eval.grader import Result
-from eval.harness import run_and_grade
+from eval.harness import prepare_task
+from eval.model import VARIANTS
+from eval.model import EvalVariant
 from eval.model import TraceUsage
 from eval.model import TranscriptReporter
 from eval.model import aggregate_usage
@@ -29,6 +31,7 @@ from eval.tasks import SCENARIOS
 @dataclasses.dataclass(frozen=True)
 class TaskRun:
     scenario: Scenario
+    variant: EvalVariant
     result: Result
     trace_path: Path
     transcript_path: Path
@@ -84,35 +87,43 @@ def _run_scenarios(
         name = scenario.task.name
         progress = f" {index}/{len(scenarios)}" if multiple_tasks else ""
         print(f"running{progress}: {name}", flush=True)
-        trace_path = run_dir / f"{name}.jsonl"
-        transcript_path = run_dir / f"{name}.transcript.txt"
-        solver = make_claude_solver(
-            task=scenario.task,
-            trace_path=trace_path,
-            transcript_path=transcript_path,
-        )
-        result = run_and_grade(task=scenario.task, solver=solver)
-        usage = read_trace_usage(trace_path=trace_path)
-        mark = "PASS" if result.passed else "FAIL"
-        detail = f": {result.reason}: {result.detail}" if result.detail else ""
-        result_line = f"{mark} {name}{detail}"
-        usage_line = (
-            format_usage(usage=usage) if usage is not None else "usage: unavailable"
-        )
-        with transcript_path.open("a", encoding="utf-8") as transcript:
-            TranscriptReporter(transcript=transcript).report_result(
-                result_line=result_line,
-                usage_line=usage_line,
-            )
-        results.append(
-            TaskRun(
-                scenario=scenario,
-                result=result,
-                trace_path=trace_path,
-                transcript_path=transcript_path,
-                usage=usage,
-            )
-        )
+        with prepare_task(scenario.task) as prepared:
+            for variant in VARIANTS:
+                print(flush=True)
+                artifact_stem = f"{name}.{variant.name}"
+                trace_path = run_dir / f"{artifact_stem}.jsonl"
+                transcript_path = run_dir / f"{artifact_stem}.transcript.txt"
+                solver = make_claude_solver(
+                    task=scenario.task,
+                    variant=variant,
+                    trace_path=trace_path,
+                    transcript_path=transcript_path,
+                )
+                result = prepared.run_and_grade(solver)
+                usage = read_trace_usage(trace_path=trace_path)
+                mark = "PASS" if result.passed else "FAIL"
+                detail = f": {result.reason}: {result.detail}" if result.detail else ""
+                result_line = f"{mark} {name} [{variant.name}]{detail}"
+                usage_line = (
+                    format_usage(usage=usage)
+                    if usage is not None
+                    else "usage: unavailable"
+                )
+                with transcript_path.open("a", encoding="utf-8") as transcript:
+                    TranscriptReporter(transcript=transcript).report_result(
+                        result_line=result_line,
+                        usage_line=usage_line,
+                    )
+                results.append(
+                    TaskRun(
+                        scenario=scenario,
+                        variant=variant,
+                        result=result,
+                        trace_path=trace_path,
+                        transcript_path=transcript_path,
+                        usage=usage,
+                    )
+                )
 
     passed = sum(run.result.passed for run in results)
     run_passed = passed == len(results)
@@ -133,7 +144,7 @@ def _run_scenarios(
         f"{json.dumps(manifest, indent=2, sort_keys=True)}\n",
         encoding="utf-8",
     )
-    if multiple_tasks:
+    if len(results) > 1:
         overall_mark = "PASS" if run_passed else "FAIL"
         print(f"overall: {overall_mark} {passed}/{len(results)}")
         if total_usage is None:
@@ -172,6 +183,7 @@ def _make_manifest(
         task_results.append(
             {
                 "name": run.scenario.task.name,
+                "variant": run.variant.name,
                 "passed": run.result.passed,
                 "reason": run.result.reason,
                 "detail": run.result.detail,
@@ -180,6 +192,8 @@ def _make_manifest(
                 "trace_sha256": trace_hash,
                 "transcript": run.transcript_path.name,
                 "transcript_sha256": transcript_hash,
+                "command_flags": build_command_flags(variant=run.variant),
+                "permission_policy": run.variant.permission_policy,
             }
         )
     return {
@@ -196,8 +210,6 @@ def _make_manifest(
         "skill_sha256": environment.skill_sha256,
         "claude_code_version": environment.claude_code_version,
         "requested_model": MODEL,
-        "command_flags": build_command_flags(),
-        "permission_policy": "Bash only; git-hunk and git commands only",
         "passed": passed,
         "usage": usage.to_dict() if usage is not None else None,
         "tasks": task_results,

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -40,7 +40,12 @@ class TaskRun:
 
 def main(argv: list[str] | None = None) -> int:
     task_names = tuple(scenario.task.name for scenario in SCENARIOS)
-    parser = argparse.ArgumentParser(prog="python -m eval")
+    task_list = "\n".join(f"  {name}" for name in task_names)
+    parser = argparse.ArgumentParser(
+        prog="python -m eval",
+        epilog=f"available tasks:\n{task_list}",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument(
         "--task",
         action="append",

--- a/eval/harness.py
+++ b/eval/harness.py
@@ -1,5 +1,13 @@
+import contextlib
+import dataclasses
 import json
+import shutil
+import stat
 import tempfile
+from collections.abc import Callable
+from collections.abc import Iterator
+from pathlib import Path
+from types import TracebackType
 from typing import Any
 from typing import cast
 
@@ -11,11 +19,31 @@ from eval.scenario import Solver
 from eval.task import Task
 
 
-def run_and_grade(task: Task, solver: Solver) -> Result:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        repo = init_repo(path=temp_dir)
-        task.build(repo)
-        base = repo.git("rev-parse", "HEAD").strip()
+def _remove_readonly(
+    function: Callable[..., object],
+    path: str,
+    exc_info: tuple[type[BaseException], BaseException, TracebackType],
+) -> None:
+    error = exc_info[1]
+    if not isinstance(error, PermissionError):
+        raise error
+    file_path = Path(path)
+    file_path.chmod(file_path.stat().st_mode | stat.S_IWRITE)
+    function(path)
+
+
+@dataclasses.dataclass(frozen=True)
+class PreparedTask:
+    task: Task
+    snapshot_path: Path
+    checkout_path: Path
+    base: str
+
+    def run_and_grade(self, solver: Solver) -> Result:
+        if self.checkout_path.exists():
+            shutil.rmtree(self.checkout_path, onerror=_remove_readonly)
+        shutil.copytree(self.snapshot_path, self.checkout_path, symlinks=True)
+        repo = GitRepo(self.checkout_path)
         try:
             solver(repo)
         except RuntimeError as error:
@@ -24,7 +52,28 @@ def run_and_grade(task: Task, solver: Solver) -> Result:
                 reason="solver-error",
                 detail=str(error),
             )
-        return grade(repo=repo, task=task, base=base)
+        return grade(repo=repo, task=self.task, base=self.base)
+
+
+@contextlib.contextmanager
+def prepare_task(task: Task) -> Iterator[PreparedTask]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        snapshot_path = root / "snapshot"
+        snapshot_path.mkdir()
+        repo = init_repo(path=snapshot_path)
+        task.build(repo)
+        yield PreparedTask(
+            task=task,
+            snapshot_path=snapshot_path,
+            checkout_path=root / "checkout",
+            base=repo.git("rev-parse", "HEAD").strip(),
+        )
+
+
+def run_and_grade(task: Task, solver: Solver) -> Result:
+    with prepare_task(task) as prepared:
+        return prepared.run_and_grade(solver)
 
 
 def run_git_hunk(repo: GitRepo, *args: str) -> str:

--- a/eval/model.py
+++ b/eval/model.py
@@ -17,6 +17,32 @@ from eval.task import Task
 
 
 @dataclasses.dataclass(frozen=True)
+class EvalVariant:
+    name: str
+    tool_instruction: str
+    allowed_tools: tuple[str, ...]
+    permission_policy: str
+
+
+VARIANTS: Final = (
+    EvalVariant(
+        name="git-hunk",
+        tool_instruction=(
+            "Run `git-hunk skills get core logical-commits` and follow both skills."
+        ),
+        allowed_tools=("Bash(git-hunk:*)", "Bash(git:*)"),
+        permission_policy="Bash only; git-hunk and git commands only",
+    ),
+    EvalVariant(
+        name="bare-git",
+        tool_instruction="Use only Git commands; do not use `git-hunk`.",
+        allowed_tools=("Bash(git:*)",),
+        permission_policy="Bash only; git commands only",
+    ),
+)
+
+
+@dataclasses.dataclass(frozen=True)
 class TokenUsage:
     input_tokens: int
     cache_creation_input_tokens: int
@@ -87,10 +113,10 @@ class TraceUsage:
         }
 
 
-def build_prompt(*, task_prompt: str) -> str:
+def build_prompt(*, task_prompt: str, variant: EvalVariant) -> str:
     preamble = (
-        "There are uncommitted changes in this Git repository. Run "
-        "`git-hunk skills get core logical-commits` and follow both skills. "
+        "There are uncommitted changes in this Git repository. "
+        f"{variant.tool_instruction} "
         "Organize the working tree into a clean series of focused commits."
     )
     if not task_prompt:
@@ -98,15 +124,14 @@ def build_prompt(*, task_prompt: str) -> str:
     return f"{preamble}\n\n{task_prompt}"
 
 
-def build_command_flags() -> list[str]:
-    ALLOWED_TOOLS: Final = ("Bash(git-hunk:*)", "Bash(git:*)")
+def build_command_flags(*, variant: EvalVariant) -> list[str]:
     return [
         "--model",
         MODEL,
         "--tools",
         "Bash",
         "--allowedTools",
-        *ALLOWED_TOOLS,
+        *variant.allowed_tools,
         "--permission-mode",
         "dontAsk",
         "--safe-mode",
@@ -121,19 +146,24 @@ def build_command_flags() -> list[str]:
     ]
 
 
-def build_command(*, prompt: str) -> list[str]:
-    return ["claude", "-p", prompt, *build_command_flags()]
+def build_command(*, prompt: str, variant: EvalVariant) -> list[str]:
+    return ["claude", "-p", prompt, *build_command_flags(variant=variant)]
 
 
 def make_claude_solver(
-    *, task: Task, trace_path: Path, transcript_path: Path
+    *,
+    task: Task,
+    variant: EvalVariant,
+    trace_path: Path,
+    transcript_path: Path,
 ) -> Solver:
-    prompt = build_prompt(task_prompt=task.prompt)
+    prompt = build_prompt(task_prompt=task.prompt, variant=variant)
 
     def solve(repo: GitRepo) -> None:
         run_claude(
             repo=repo,
             prompt=prompt,
+            variant=variant,
             trace_path=trace_path,
             transcript_path=transcript_path,
         )
@@ -145,6 +175,7 @@ def run_claude(
     *,
     repo: GitRepo,
     prompt: str,
+    variant: EvalVariant,
     trace_path: Path,
     transcript_path: Path,
 ) -> None:
@@ -154,11 +185,12 @@ def run_claude(
     transcript_path.parent.mkdir(parents=True, exist_ok=True)
     with transcript_path.open("w", encoding="utf-8") as transcript:
         reporter = TranscriptReporter(transcript=transcript)
+        reporter.report_variant(variant=variant)
         reporter.report_prompt(prompt=prompt)
         reporter.report_tool_calls_header()
         try:
             result = repo.run_stream(
-                *build_command(prompt=prompt),
+                *build_command(prompt=prompt, variant=variant),
                 timeout_seconds=MODEL_TIMEOUT_SECONDS,
                 on_stdout_line=reporter.consume_line,
             )
@@ -198,6 +230,9 @@ def run_claude(
 class TranscriptReporter:
     def __init__(self, *, transcript: TextIO) -> None:
         self._transcript = transcript
+
+    def report_variant(self, *, variant: EvalVariant) -> None:
+        self._emit(f"variant: {variant.name}")
 
     def report_prompt(self, *, prompt: str) -> None:
         self._emit("prompt:")

--- a/tests/eval/deterministic_test.py
+++ b/tests/eval/deterministic_test.py
@@ -1,9 +1,16 @@
+import os
+import stat
 import subprocess
+import sys
+from collections.abc import Callable
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Final
 
 import pytest
 
+import eval.harness as eval_harness
+from eval.harness import prepare_task
 from eval.harness import run_and_grade
 from eval.repo import GitRepo
 from eval.scenario import Scenario
@@ -53,6 +60,78 @@ def test_solver_error_is_a_failed_result() -> None:
     assert not result.passed
     assert result.reason == "solver-error"
     assert result.detail == "solver stopped"
+
+
+def test_prepared_task_reuses_exact_initial_repository() -> None:
+    scenario = SCENARIOS[0]
+    initial_repositories: list[tuple[Path, str, str]] = []
+
+    def record_and_solve(repo: GitRepo) -> None:
+        initial_repositories.append(
+            (
+                repo.path,
+                repo.git("rev-parse", "HEAD").strip(),
+                repo.git("status", "--porcelain=v1", "--untracked-files=all"),
+            )
+        )
+        scenario.golden(repo)
+
+    with prepare_task(scenario.task) as prepared:
+        first = prepared.run_and_grade(record_and_solve)
+        second = prepared.run_and_grade(record_and_solve)
+
+    assert first.passed, first.detail
+    assert second.passed, second.detail
+    assert initial_repositories[0] == initial_repositories[1]
+
+
+def test_prepared_task_replaces_windows_readonly_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_shutil = eval_harness.shutil
+
+    def windows_rmtree(
+        path: str | Path,
+        ignore_errors: bool = False,
+        onerror: Callable[..., object] | None = None,
+    ) -> None:
+        checkout_path = Path(path)
+        if checkout_path.name != "checkout":
+            real_shutil.rmtree(path, ignore_errors=ignore_errors, onerror=onerror)
+            return
+        object_path = next(
+            path
+            for path in (checkout_path / ".git" / "objects").rglob("*")
+            if path.is_file()
+        )
+        object_path.chmod(stat.S_IREAD)
+        if onerror is None:
+            raise PermissionError(object_path)
+
+        def unlink_readonly(path: str) -> None:
+            if not os.stat(path).st_mode & stat.S_IWRITE:
+                raise PermissionError(path)
+            os.unlink(path)
+
+        try:
+            raise PermissionError(object_path)
+        except PermissionError:
+            onerror(unlink_readonly, str(object_path), sys.exc_info())
+        real_shutil.rmtree(path, ignore_errors=ignore_errors, onerror=onerror)
+
+    monkeypatch.setattr(
+        eval_harness,
+        "shutil",
+        SimpleNamespace(rmtree=windows_rmtree, copytree=real_shutil.copytree),
+    )
+    scenario = SCENARIOS[0]
+
+    with prepare_task(scenario.task) as prepared:
+        first = prepared.run_and_grade(scenario.golden)
+        second = prepared.run_and_grade(scenario.golden)
+
+    assert first.passed, first.detail
+    assert second.passed, second.detail
 
 
 def test_drop_debug_golden_ignores_global_autocrlf(

--- a/tests/eval/model_test.py
+++ b/tests/eval/model_test.py
@@ -8,6 +8,7 @@ from typing import NoReturn
 import pytest
 
 from eval.config import MODEL
+from eval.model import VARIANTS
 from eval.model import aggregate_usage
 from eval.model import build_command
 from eval.model import build_prompt
@@ -64,16 +65,34 @@ def _write_trace(*, trace_path: Path, events: list[dict[str, Any]]) -> None:
     )
 
 
-def test_prompt_loads_both_bundled_skills() -> None:
-    prompt = build_prompt(task_prompt="Keep unrelated work in place.")
+def test_variant_prompts_differ_only_by_tool_instruction() -> None:
+    task_prompt = "Keep unrelated work in place."
+    git_hunk_variant, bare_git_variant = VARIANTS
+    git_hunk_prompt = build_prompt(
+        task_prompt=task_prompt,
+        variant=git_hunk_variant,
+    )
+    bare_git_prompt = build_prompt(
+        task_prompt=task_prompt,
+        variant=bare_git_variant,
+    )
 
-    assert "git-hunk skills get core logical-commits" in prompt
-    assert "follow both skills" in prompt
-    assert "conventional" not in prompt.lower()
+    git_hunk_instruction = (
+        "Run `git-hunk skills get core logical-commits` and follow both skills."
+    )
+    bare_git_instruction = "Use only Git commands; do not use `git-hunk`."
+    assert git_hunk_instruction in git_hunk_prompt
+    assert bare_git_instruction in bare_git_prompt
+    assert git_hunk_prompt.replace(
+        git_hunk_instruction, "<tool instruction>"
+    ) == bare_git_prompt.replace(bare_git_instruction, "<tool instruction>")
+    assert git_hunk_prompt.endswith(task_prompt)
+    assert bare_git_prompt.endswith(task_prompt)
 
 
 def test_command_pins_model_and_isolates_claude() -> None:
-    command = build_command(prompt="Do the task")
+    git_hunk_variant, bare_git_variant = VARIANTS
+    command = build_command(prompt="Do the task", variant=git_hunk_variant)
 
     assert command[:3] == ["claude", "-p", "Do the task"]
     assert command[command.index("--model") + 1] == MODEL
@@ -91,6 +110,13 @@ def test_command_pins_model_and_isolates_claude() -> None:
         "Bash(git-hunk:*)",
         "Bash(git:*)",
     ]
+
+    bare_git_command = build_command(prompt="Do the task", variant=bare_git_variant)
+    bare_allowed_index = bare_git_command.index("--allowedTools")
+    assert bare_git_command[bare_allowed_index + 1 : bare_allowed_index + 2] == [
+        "Bash(git:*)"
+    ]
+    assert "Bash(git-hunk:*)" not in bare_git_command
 
 
 def test_validate_trace_accepts_complete_trace(
@@ -234,6 +260,7 @@ def test_run_claude_writes_partial_trace_on_timeout(
         run_claude(
             repo=repo,
             prompt="Do the task",
+            variant=VARIANTS[0],
             trace_path=trace_path,
             transcript_path=transcript_path,
         )
@@ -302,12 +329,14 @@ def test_run_claude_streams_tool_calls_without_results(
     run_claude(
         repo=repo,
         prompt="First line.\n\nSecond line.",
+        variant=VARIANTS[0],
         trace_path=trace_path,
         transcript_path=transcript_path,
     )
 
     expected = "\n".join(
         [
+            "variant: git-hunk",
             "prompt:",
             "  First line.",
             "  ",

--- a/tests/eval/runner_test.py
+++ b/tests/eval/runner_test.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import subprocess
 import sys
@@ -9,6 +10,7 @@ import pytest
 import eval.__main__ as eval_main
 from eval.environment import EvalEnvironment
 from eval.grader import Result
+from eval.model import EvalVariant
 from eval.repo import GitRepo
 from eval.scenario import Solver
 from eval.task import Task
@@ -53,27 +55,41 @@ def test_run_reports_context_usage_and_artifacts(
         "modelUsage": {},
     }
 
-    def make_solver(*, task: Task, trace_path: Path, transcript_path: Path) -> Solver:
+    def make_solver(
+        *,
+        task: Task,
+        variant: EvalVariant,
+        trace_path: Path,
+        transcript_path: Path,
+    ) -> Solver:
         del task
 
         def solve(repo: GitRepo) -> None:
             del repo
+            print(f"variant: {variant.name}")
             trace_path.write_text(
                 f"{json.dumps(result_event)}\n",
                 encoding="utf-8",
             )
-            transcript_path.write_text("$ git status\n  clean\n", encoding="utf-8")
+            transcript_path.write_text(
+                f"variant: {variant.name}\n",
+                encoding="utf-8",
+            )
 
         return solve
 
-    def run_and_grade(*, task: Task, solver: Solver) -> Result:
+    class PreparedTask:
+        def run_and_grade(self, solver: Solver) -> Result:
+            solver(GitRepo(tmp_path))
+            return Result(passed=True)
+
+    def prepare_task(task: Task) -> contextlib.AbstractContextManager[PreparedTask]:
         del task
-        solver(GitRepo(tmp_path))
-        return Result(passed=True)
+        return contextlib.nullcontext(PreparedTask())
 
     monkeypatch.setattr(eval_main.tempfile, "mkdtemp", lambda **kwargs: str(run_dir))
     monkeypatch.setattr(eval_main, "make_claude_solver", make_solver)
-    monkeypatch.setattr(eval_main, "run_and_grade", run_and_grade)
+    monkeypatch.setattr(eval_main, "prepare_task", prepare_task)
     monotonic_values = iter((100.0, 122.67))
     monkeypatch.setattr(eval_main.time, "monotonic", lambda: next(monotonic_values))
     environment = EvalEnvironment(
@@ -102,27 +118,26 @@ def test_run_reports_context_usage_and_artifacts(
     expected_lines = [
         "eval: model=claude-sonnet-5 claude=2.1.226 commit=61e2c19 dirty=true",
     ]
-    if scenario_count == 1:
-        expected_lines += [
-            "running: split_refactor_vs_feature",
-            "result:",
-            "  PASS split_refactor_vs_feature",
-            f"  {expected_usage}",
-        ]
-    else:
-        expected_lines += [
-            "running 1/2: split_refactor_vs_feature",
-            "result:",
-            "  PASS split_refactor_vs_feature",
-            f"  {expected_usage}",
-            "running 2/2: separate_mixed_hunks",
-            "result:",
-            "  PASS separate_mixed_hunks",
-            f"  {expected_usage}",
-            "overall: PASS 2/2",
-            "usage: 45.3s · 16 turns · tokens 32 input / 16.9k cache-write / "
-            "119.6k cache-read / 2.7k output · $0.1783",
-        ]
+    for index, scenario in enumerate(SCENARIOS[:scenario_count], start=1):
+        progress = f" {index}/{scenario_count}" if scenario_count > 1 else ""
+        expected_lines.append(f"running{progress}: {scenario.task.name}")
+        for variant in ("git-hunk", "bare-git"):
+            expected_lines.append("")
+            expected_lines += [
+                f"variant: {variant}",
+                "result:",
+                f"  PASS {scenario.task.name} [{variant}]",
+                f"  {expected_usage}",
+            ]
+    run_count = scenario_count * 2
+    expected_lines += [
+        f"overall: PASS {run_count}/{run_count}",
+        f"usage: {run_count * 22.67:.1f}s · {run_count * 8} turns · "
+        f"tokens {run_count * 16} input / "
+        f"{run_count * 8434 / 1000:.1f}k cache-write / "
+        f"{run_count * 59782 / 1000:.1f}k cache-read / "
+        f"{run_count * 1327 / 1000:.1f}k output · ${run_count * 0.0891406:.4f}",
+    ]
     expected_lines.append(f"artifacts: {run_dir}")
     assert output.out.splitlines() == expected_lines
     manifest = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
@@ -132,11 +147,14 @@ def test_run_reports_context_usage_and_artifacts(
     assert "complete" not in manifest
     assert "qualifying" not in manifest
     assert "retried" not in manifest
-    assert len(manifest["tasks"]) == scenario_count
-    assert manifest["usage"]["cost_usd"] == pytest.approx(0.0891406 * scenario_count)
+    assert len(manifest["tasks"]) == run_count
+    assert [task["variant"] for task in manifest["tasks"]] == [
+        variant for _ in range(scenario_count) for variant in ("git-hunk", "bare-git")
+    ]
+    assert manifest["usage"]["cost_usd"] == pytest.approx(0.0891406 * run_count)
     assert manifest["tasks"][0]["usage"]["tokens"]["output"] == 1327
     assert manifest["tasks"][0]["transcript"] == (
-        "split_refactor_vs_feature.transcript.txt"
+        "split_refactor_vs_feature.git-hunk.transcript.txt"
     )
     assert manifest["tasks"][0]["transcript_sha256"]
     transcript = (run_dir / manifest["tasks"][0]["transcript"]).read_text(
@@ -144,6 +162,6 @@ def test_run_reports_context_usage_and_artifacts(
     )
     assert transcript.splitlines()[-3:] == [
         "result:",
-        "  PASS split_refactor_vs_feature",
+        "  PASS split_refactor_vs_feature [git-hunk]",
         f"  {expected_usage}",
     ]

--- a/tests/eval/runner_test.py
+++ b/tests/eval/runner_test.py
@@ -17,6 +17,22 @@ from eval.task import Task
 from eval.tasks import SCENARIOS
 
 
+def test_runner_help_lists_available_tasks() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [sys.executable, "-m", "eval", "--help"],
+        capture_output=True,
+        cwd=repository_root,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    _, task_section = result.stdout.split("available tasks:\n", maxsplit=1)
+    assert task_section.splitlines() == [
+        f"  {scenario.task.name}" for scenario in SCENARIOS
+    ]
+
+
 def test_runner_rejects_model_override_before_running_tasks() -> None:
     repository_root = Path(__file__).resolve().parents[2]
     result = subprocess.run(


### PR DESCRIPTION
Stacked on #215; merge that PR first. The evaluator now runs each scenario with both git-hunk and bare Git from equivalent repository state, making tool-use and cost differences directly comparable.

## Summary

- isolate the two variants with tool-specific permission policies and equivalent prompts
- preserve variant-qualified traces, transcripts, results, and usage metrics
- list valid task names in `eval --help`

## Test plan

- [x] `uv run eval`: 8/8 variants passed
- [x] each commit: `uv run pytest tests/eval tests/e2e/skills_test.py tests/package_content_test.py -q`
- [x] each commit: `uv run ty check`
- [x] each commit: `uv run ruff check .`
