### PR TITLE
perf: condense logical commit guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
 
 - Streamline the core skill around one inspection call and one execution call,
   reducing redundant agent tool use (#217).
+- Condense the logical-commits skill around commit judgment and make core
+  isolate and refresh partial-line and Conditional Hunk ID operations (#218).
 - **Breaking:** Use durable Hunk identity from ADR 0003. JSON returns full
   SHA-256 IDs and `id_stability`; human output shows unique prefixes and marks
   Conditional IDs; commands accept unambiguous case-insensitive prefixes from

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: core
-description: Provides non-interactive git-hunk mechanics for inspecting, splitting, committing, or explicitly discarding working-tree changes by stable Hunk ID or exact Repository path. Use when an agent needs hunk-level staging or commits without an interactive prompt.
+description: Provides non-interactive git-hunk mechanics for inspecting, splitting, committing, or explicitly discarding working-tree changes by Hunk ID or exact Repository path. Use when an agent needs hunk-level staging or commits without an interactive prompt.
 allowed-tools: Bash(git-hunk:*), Bash(git:*)
 ---
 
@@ -16,10 +16,15 @@ After loading the skills, normally use only two more Bash calls:
 
 1. Run `git-hunk list && git-hunk show` once. The list includes untracked files;
    show prints every staged and unstaged diff with its Hunk ID. Plan all commits
-   from that output. Do not also run `git status`, `git diff`, `git log`, `cat`,
-   or individual `show` commands unless information is genuinely missing.
-2. In one Bash call, chain the complete plan: one `git-hunk commit` per logical
-   change, any requested cleanup, then `git-hunk list` as the final check.
+   from that output and record their Hunk IDs. Do not also run `git status`,
+   `git diff`, `git log`, `cat`, or individual `show` commands unless information
+   is genuinely missing.
+2. In one Bash call, chain the plan while it uses Repository paths or Hunk IDs
+   not marked `conditional`. A partial-line operation must be the last
+   mutation in its call; a Conditional Hunk ID operation must be the only
+   mutation. End every execution call with `git-hunk list`. If work remains,
+   inspect that output, replace recorded IDs in the plan, and continue in a new
+   call.
 
 Example:
 
@@ -32,39 +37,49 @@ git-hunk list
 
 `git-hunk commit <id-or-path>... -m <message>` stages exactly the selected
 hunks and commits them. It aborts when the index already contains staged
-changes. Stable Hunk IDs remain valid as other complete hunks are committed, so
-independent commits can be chained. Conditional IDs can change when a duplicate
-hunk is committed; after using one, re-run `git-hunk list` before the next
-mutation. A Repository path selects every changed hunk in that exact file and
-is usually shorter than an ID for a whole-file commit.
+changes. Human output marks Conditional Hunk IDs with `conditional`; IDs of
+complete hunks not marked `conditional` remain valid as other complete hunks
+are committed. A Conditional Hunk ID can change when its Duplicate Hunk group
+changes, so the core loop isolates those operations. A Repository path selects
+every changed hunk in that exact file and is usually shorter than an ID for
+committing an entire file.
 
-The final `git-hunk list` must show no hunks when the whole tree should be clean.
-When the user says to preserve unrelated work, it must show only that work.
+The final `git-hunk list` must show no hunks or untracked inventory entries when
+the whole tree should be clean. Otherwise, it must show only the intentionally
+preserved work.
 
 ## Splitting and cleanup
 
-For part of one hunk, select changed-line positions shown by `git-hunk show`:
+For part of one hunk, select the 1-based body positions shown by `git-hunk show`,
+counting context lines:
 
 ```bash
-git-hunk commit d161935 -l 3,5-7 -m "add retry"
+git-hunk commit d161935 -l 3,5-7 -m "add retry" &&
+git-hunk list
 ```
 
-Prefer content matching when separating a recognizable line; it avoids another
-inspection round trip:
+Prefer content matching when a target line has distinctive text; it avoids
+manually tracking body positions. End the call with the required refresh:
 
 ```bash
 git-hunk commit d161935 --exclude-matching 'print("DEBUG"' -m "fix total" &&
+git-hunk list
+```
+
+After inspecting the refreshed inventory:
+
+```bash
 git-hunk discard src/total.py &&
 git-hunk list
 ```
 
 `--include-matching` and `--exclude-matching` match changed-line content as a
-literal substring; add `--regex` for a regular expression. They are repeatable
-and cannot be combined with `-l`. A partial operation changes the remainder's
-ID. A Repository path selects every remaining hunk in that file, so use the
-shortcut above only when the initial inspection proved that this hunk was the
-file's sole change. Otherwise, re-run `git-hunk list` after the partial commit
-and discard the remainder by its new ID.
+literal substring; add `--regex` for a regular expression. Each is repeatable
+and OR'd, but choose only one of `-l`, `--include-matching`, or
+`--exclude-matching`. Selection requires one text hunk. Whole-file hunks,
+submodule pointer changes, and grouped replacements wider than one-for-one must
+be selected whole. Use a Repository path for the remainder only when no other
+work in that file must be preserved.
 
 Use `git-hunk stage` plus `git commit` only when staged inspection is required.
 Use `git-hunk unstage` to correct staging. `git-hunk discard` permanently
@@ -74,8 +89,9 @@ cleanup or confirmed it.
 ## Boundaries
 
 - Paths are exact, worktree-root-relative Repository paths; they are not globs
-  or Git pathspecs. `show` accepts IDs only, while mutation commands accept IDs
-  or paths. Shell-quote every path operand copied from inventory output.
+  or Git pathspecs. `show` accepts Hunk IDs only, `list` accepts Repository paths
+  only, and mutation commands accept either. Shell-quote every path operand
+  copied from inventory output.
 - Untracked files have no Hunk ID. For a commit that combines them with tracked
   hunks, run `git-hunk stage <id-or-path>...`, then
   `git --literal-pathspecs -C "$(git rev-parse --show-toplevel)" add -- 'path/to/file'`,

--- a/git_hunk/skills/logical-commits/SKILL.md
+++ b/git_hunk/skills/logical-commits/SKILL.md
@@ -1,42 +1,30 @@
 ---
 name: logical-commits
-description: Group hunks into logical commits, one logical change per commit, ordered so each commit is independently valid, with a message that describes that one change. Use when splitting a pile of changes into commits in a project with no commit conventions of its own.
+description: Decides how to group, order, and describe working-tree changes as focused commits. Use when splitting mixed changes in a project with no commit conventions of its own.
 allowed-tools: Bash(git-hunk:*), Bash(git:*)
 ---
 
 # git-hunk logical commits
 
-Judgment guidance for splitting changes into logical commits. The mechanics of
-inspecting and staging hunks are in the `core` skill; this skill covers only
-what belongs in which commit, in what order, and how its message reads.
+Plan the entire commit series from the core skill's diff output before changing
+the repository, and follow that skill's command workflow.
 
-## Grouping hunks into commits
+## Grouping
 
-Plan the commits *before* you stage anything. For each planned commit, write
-down the current Hunk IDs it contains. Refresh the inventory and recorded IDs
-after a partial operation or an operation on a Conditional Hunk ID. Use the
-`core` skill for ID and command behavior.
+- Put one intent in each commit: one feature, fix, refactor, test, or formatting
+  change.
+- Group by intent, not file. Related hunks across files belong together;
+  unrelated hunks in one file stay apart.
+- Preserve incomplete or unrelated work when the user asks. If intent remains
+  genuinely ambiguous after reading the diff, ask instead of guessing.
 
-- **One logical change per commit.** A bug fix, a refactor, a feature, a
-  formatting pass, a test: each is its own commit, even when they touch the
-  same file.
-- **Group by intent, not by file.** Two hunks in different files that serve one
-  change belong together; two hunks in one file that serve different changes
-  belong apart.
-- **When grouping is ambiguous, ask the user.** Don't guess at intent you can't
-  see in the diff.
+## Ordering
 
-## Ordering commits
+Each commit must stand alone: the build and tests would pass at every commit,
+not only the last. Put prerequisites first: a refactor, rename, or signature
+change precedes behavior that depends on it. Keep pure formatting separate.
 
-Order so that **each commit is independently valid**: the build/tests would
-pass at every commit, not just at the end.
+## Messages
 
-- Refactors and groundwork that a feature depends on come **before** the feature.
-- A symbol rename or signature change comes before the code that uses the new form.
-- Pure formatting goes in its own commit (first or last), never mixed into a
-  logic commit where it hides the real change.
-
-## Commit messages
-
-The message describes the commit's one logical change. Its format follows the
-project's own conventions.
+Follow any clear repository convention. Otherwise use a concise message
+describing only that commit's change.

--- a/tests/e2e/skills_test.py
+++ b/tests/e2e/skills_test.py
@@ -24,9 +24,16 @@ def test_list_shows_skill_name(cli: GitHunkCLI) -> None:
 def test_list_json(cli: GitHunkCLI) -> None:
     skills = cli.run_json("skills", "list", "--json")
     names = [skill["name"] for skill in skills]
-    assert "core" in names
+    assert {"core", "logical-commits"} <= set(names)
     core = next(s for s in skills if s["name"] == "core")
     assert "git-hunk" in core["description"].lower()
+
+
+def test_list_json_has_parsed_skill_descriptions(cli: GitHunkCLI) -> None:
+    for skill in cli.run_json("skills", "list", "--json"):
+        description = skill["description"]
+        assert description.endswith("."), skill["name"]
+        assert "Use when" in description, skill["name"]
 
 
 def test_get_outputs_full_content(cli: GitHunkCLI) -> None:


### PR DESCRIPTION
Restacked on `main` after #217 merged. The logical-commits skill repeated mechanics already owned by the core skill, so every agent run paid for guidance it did not need.

The final clean-tree paired eval kept 8/8 success. Compared with bare Git, git-hunk used 13 vs 30 tool calls, 92,753 vs 196,929 reported tokens, and $0.1780 vs $0.2511.

## Test plan

- [x] paired agent eval: 8/8 variants passed
- [x] `uv run pytest tests/`: 705 passed at each commit
- [x] `uv run ty check --no-progress`
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run mdformat --check ...`
- [x] `uv run typos`
