### PR TITLE
feat: report eval runs as a git-hunk vs bare-git table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ### Added
 
+- Agent evals end with a Markdown summary table comparing git-hunk and bare Git
+  per task, with outcome, turns, and cost per cell, a legend for the failure
+  reasons that occurred, and the prompt-cache caveat that makes the cost column
+  readable. The exit code now reports the subject under test (the git-hunk
+  variant) and solver errors, so a graded bare-Git failure is evidence instead
+  of a red run (#221).
 - Agent evals run every task with git-hunk and bare Git from equivalent initial
   state for direct workflow and cost comparison, and `--help` lists the
   available tasks (#216).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -74,6 +74,10 @@
 - **git-hunk toolchain**: the git-hunk CLI together with the bundled `core` and
   `logical-commits` skills as presented to an agent.
 
+- **Subject under test**: the eval variant whose graded outcome decides the run's exit
+  code. The git-hunk variant is the subject; bare Git is the comparison baseline, so its
+  graded outcome is evidence and never fails the run.
+
 - **Agent demonstration**: one side-by-side scenario run by the same pinned agent
   from the same Repository state with bare Git and with the git-hunk toolchain. It
   illustrates the difference between the resulting commit series but is not a

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -58,6 +58,9 @@ The fixed order makes repeated runs easy to compare, but raw cost is subject to
 prompt-cache asymmetry: the first variant can create cache entries that the
 second variant reads. The manifest retains cache-creation and cache-read token
 counts separately, so cost comparisons must account for that warm-cache effect.
+Because the run ends with a table that places both variants' costs side by side,
+the runner prints that caveat directly under the table. A reader who copies the
+table therefore copies the reason its cost column is not order-neutral.
 
 The evaluator tests commit grouping and order. It does not require a
 Conventional Commit prefix. Commit message format is a project convention, and
@@ -136,14 +139,40 @@ grader outcome and usage summary appear together under a `result` section.
 
 Validation requires assistant turns, Bash inputs, tool results, one successful
 result event, and the pinned reported model. When Claude reports usage and cost,
-the runner prints compact per-task summaries and, for multi-task invocations, an
-aggregate summary. Usage durations come from Claude's task results; the run
-manifest separately records whole-run wall time. The runner copies normalized
-metrics, including the per-model breakdown, into the run manifest. The original
-fields remain in the trace. The grader never reads the trace.
+the runner prints a compact per-task summary. Usage durations come from Claude's
+task results; the run manifest separately records whole-run wall time.
 
-The runner exits nonzero for a failed task variant, solver error, environment
-mismatch, or missing or malformed trace. Each selected task is an independent
+The runner copies normalized metrics, including the per-model breakdown, into
+the run manifest. The original fields remain in the trace. The grader never
+reads the trace. The manifest field for the run-level verdict is `gate_passed`,
+not `passed`, because it reports the exit-code gate below rather than every
+graded outcome.
+
+The run ends with one Markdown table: a row per task, a column per variant, and
+a cell holding that variant's outcome, turn count, and cost. A multi-task run
+adds a total row whose per-variant count is how many of those distinct tasks
+that variant got right. Because each cell is one sample, that count is a
+demonstration tally and not a success rate over repeated trials. Grading is the
+headline, so a failed cell names the grader's failure reason verbatim and a
+legend below the table glosses only the reasons that occurred. That keeps one
+vocabulary across grader, manifest, transcript, and table. The legend is a
+Markdown list: consecutive bare lines collapse into one rendered paragraph,
+which would make a pasted legend unreadable. A cell whose run reported no usage
+shows the outcome with its metrics collapsed, and the total then states how many
+runs reported, including when none did. Cost is rounded to the cent, and a
+nonzero cost that would round to zero renders as `<$0.01` instead. The table
+replaces a separate aggregate line, which would restate the total row with less
+detail. Task rows are named by the task identifier that `--task` selects, not by
+a prose title, so a reader can rerun any single row.
+
+The exit code reports the subject under test, not the comparison. Each variant
+declares whether it is the subject, so the gate reads that flag rather than
+matching a variant name. The runner exits zero only when every subject variant
+passes. A graded bare-Git outcome is evidence and never fails the run, because
+the runs that best show what git-hunk adds are exactly the runs where bare Git
+fails. The runner still exits nonzero for a solver error in either variant, an
+environment mismatch, or a missing or malformed trace: those are broken
+infrastructure rather than a graded result. Each selected task is an independent
 paired comparison; passing it does not depend on running any other task in the
 same invocation.
 
@@ -163,5 +192,9 @@ gates pass.
 - Release artifacts cannot include evaluator code or run data.
 - A line-set collision cannot hide an incorrect final tree.
 - Staged, tracked, and untracked leftovers have separate diagnoses.
+- A bare-Git failure is a published result, not a red run.
+- The table reports one sample per cell. It is an agent demonstration, not a
+  statistical benchmark, so its totals count distinct tasks rather than repeated
+  trials of one task.
 - A later change to the CLI, either skill, an eval task, the runner, or the
   Claude Code version makes an earlier model result stale.

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -1,5 +1,4 @@
 import argparse
-import dataclasses
 import datetime
 import hashlib
 import json
@@ -13,10 +12,10 @@ from eval.config import MODEL
 from eval.config import TASK_SCHEMA_VERSION
 from eval.environment import EvalEnvironment
 from eval.environment import resolve_environment
-from eval.grader import Result
+from eval.grader import SOLVER_ERROR
 from eval.harness import prepare_task
 from eval.model import VARIANTS
-from eval.model import EvalVariant
+from eval.model import TaskRun
 from eval.model import TraceUsage
 from eval.model import TranscriptReporter
 from eval.model import aggregate_usage
@@ -25,17 +24,8 @@ from eval.model import format_usage
 from eval.model import make_claude_solver
 from eval.model import read_trace_usage
 from eval.scenario import Scenario
+from eval.summary import render_summary
 from eval.tasks import SCENARIOS
-
-
-@dataclasses.dataclass(frozen=True)
-class TaskRun:
-    scenario: Scenario
-    variant: EvalVariant
-    result: Result
-    trace_path: Path
-    transcript_path: Path
-    usage: TraceUsage | None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -107,7 +97,9 @@ def _run_scenarios(
                 result = prepared.run_and_grade(solver)
                 usage = read_trace_usage(trace_path=trace_path)
                 mark = "PASS" if result.passed else "FAIL"
-                detail = f": {result.reason}: {result.detail}" if result.detail else ""
+                detail = f": {result.reason}" if result.reason else ""
+                if result.detail:
+                    detail += f": {result.detail}"
                 result_line = f"{mark} {name} [{variant.name}]{detail}"
                 usage_line = (
                     format_usage(usage=usage)
@@ -130,9 +122,8 @@ def _run_scenarios(
                     )
                 )
 
-    passed = sum(run.result.passed for run in results)
-    run_passed = passed == len(results)
-    exit_code = 0 if run_passed else 1
+    gate_passed = _gate_passed(results=results)
+    exit_code = 0 if gate_passed else 1
     duration_seconds = time.monotonic() - started_clock
     reported_usages = tuple(run.usage for run in results if run.usage is not None)
     total_usage = aggregate_usage(usages=reported_usages)
@@ -142,27 +133,26 @@ def _run_scenarios(
         started_at=started_at,
         duration_seconds=duration_seconds,
         exit_code=exit_code,
-        passed=run_passed,
+        gate_passed=gate_passed,
         usage=total_usage,
     )
     (run_dir / "run.json").write_text(
         f"{json.dumps(manifest, indent=2, sort_keys=True)}\n",
         encoding="utf-8",
     )
-    if len(results) > 1:
-        overall_mark = "PASS" if run_passed else "FAIL"
-        print(f"overall: {overall_mark} {passed}/{len(results)}")
-        if total_usage is None:
-            print("usage: unavailable")
-        else:
-            total_usage_line = format_usage(usage=total_usage)
-            if len(reported_usages) != len(results):
-                total_usage_line += (
-                    f" ({len(reported_usages)}/{len(results)} tasks reported)"
-                )
-            print(total_usage_line)
+    summary = render_summary(runs=results)
+    if summary:
+        print()
+        print(summary)
+        print()
     print(f"artifacts: {run_dir}")
     return exit_code
+
+
+def _gate_passed(*, results: list[TaskRun]) -> bool:
+    if any(run.result.reason == SOLVER_ERROR for run in results):
+        return False
+    return all(run.result.passed for run in results if run.variant.subject_under_test)
 
 
 def _make_manifest(
@@ -172,7 +162,7 @@ def _make_manifest(
     started_at: datetime.datetime,
     duration_seconds: float,
     exit_code: int,
-    passed: bool,
+    gate_passed: bool,
     usage: TraceUsage | None,
 ) -> dict[str, Any]:
     task_results = []
@@ -215,7 +205,7 @@ def _make_manifest(
         "skill_sha256": environment.skill_sha256,
         "claude_code_version": environment.claude_code_version,
         "requested_model": MODEL,
-        "passed": passed,
+        "gate_passed": gate_passed,
         "usage": usage.to_dict() if usage is not None else None,
         "tasks": task_results,
         "exit_code": exit_code,

--- a/eval/grader.py
+++ b/eval/grader.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os
 import stat
+from typing import Final
 from typing import Literal
 from typing import cast
 
@@ -21,12 +22,18 @@ FailureReason = Literal[
     "solver-error",
 ]
 
+SOLVER_ERROR: Final[FailureReason] = "solver-error"
+
 
 @dataclasses.dataclass(frozen=True)
 class Result:
     passed: bool
     reason: FailureReason | None = None
     detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.passed != (self.reason is None):
+            raise ValueError("a Result has a failure reason if and only if it failed")
 
 
 def grade(repo: GitRepo, task: Task, base: str) -> Result:

--- a/eval/harness.py
+++ b/eval/harness.py
@@ -11,6 +11,7 @@ from types import TracebackType
 from typing import Any
 from typing import cast
 
+from eval.grader import SOLVER_ERROR
 from eval.grader import Result
 from eval.grader import grade
 from eval.repo import GitRepo
@@ -49,7 +50,7 @@ class PreparedTask:
         except RuntimeError as error:
             return Result(
                 passed=False,
-                reason="solver-error",
+                reason=SOLVER_ERROR,
                 detail=str(error),
             )
         return grade(repo=repo, task=self.task, base=self.base)

--- a/eval/model.py
+++ b/eval/model.py
@@ -11,7 +11,9 @@ from typing import TextIO
 from typing import cast
 
 from eval.config import MODEL
+from eval.grader import Result
 from eval.repo import GitRepo
+from eval.scenario import Scenario
 from eval.scenario import Solver
 from eval.task import Task
 
@@ -22,6 +24,7 @@ class EvalVariant:
     tool_instruction: str
     allowed_tools: tuple[str, ...]
     permission_policy: str
+    subject_under_test: bool
 
 
 VARIANTS: Final = (
@@ -32,12 +35,14 @@ VARIANTS: Final = (
         ),
         allowed_tools=("Bash(git-hunk:*)", "Bash(git:*)"),
         permission_policy="Bash only; git-hunk and git commands only",
+        subject_under_test=True,
     ),
     EvalVariant(
         name="bare-git",
         tool_instruction="Use only Git commands; do not use `git-hunk`.",
         allowed_tools=("Bash(git:*)",),
         permission_policy="Bash only; git commands only",
+        subject_under_test=False,
     ),
 )
 
@@ -111,6 +116,16 @@ class TraceUsage:
             "tokens": self.tokens.to_dict(),
             "models": {name: usage.to_dict() for name, usage in self.models.items()},
         }
+
+
+@dataclasses.dataclass(frozen=True)
+class TaskRun:
+    scenario: Scenario
+    variant: EvalVariant
+    result: Result
+    trace_path: Path
+    transcript_path: Path
+    usage: TraceUsage | None
 
 
 def build_prompt(*, task_prompt: str, variant: EvalVariant) -> str:

--- a/eval/summary.py
+++ b/eval/summary.py
@@ -1,0 +1,123 @@
+from collections.abc import Iterable
+from typing import Final
+
+from eval.grader import FailureReason
+from eval.model import TaskRun
+from eval.model import TraceUsage
+
+_CACHE_CAVEAT: Final = (
+    "{second} runs second and may read cache written by the {first} run; "
+    "costs are not order-neutral."
+)
+
+REASON_LEGEND: Final[dict[FailureReason, str]] = {
+    "partition": "commits do not match the required change groups",
+    "order": "a required commit order constraint is violated",
+    "final-tree": "the final HEAD tree does not match the expected files",
+    "leftover-index": "the index does not match HEAD",
+    "leftover-worktree": "tracked worktree files do not match the expected state",
+    "leftover-untracked": "untracked files do not match the expected state",
+    "solver-error": "the model run failed before grading",
+}
+
+_MISSING_METRICS: Final = "—"
+
+# A cost strictly below this rounds to $0.00 at cent precision, which would read
+# as free rather than as cheap.
+_ROUNDS_TO_ZERO_USD: Final = 0.005
+
+
+def render_summary(*, runs: list[TaskRun]) -> str:
+    if not runs:
+        return ""
+    variant_names = _unique_in_order(values=(run.variant.name for run in runs))
+    task_names = _unique_in_order(values=(run.scenario.task.name for run in runs))
+    by_cell = {(run.scenario.task.name, run.variant.name): run for run in runs}
+
+    rows = [["Task", *variant_names]]
+    rows += [
+        [
+            task_name,
+            *(
+                _format_cell(run=by_cell[(task_name, variant_name)])
+                for variant_name in variant_names
+            ),
+        ]
+        for task_name in task_names
+    ]
+    if len(task_names) > 1:
+        rows.append(
+            [
+                "**total**",
+                *(
+                    _format_total(
+                        runs=[run for run in runs if run.variant.name == variant_name]
+                    )
+                    for variant_name in variant_names
+                ),
+            ]
+        )
+
+    lines = _format_table(rows=rows)
+    if len(variant_names) == 2:
+        first, second = variant_names
+        lines += ["", _CACHE_CAVEAT.format(first=first, second=second)]
+    legend = _format_legend(runs=runs)
+    if legend:
+        lines += ["", *legend]
+    return "\n".join(lines)
+
+
+def _unique_in_order(*, values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _format_cell(*, run: TaskRun) -> str:
+    outcome = "PASS" if run.result.passed else f"FAIL {run.result.reason}"
+    usages = [] if run.usage is None else [run.usage]
+    return f"{outcome} · {_format_metrics(usages=usages)}"
+
+
+def _format_total(*, runs: list[TaskRun]) -> str:
+    passed = sum(run.result.passed for run in runs)
+    usages = [run.usage for run in runs if run.usage is not None]
+    total = f"**{passed}/{len(runs)} · {_format_metrics(usages=usages)}**"
+    if len(usages) != len(runs):
+        total += f" ({len(usages)}/{len(runs)} reported)"
+    return total
+
+
+def _format_metrics(*, usages: list[TraceUsage]) -> str:
+    if not usages:
+        return _MISSING_METRICS
+    turns = sum(usage.turns for usage in usages)
+    return f"{turns}t · {_format_cost(value=sum(usage.cost_usd for usage in usages))}"
+
+
+def _format_cost(*, value: float) -> str:
+    if 0 < value < _ROUNDS_TO_ZERO_USD:
+        return "<$0.01"
+    return f"${value:.2f}"
+
+
+def _format_legend(*, runs: list[TaskRun]) -> list[str]:
+    reasons = {run.result.reason for run in runs if not run.result.passed}
+    return [
+        f"- {reason}: {gloss}"
+        for reason, gloss in REASON_LEGEND.items()
+        if reason in reasons
+    ]
+
+
+def _format_table(*, rows: list[list[str]]) -> list[str]:
+    widths = [max(len(cell) for cell in column) for column in zip(*rows)]
+    header, *body = rows
+    separator: list[str] = ["-" * width for width in widths]
+    return [
+        _format_row(cells=cells, widths=widths) for cells in (header, separator, *body)
+    ]
+
+
+def _format_row(*, cells: list[str], widths: list[int]) -> str:
+    padded = " | ".join(cell.ljust(width) for cell, width in zip(cells, widths))
+    return f"| {padded} |"

--- a/tests/eval/grader_test.py
+++ b/tests/eval/grader_test.py
@@ -3,6 +3,7 @@ from typing import Final
 import pytest
 
 from eval.grader import FailureReason
+from eval.grader import Result
 from eval.grader import grade
 from eval.repo import GitRepo
 from eval.scenario import Solver
@@ -22,6 +23,19 @@ _FAILURE_PARAMS: Final = [
     pytest.param(task, solver, reason, id=reason)
     for reason, (task, solver) in _FAILURE_CASES.items()
 ]
+
+
+@pytest.mark.parametrize(
+    ("passed", "reason"),
+    [(False, None), (True, "order")],
+    ids=["failed-without-reason", "passed-with-reason"],
+)
+def test_result_requires_a_failure_reason_exactly_when_it_failed(
+    passed: bool,
+    reason: FailureReason | None,
+) -> None:
+    with pytest.raises(ValueError, match="if and only if it failed"):
+        Result(passed=passed, reason=reason)
 
 
 def test_grade_accepts_exact_repository_state(eval_repo: GitRepo) -> None:

--- a/tests/eval/runner_test.py
+++ b/tests/eval/runner_test.py
@@ -2,8 +2,10 @@ import contextlib
 import json
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from typing import Final
 
 import pytest
 
@@ -15,6 +17,11 @@ from eval.repo import GitRepo
 from eval.scenario import Solver
 from eval.task import Task
 from eval.tasks import SCENARIOS
+
+_CACHE_CAVEAT: Final = (
+    "bare-git runs second and may read cache written by the git-hunk run; "
+    "costs are not order-neutral."
+)
 
 
 def test_runner_help_lists_available_tasks() -> None:
@@ -46,30 +53,32 @@ def test_runner_rejects_model_override_before_running_tasks() -> None:
     assert "unrecognized arguments: --model opus" in result.stderr
 
 
-@pytest.mark.parametrize("scenario_count", [1, 2])
-def test_run_reports_context_usage_and_artifacts(
+_RESULT_EVENT: Final[dict[str, Any]] = {
+    "type": "result",
+    "subtype": "success",
+    "duration_ms": 22670,
+    "duration_api_ms": 22618,
+    "num_turns": 8,
+    "total_cost_usd": 0.0891406,
+    "usage": {
+        "input_tokens": 16,
+        "cache_creation_input_tokens": 8434,
+        "cache_read_input_tokens": 59782,
+        "output_tokens": 1327,
+    },
+    "modelUsage": {},
+}
+
+
+def _install_fake_run(
+    *,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
-    scenario_count: int,
-) -> None:
-    run_dir = tmp_path / "run"
-    run_dir.mkdir()
-    result_event: dict[str, Any] = {
-        "type": "result",
-        "subtype": "success",
-        "duration_ms": 22670,
-        "duration_api_ms": 22618,
-        "num_turns": 8,
-        "total_cost_usd": 0.0891406,
-        "usage": {
-            "input_tokens": 16,
-            "cache_creation_input_tokens": 8434,
-            "cache_read_input_tokens": 59782,
-            "output_tokens": 1327,
-        },
-        "modelUsage": {},
-    }
+    run_dir: Path,
+    next_result: Callable[[], Result],
+    monotonic: Callable[[], float],
+) -> EvalEnvironment:
+    """Drive `_run_scenarios` without a model: fake solver, grade, and clock."""
 
     def make_solver(
         *,
@@ -84,7 +93,7 @@ def test_run_reports_context_usage_and_artifacts(
             del repo
             print(f"variant: {variant.name}")
             trace_path.write_text(
-                f"{json.dumps(result_event)}\n",
+                f"{json.dumps(_RESULT_EVENT)}\n",
                 encoding="utf-8",
             )
             transcript_path.write_text(
@@ -97,7 +106,7 @@ def test_run_reports_context_usage_and_artifacts(
     class PreparedTask:
         def run_and_grade(self, solver: Solver) -> Result:
             solver(GitRepo(tmp_path))
-            return Result(passed=True)
+            return next_result()
 
     def prepare_task(task: Task) -> contextlib.AbstractContextManager[PreparedTask]:
         del task
@@ -106,9 +115,8 @@ def test_run_reports_context_usage_and_artifacts(
     monkeypatch.setattr(eval_main.tempfile, "mkdtemp", lambda **kwargs: str(run_dir))
     monkeypatch.setattr(eval_main, "make_claude_solver", make_solver)
     monkeypatch.setattr(eval_main, "prepare_task", prepare_task)
-    monotonic_values = iter((100.0, 122.67))
-    monkeypatch.setattr(eval_main.time, "monotonic", lambda: next(monotonic_values))
-    environment = EvalEnvironment(
+    monkeypatch.setattr(eval_main.time, "monotonic", monotonic)
+    return EvalEnvironment(
         checkout=tmp_path,
         commit="61e2c1911d58abe1e6030b0d3e552c94dc067c39",
         dirty=True,
@@ -117,6 +125,48 @@ def test_run_reports_context_usage_and_artifacts(
         skill_paths={},
         skill_sha256={},
         claude_code_version="2.1.226 (Claude Code)",
+    )
+
+
+_SINGLE_TASK_SUMMARY: Final = [
+    "| Task                      | git-hunk          | bare-git          |",
+    "| ------------------------- | ----------------- | ----------------- |",
+    "| split_refactor_vs_feature | PASS · 8t · $0.09 | PASS · 8t · $0.09 |",
+    "",
+    _CACHE_CAVEAT,
+]
+
+_TWO_TASK_SUMMARY: Final = [
+    "| Task                      | git-hunk              | bare-git              |",
+    "| ------------------------- | --------------------- | --------------------- |",
+    "| split_refactor_vs_feature | PASS · 8t · $0.09     | PASS · 8t · $0.09     |",
+    "| separate_mixed_hunks      | PASS · 8t · $0.09     | PASS · 8t · $0.09     |",
+    "| **total**                 | **2/2 · 16t · $0.18** | **2/2 · 16t · $0.18** |",
+    "",
+    _CACHE_CAVEAT,
+]
+
+
+@pytest.mark.parametrize(
+    ("scenario_count", "expected_summary"),
+    [(1, _SINGLE_TASK_SUMMARY), (2, _TWO_TASK_SUMMARY)],
+)
+def test_run_reports_context_usage_and_artifacts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    scenario_count: int,
+    expected_summary: list[str],
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monotonic_values = iter((100.0, 122.67))
+    environment = _install_fake_run(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        run_dir=run_dir,
+        next_result=lambda: Result(passed=True),
+        monotonic=lambda: next(monotonic_values),
     )
 
     exit_code = eval_main._run_scenarios(
@@ -146,19 +196,12 @@ def test_run_reports_context_usage_and_artifacts(
                 f"  {expected_usage}",
             ]
     run_count = scenario_count * 2
-    expected_lines += [
-        f"overall: PASS {run_count}/{run_count}",
-        f"usage: {run_count * 22.67:.1f}s · {run_count * 8} turns · "
-        f"tokens {run_count * 16} input / "
-        f"{run_count * 8434 / 1000:.1f}k cache-write / "
-        f"{run_count * 59782 / 1000:.1f}k cache-read / "
-        f"{run_count * 1327 / 1000:.1f}k output · ${run_count * 0.0891406:.4f}",
-    ]
-    expected_lines.append(f"artifacts: {run_dir}")
+    expected_lines += ["", *expected_summary, "", f"artifacts: {run_dir}"]
     assert output.out.splitlines() == expected_lines
     manifest = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
     assert manifest["clean_worktree"] is False
-    assert manifest["passed"] is True
+    assert manifest["gate_passed"] is True
+    assert "passed" not in manifest
     assert "selected_run" not in manifest
     assert "complete" not in manifest
     assert "qualifying" not in manifest
@@ -181,3 +224,43 @@ def test_run_reports_context_usage_and_artifacts(
         "  PASS split_refactor_vs_feature [git-hunk]",
         f"  {expected_usage}",
     ]
+
+
+@pytest.mark.parametrize(
+    ("results", "expected_exit_code"),
+    [
+        ((Result(passed=True), Result(passed=True)), 0),
+        ((Result(passed=True), Result(passed=False, reason="partition")), 0),
+        ((Result(passed=False, reason="order"), Result(passed=True)), 1),
+        ((Result(passed=True), Result(passed=False, reason="solver-error")), 1),
+    ],
+    ids=["both-pass", "bare-git-graded-failure", "git-hunk-failure", "solver-error"],
+)
+def test_run_gates_on_subject_variant_outcomes_and_solver_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    results: tuple[Result, Result],
+    expected_exit_code: int,
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    pending = list(results)
+    environment = _install_fake_run(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        run_dir=run_dir,
+        next_result=lambda: pending.pop(0),
+        monotonic=lambda: 0.0,
+    )
+
+    exit_code = eval_main._run_scenarios(
+        environment=environment,
+        scenarios=SCENARIOS[:1],
+    )
+
+    capsys.readouterr()
+    assert exit_code == expected_exit_code
+    manifest = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert manifest["gate_passed"] is (expected_exit_code == 0)
+    assert manifest["exit_code"] == expected_exit_code

--- a/tests/eval/summary_test.py
+++ b/tests/eval/summary_test.py
@@ -1,0 +1,239 @@
+from pathlib import Path
+from typing import get_args
+
+from eval.grader import FailureReason
+from eval.grader import Result
+from eval.model import VARIANTS
+from eval.model import TaskRun
+from eval.model import TokenUsage
+from eval.model import TraceUsage
+from eval.scenario import Scenario
+from eval.summary import REASON_LEGEND
+from eval.summary import render_summary
+from eval.tasks import SCENARIOS
+
+_CACHE_CAVEAT = (
+    "bare-git runs second and may read cache written by the git-hunk run; "
+    "costs are not order-neutral."
+)
+
+
+def _make_usage(*, turns: int, cost_usd: float) -> TraceUsage:
+    return TraceUsage(
+        duration_seconds=22.67,
+        api_duration_seconds=22.62,
+        turns=turns,
+        cost_usd=cost_usd,
+        tokens=TokenUsage(
+            input_tokens=16,
+            cache_creation_input_tokens=8434,
+            cache_read_input_tokens=59782,
+            output_tokens=1327,
+        ),
+        models={},
+    )
+
+
+def _make_run(
+    *,
+    scenario: Scenario,
+    variant_index: int,
+    passed: bool,
+    reason: FailureReason | None = None,
+    usage: TraceUsage | None,
+) -> TaskRun:
+    return TaskRun(
+        scenario=scenario,
+        variant=VARIANTS[variant_index],
+        result=Result(
+            passed=passed, reason=reason, detail="detail" if reason else None
+        ),
+        trace_path=Path("trace.jsonl"),
+        transcript_path=Path("transcript.txt"),
+        usage=usage,
+    )
+
+
+def test_render_summary_pairs_variants_and_totals_reported_metrics() -> None:
+    runs = [
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=0,
+            passed=True,
+            usage=_make_usage(turns=12, cost_usd=0.21),
+        ),
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=1,
+            passed=False,
+            reason="order",
+            usage=_make_usage(turns=9, cost_usd=0.18),
+        ),
+        _make_run(
+            scenario=SCENARIOS[1],
+            variant_index=0,
+            passed=True,
+            usage=_make_usage(turns=10, cost_usd=0.19),
+        ),
+        _make_run(
+            scenario=SCENARIOS[1],
+            variant_index=1,
+            passed=False,
+            reason="leftover-worktree",
+            usage=_make_usage(turns=8, cost_usd=0.15),
+        ),
+    ]
+
+    assert render_summary(runs=runs).splitlines() == [
+        "| Task                      | git-hunk              "
+        "| bare-git                            |",
+        "| ------------------------- | --------------------- "
+        "| ----------------------------------- |",
+        "| split_refactor_vs_feature | PASS · 12t · $0.21    "
+        "| FAIL order · 9t · $0.18             |",
+        "| separate_mixed_hunks      | PASS · 10t · $0.19    "
+        "| FAIL leftover-worktree · 8t · $0.15 |",
+        "| **total**                 | **2/2 · 22t · $0.40** "
+        "| **0/2 · 17t · $0.33**               |",
+        "",
+        _CACHE_CAVEAT,
+        "",
+        f"- order: {REASON_LEGEND['order']}",
+        f"- leftover-worktree: {REASON_LEGEND['leftover-worktree']}",
+    ]
+
+
+def test_render_summary_omits_total_row_for_a_single_task() -> None:
+    runs = [
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=0,
+            passed=True,
+            usage=_make_usage(turns=12, cost_usd=0.21),
+        ),
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=1,
+            passed=True,
+            usage=_make_usage(turns=9, cost_usd=0.18),
+        ),
+    ]
+
+    lines = render_summary(runs=runs).splitlines()
+
+    assert lines == [
+        "| Task                      | git-hunk           | bare-git          |",
+        "| ------------------------- | ------------------ | ----------------- |",
+        "| split_refactor_vs_feature | PASS · 12t · $0.21 | PASS · 9t · $0.18 |",
+        "",
+        _CACHE_CAVEAT,
+    ]
+
+
+def test_render_summary_marks_missing_usage_and_counts_reported_runs() -> None:
+    runs = [
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=0,
+            passed=True,
+            usage=_make_usage(turns=12, cost_usd=0.21),
+        ),
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=1,
+            passed=False,
+            reason="solver-error",
+            usage=None,
+        ),
+        _make_run(
+            scenario=SCENARIOS[1],
+            variant_index=0,
+            passed=True,
+            usage=_make_usage(turns=10, cost_usd=0.19),
+        ),
+        _make_run(
+            scenario=SCENARIOS[1],
+            variant_index=1,
+            passed=True,
+            usage=_make_usage(turns=8, cost_usd=0.15),
+        ),
+    ]
+
+    lines = render_summary(runs=runs).splitlines()
+
+    assert "| FAIL solver-error · —" in lines[2]
+    assert "**1/2 · 8t · $0.15** (1/2 reported)" in lines[4]
+
+
+def test_render_summary_states_the_reported_count_when_no_run_reported() -> None:
+    runs = [
+        _make_run(scenario=SCENARIOS[0], variant_index=0, passed=True, usage=None),
+        _make_run(scenario=SCENARIOS[0], variant_index=1, passed=True, usage=None),
+        _make_run(scenario=SCENARIOS[1], variant_index=0, passed=True, usage=None),
+        _make_run(scenario=SCENARIOS[1], variant_index=1, passed=True, usage=None),
+    ]
+
+    lines = render_summary(runs=runs).splitlines()
+
+    assert lines[4] == (
+        "| **total**                 "
+        "| **2/2 · —** (0/2 reported) | **2/2 · —** (0/2 reported) |"
+    )
+
+
+def test_render_summary_never_reports_a_sub_cent_cost_as_zero() -> None:
+    runs = [
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=0,
+            passed=True,
+            usage=_make_usage(turns=1, cost_usd=0.0012),
+        ),
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=1,
+            passed=True,
+            usage=_make_usage(turns=1, cost_usd=0.0),
+        ),
+    ]
+
+    lines = render_summary(runs=runs).splitlines()
+
+    assert "PASS · 1t · <$0.01" in lines[2]
+    assert "PASS · 1t · $0.00" in lines[2]
+
+
+def test_render_summary_lists_only_reasons_that_occurred_in_grader_order() -> None:
+    runs = [
+        _make_run(
+            scenario=SCENARIOS[0],
+            variant_index=1,
+            passed=False,
+            reason="leftover-untracked",
+            usage=_make_usage(turns=9, cost_usd=0.18),
+        ),
+        _make_run(
+            scenario=SCENARIOS[1],
+            variant_index=1,
+            passed=False,
+            reason="partition",
+            usage=_make_usage(turns=9, cost_usd=0.18),
+        ),
+    ]
+
+    lines = render_summary(runs=runs).splitlines()
+
+    # The `- ` prefix matters: consecutive bare lines collapse into one
+    # rendered paragraph, which would make a pasted legend unreadable.
+    assert lines[-2:] == [
+        f"- partition: {REASON_LEGEND['partition']}",
+        f"- leftover-untracked: {REASON_LEGEND['leftover-untracked']}",
+    ]
+
+
+def test_render_summary_is_empty_without_runs() -> None:
+    assert render_summary(runs=[]) == ""
+
+
+def test_reason_legend_matches_every_grader_failure_reason_in_order() -> None:
+    assert list(REASON_LEGEND) == list(get_args(FailureReason))


### PR DESCRIPTION
Reading what git-hunk changed meant pairing up per-task lines by eye, and the
comparison from #216 could not be shown to anyone without transcribing it. A run
now ends with a Markdown table that pastes into a document unchanged:

```
| Task                      | git-hunk              | bare-git                            |
| ------------------------- | --------------------- | ----------------------------------- |
| split_refactor_vs_feature | PASS · 12t · $0.21    | FAIL order · 9t · $0.18             |
| separate_mixed_hunks      | PASS · 10t · $0.19    | FAIL partition · 11t · $0.22        |
| drop_debug_lines          | PASS · 8t · $0.14     | PASS · 7t · $0.12                   |
| protect_unrelated_work    | PASS · 9t · $0.17     | FAIL leftover-worktree · 8t · $0.15 |
| **total**                 | **4/4 · 39t · $0.71** | **1/4 · 35t · $0.67**               |

bare-git runs second and may read cache written by the git-hunk run; costs are not order-neutral.

- partition: commits do not match the required change groups
- order: a required commit order constraint is violated
- leftover-worktree: tracked worktree files do not match the expected state
```

Numbers above are illustrative — `make eval` was not run for this PR.

Three non-obvious bits:

1. The exit code now gates on the variant that declares itself the subject under
   test, so a graded bare-Git failure no longer fails the run. Without that, the
   runs that best show what git-hunk adds are exactly the runs that report red. A
   solver error in *either* variant still exits nonzero, so a crash or timeout is
   never mistaken for evidence; ADR 0004 is updated to match.

2. The legend is a Markdown list rather than plain lines. Consecutive bare lines
   collapse into one rendered paragraph, so the pasted legend would be unreadable
   — verified through a Markdown renderer, and pinned by a test.

3. The run manifest's `passed` is renamed `gate_passed`, because it now answers
   the gate rather than "did every variant pass". Nothing reads `run.json`; run
   directories are diagnostic, not durable evidence.

Cost is printed with the prompt-cache caveat because the variants run in a fixed
order, which ADR 0004 already identified as making raw cost comparisons unfair.
Each cell is one sample; the totals count distinct tasks, not repeated trials.

No README section: ADR 0004 keeps itself Proposed and treats a model result as
durable evidence only once archived, so publishing a headline number from n=1
would jump that process. The table is built to be pasted when there is a run
worth publishing.

## Test plan
- [x] tests added: `tests/eval/summary_test.py` (table shape, single-task, missing usage, sub-cent cost, legend order and list form), `tests/eval/runner_test.py` (rendered output, all four exit-code combinations), `tests/eval/grader_test.py` (Result invariant)
- [x] `make test` — 719 passed
- [x] `make lint`
- [x] each commit passes lint, type-check, mdformat, and the full suite in an isolated worktree
- [x] rendered through a Markdown renderer: table renders as a table, legend as a list; output is byte-identical after `mdformat`
