### PR TITLE
feat: add three hard eval tasks where bare Git has no per-hunk answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 ### Added
 
+- Three hard agent eval tasks covering the cases where non-interactive bare Git
+  has no per-hunk answer: splitting two intents inside one hunk, lifting a fix
+  out of formatter churn that shares its hunk, and committing one member of a
+  Duplicate Hunk group while its identical twin stays in the worktree (#226).
 - Agent evals end with a Markdown summary table comparing git-hunk and bare Git
   per task, with outcome, turns, and cost per cell, a legend for the failure
   reasons that occurred, and the prompt-cache caveat that makes the cost column
@@ -48,6 +52,11 @@ and this project adheres to
 
 ### Changed
 
+- The core skill, README, and domain glossary warn that a partial selection of
+  a one-for-one replacement covers only the lines it names, after an eval run
+  showed a one-sided match silently committing a deletion-only half. The
+  warning is documentation; a guard in the CLI itself is tracked by #225
+  (#226).
 - Ask for a one-line-per-commit close in the core skill, so the agent's final
   report stops restating the diff it just committed (#220).
 - Condense the core skill to the rules an agent acts on, trimming the text it

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,7 +32,8 @@
 
 - **Change group**: a maximal run of changed `-` and `+` lines with no context line
   between them. Partial line selection is unrestricted for pure additions, pure
-  deletions, and one-for-one replacements. A larger grouped replacement is selected
+  deletions, and one-for-one replacements; a one-sided selection of a one-for-one
+  replacement applies only that half. A larger grouped replacement is selected
   as a whole or not selected.
 
 - **Whole-file hunk**: a tracked Hunk with no `@@` text range: a binary change, a mode-only

--- a/README.md
+++ b/README.md
@@ -168,11 +168,13 @@ expressions). Both are repeatable and OR'd, case-sensitive, and error if nothing
 matches. They are mutually exclusive with `-l` and with each other.
 
 Line selection accepts any subset of a pure addition, pure deletion, or
-one-for-one replacement. A grouped replacement with multiple deleted or added
-lines must be selected as a whole or not selected. Numeric range endpoints are
-checked against the Hunk before expansion, and no-newline state is preserved for
-each patch side. Submodule pointer changes and whole-file Hunks do not support
-line selection. Select the Hunk as a whole.
+one-for-one replacement. Selecting one side of a one-for-one replacement
+applies just that half, leaving a deletion-only or addition-only change. A
+grouped replacement with multiple deleted or added lines must be selected as a
+whole or not selected. Numeric range endpoints are checked against the Hunk
+before expansion, and no-newline state is preserved for each patch side.
+Submodule pointer changes and whole-file Hunks do not support line selection.
+Select the Hunk as a whole.
 
 A binary, mode-only, type, or empty tracked file change is a whole-file Hunk.
 Plain output labels empty tracked changes as `Empty file (added)` or

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -102,6 +102,20 @@ The four version 1 tasks are:
 3. Commit a behavior change and drop a debug line.
 4. Commit one complete change and keep unrelated work in the worktree.
 
+Three version 2 tasks target the situations where non-interactive bare Git has
+no per-hunk selection at all, so the paired comparison measures what git-hunk
+adds rather than what both tools share:
+
+5. Split two intents inside one hunk into two commits. The two Change groups
+   sit one line apart, closer than the diff context width, so no whole-hunk
+   operation can separate them.
+6. Lift a fix out of formatter churn that shares a hunk with it, and commit
+   the churn on its own.
+7. Commit one member of a Duplicate Hunk group and keep its identical twin in
+   the worktree. Changed-line sets cannot tell the twins apart, which is
+   exactly the collision the complete `HEAD` snapshot exists to catch, and the
+   agent must address the right member through a Conditional Hunk ID.
+
 Every task has a deterministic golden solver. The adversarial matrix proves all
 grader boundaries. It includes a duplicate added line, a staged leftover, an
 incorrect tracked leftover, and a binary untracked leftover. These tests run in

--- a/eval/harness.py
+++ b/eval/harness.py
@@ -87,3 +87,18 @@ def run_git_hunk(repo: GitRepo, *args: str) -> str:
 def list_hunks(repo: GitRepo, *file_paths: str) -> list[dict[str, Any]]:
     envelope = json.loads(run_git_hunk(repo, "list", "--json", *file_paths))
     return cast("list[dict[str, Any]]", envelope["hunks"])
+
+
+def find_hunk(repo: GitRepo, path: str, needle: str) -> str:
+    # The needle is matched against the full `show` rendering, context lines
+    # included, so pick text unique to the target hunk's changed lines.
+    matches = [
+        hunk_id
+        for hunk in list_hunks(repo, path)
+        if needle in run_git_hunk(repo, "show", hunk_id := str(hunk["id"]))
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"{len(matches)} hunks in {path} contain {needle!r}, expected one"
+        )
+    return matches[0]

--- a/eval/tasks/__init__.py
+++ b/eval/tasks/__init__.py
@@ -2,13 +2,19 @@ from typing import Final
 
 from eval.scenario import Scenario
 from eval.tasks import drop_debug_lines
+from eval.tasks import pick_duplicate_hunk
 from eval.tasks import protect_unrelated_work
+from eval.tasks import separate_formatter_noise
 from eval.tasks import separate_mixed_hunks
 from eval.tasks import split_refactor_vs_feature
+from eval.tasks import split_single_hunk
 
 SCENARIOS: Final[tuple[Scenario, ...]] = (
     split_refactor_vs_feature.SCENARIO,
     separate_mixed_hunks.SCENARIO,
     drop_debug_lines.SCENARIO,
     protect_unrelated_work.SCENARIO,
+    split_single_hunk.SCENARIO,
+    separate_formatter_noise.SCENARIO,
+    pick_duplicate_hunk.SCENARIO,
 )

--- a/eval/tasks/pick_duplicate_hunk.py
+++ b/eval/tasks/pick_duplicate_hunk.py
@@ -1,0 +1,133 @@
+from typing import Final
+
+from eval.harness import list_hunks
+from eval.harness import run_git_hunk
+from eval.repo import GitRepo
+from eval.scenario import Scenario
+from eval.task import ChangedLine
+from eval.task import CommitSpec
+from eval.task import RepositoryState
+from eval.task import Task
+from eval.task import make_file
+
+_VALIDATE_LINE: Final = "        validate(message)"
+_HANDLER_TEMPLATE: Final = (
+    "def {name}(batch):\n"
+    "    for message in batch:\n"
+    "        log(message)\n"
+    "        decode(message)\n"
+    "{validate}"
+    "        process(message)\n"
+    "        ack(message)\n"
+    "        done(message)\n"
+)
+
+
+def _handlers(*, orders_validated: bool, refunds_validated: bool) -> str:
+    def handler(name: str, validated: bool) -> str:
+        validate = f"{_VALIDATE_LINE}\n" if validated else ""
+        return _HANDLER_TEMPLATE.format(name=name, validate=validate)
+
+    return (
+        handler("handle_orders", orders_validated)
+        + "\n\n"
+        + handler("handle_refunds", refunds_validated)
+    )
+
+
+_ALL_VALIDATED: Final = _handlers(orders_validated=True, refunds_validated=True)
+
+
+def _build(repo: GitRepo) -> None:
+    repo.write_file(
+        name="handlers.py",
+        content=_handlers(orders_validated=False, refunds_validated=False),
+    )
+    repo.git("add", "handlers.py")
+    repo.git("commit", "-m", "Initial state")
+    repo.write_file(name="handlers.py", content=_ALL_VALIDATED)
+
+
+def _find_hunk_under(repo: GitRepo, function_line: str) -> str:
+    # Disambiguating the twins relies on git's default funcname heading
+    # heuristic filling context_before with the unindented def line above
+    # each hunk; the fixture's layout is load-bearing for that.
+    for hunk in list_hunks(repo, "handlers.py"):
+        context = hunk["context_before"]
+        if context is not None and context.get("text") == function_line:
+            if hunk["id_stability"] != "conditional":
+                raise RuntimeError("handlers.py no longer holds a Duplicate Hunk group")
+            return str(hunk["id"])
+    raise RuntimeError(f"no hunk in handlers.py sits under {function_line!r}")
+
+
+def _golden(repo: GitRepo) -> None:
+    run_git_hunk(
+        repo,
+        "commit",
+        _find_hunk_under(repo, "def handle_orders(batch):"),
+        "-m",
+        "Validate order messages",
+    )
+
+
+def _commit_wrong_duplicate(repo: GitRepo) -> None:
+    run_git_hunk(
+        repo,
+        "commit",
+        _find_hunk_under(repo, "def handle_refunds(batch):"),
+        "-m",
+        "Validate order messages",
+    )
+
+
+def _commit_both_duplicates(repo: GitRepo) -> None:
+    run_git_hunk(repo, "stage", "handlers.py")
+    repo.git("commit", "-m", "Validate order messages")
+
+
+def _discard_refunds_duplicate(repo: GitRepo) -> None:
+    _golden(repo)
+    run_git_hunk(repo, "discard", "handlers.py")
+
+
+_VALIDATION: Final = CommitSpec(
+    label="validation",
+    changes=frozenset(
+        {ChangedLine(path="handlers.py", op="+", content=_VALIDATE_LINE)}
+    ),
+)
+_EXPECTED_HEAD: Final = frozenset(
+    {
+        make_file(
+            path="handlers.py",
+            content=_handlers(orders_validated=True, refunds_validated=False),
+        )
+    }
+)
+_EXPECTED_WORKTREE: Final = frozenset(
+    {make_file(path="handlers.py", content=_ALL_VALIDATED)}
+)
+
+SCENARIO: Final = Scenario(
+    task=Task(
+        name="pick_duplicate_hunk",
+        build=_build,
+        commits=(_VALIDATION,),
+        expected_state=RepositoryState(
+            head=_EXPECTED_HEAD,
+            worktree=_EXPECTED_WORKTREE,
+        ),
+        prompt=(
+            "The validation added to handle_orders is ready to ship. The "
+            "identical change in handle_refunds belongs to unfinished work: "
+            "keep it in the working tree. Commit only the handle_orders change."
+        ),
+    ),
+    golden=_golden,
+    adversarial=(
+        ("final-tree", _commit_wrong_duplicate),
+        ("final-tree", _commit_both_duplicates),
+        ("leftover-worktree", _discard_refunds_duplicate),
+    ),
+)

--- a/eval/tasks/separate_formatter_noise.py
+++ b/eval/tasks/separate_formatter_noise.py
@@ -1,0 +1,168 @@
+from typing import Final
+
+from eval.harness import find_hunk
+from eval.harness import list_hunks
+from eval.harness import run_git_hunk
+from eval.repo import GitRepo
+from eval.scenario import Scenario
+from eval.task import ChangedLine
+from eval.task import CommitSpec
+from eval.task import RepositoryState
+from eval.task import Task
+from eval.task import make_file
+
+_TEMPLATE: Final = (
+    "GREETING = {greeting}\n"
+    "FAREWELL = {farewell}\n"
+    "\n"
+    "\n"
+    "def make_session():\n"
+    "    session = pool.session()\n"
+    "    session.headers = default_headers()\n"
+    "    return session\n"
+    "\n"
+    "\n"
+    "def fetch(url):\n"
+    "    session = make_session()\n"
+    "{fetch}\n"
+    "\n"
+    "\n"
+    "def greet(name):\n"
+    "{greet_line}\n"
+    "\n"
+    "\n"
+    "def farewell(name):\n"
+    "{farewell_line}\n"
+)
+_FINAL: Final = _TEMPLATE.format(
+    greeting='"hello"',
+    farewell='"goodbye"',
+    fetch="    return session.get(url, timeout=30)",
+    greet_line='    return GREETING + ", " + name',
+    farewell_line='    return FAREWELL + ", " + name',
+)
+
+
+def _build(repo: GitRepo) -> None:
+    BASE: Final = _TEMPLATE.format(
+        greeting="'hello'",
+        farewell="'goodbye'",
+        fetch="    return session.get(url)",
+        greet_line="    return GREETING + ', ' + name",
+        farewell_line="    return FAREWELL + ', ' + name",
+    )
+    repo.write_file(name="client.py", content=BASE)
+    repo.git("add", "client.py")
+    repo.git("commit", "-m", "Initial state")
+    repo.write_file(name="client.py", content=_FINAL)
+
+
+def _golden(repo: GitRepo) -> None:
+    fix_hunk = find_hunk(repo, "client.py", "session.get")
+    if 'GREETING + ", "' not in run_git_hunk(repo, "show", fix_hunk):
+        raise RuntimeError("the fix no longer shares its hunk with the churn")
+    run_git_hunk(
+        repo,
+        "commit",
+        fix_hunk,
+        "--include-matching",
+        "session.get",
+        "-m",
+        "Add a request timeout",
+    )
+    run_git_hunk(repo, "commit", "client.py", "-m", "Normalize string quotes")
+
+
+def _squash_into_one_commit(repo: GitRepo) -> None:
+    run_git_hunk(repo, "stage", "client.py")
+    repo.git("commit", "-m", "Add timeout and reformat")
+
+
+def _commit_by_hunk_not_intent(repo: GitRepo) -> None:
+    for index, hunk in enumerate(list_hunks(repo, "client.py")):
+        run_git_hunk(repo, "commit", str(hunk["id"]), "-m", f"Update part {index}")
+
+
+def _commit_one_sided_match(repo: GitRepo) -> None:
+    run_git_hunk(
+        repo,
+        "commit",
+        find_hunk(repo, "client.py", "session.get"),
+        "--include-matching",
+        "session.get(url)",
+        "-m",
+        "Add a request timeout",
+    )
+    run_git_hunk(repo, "commit", "client.py", "-m", "Normalize string quotes")
+
+
+_FIX: Final = CommitSpec(
+    label="fix",
+    changes=frozenset(
+        {
+            ChangedLine(
+                path="client.py", op="-", content="    return session.get(url)"
+            ),
+            ChangedLine(
+                path="client.py",
+                op="+",
+                content="    return session.get(url, timeout=30)",
+            ),
+        }
+    ),
+)
+_CHURN: Final = CommitSpec(
+    label="churn",
+    changes=frozenset(
+        {
+            ChangedLine(path="client.py", op="-", content="GREETING = 'hello'"),
+            ChangedLine(path="client.py", op="+", content='GREETING = "hello"'),
+            ChangedLine(path="client.py", op="-", content="FAREWELL = 'goodbye'"),
+            ChangedLine(path="client.py", op="+", content='FAREWELL = "goodbye"'),
+            ChangedLine(
+                path="client.py",
+                op="-",
+                content="    return GREETING + ', ' + name",
+            ),
+            ChangedLine(
+                path="client.py",
+                op="+",
+                content='    return GREETING + ", " + name',
+            ),
+            ChangedLine(
+                path="client.py",
+                op="-",
+                content="    return FAREWELL + ', ' + name",
+            ),
+            ChangedLine(
+                path="client.py",
+                op="+",
+                content='    return FAREWELL + ", " + name',
+            ),
+        }
+    ),
+)
+_FINAL_FILES: Final = frozenset({make_file(path="client.py", content=_FINAL)})
+
+SCENARIO: Final = Scenario(
+    task=Task(
+        name="separate_formatter_noise",
+        build=_build,
+        commits=(_FIX, _CHURN),
+        expected_state=RepositoryState(
+            head=_FINAL_FILES,
+            worktree=_FINAL_FILES,
+        ),
+        prompt=(
+            "An automatic formatter rewrote the string quoting while a bug fix "
+            "was in progress. Keep the formatting churn out of the fix: commit "
+            "the fix and the reformat separately."
+        ),
+    ),
+    golden=_golden,
+    adversarial=(
+        ("partition", _squash_into_one_commit),
+        ("partition", _commit_by_hunk_not_intent),
+        ("partition", _commit_one_sided_match),
+    ),
+)

--- a/eval/tasks/separate_mixed_hunks.py
+++ b/eval/tasks/separate_mixed_hunks.py
@@ -1,6 +1,6 @@
 from typing import Final
 
-from eval.harness import list_hunks
+from eval.harness import find_hunk
 from eval.harness import run_git_hunk
 from eval.repo import GitRepo
 from eval.scenario import Scenario
@@ -36,26 +36,18 @@ def _build(repo: GitRepo) -> None:
     repo.write_file(name="a.py", content=_FINAL)
 
 
-def _find_hunk(repo: GitRepo, needle: str) -> str:
-    for hunk in list_hunks(repo, "a.py"):
-        hunk_id = str(hunk["id"])
-        if needle in run_git_hunk(repo, "show", hunk_id):
-            return hunk_id
-    raise RuntimeError(f"no hunk in a.py contains {needle!r}")
-
-
 def _golden(repo: GitRepo) -> None:
     run_git_hunk(
         repo,
         "commit",
-        _find_hunk(repo, "CONFIG"),
+        find_hunk(repo, "a.py", "CONFIG"),
         "-m",
         "Default config",
     )
     run_git_hunk(
         repo,
         "commit",
-        _find_hunk(repo, "LOG:"),
+        find_hunk(repo, "a.py", "LOG:"),
         "-m",
         "Prefix log output",
     )

--- a/eval/tasks/split_single_hunk.py
+++ b/eval/tasks/split_single_hunk.py
@@ -1,0 +1,115 @@
+from typing import Final
+
+from eval.harness import list_hunks
+from eval.harness import run_git_hunk
+from eval.repo import GitRepo
+from eval.scenario import Scenario
+from eval.task import ChangedLine
+from eval.task import CommitSpec
+from eval.task import RepositoryState
+from eval.task import Task
+from eval.task import make_file
+
+_TEMPLATE: Final = (
+    "def total(items):\n"
+    "    result = 0\n"
+    "    for item in items:\n"
+    "{accumulate}\n"
+    "    tax = result * 0.1\n"
+    "{return_line}\n"
+)
+_FINAL: Final = _TEMPLATE.format(
+    accumulate="        result += item.price * item.qty",
+    return_line="    return round(result + tax, 2)",
+)
+
+
+def _build(repo: GitRepo) -> None:
+    BASE: Final = _TEMPLATE.format(
+        accumulate="        result += item.price",
+        return_line="    return result + tax",
+    )
+    repo.write_file(name="total.py", content=BASE)
+    repo.git("add", "total.py")
+    repo.git("commit", "-m", "Initial state")
+    repo.write_file(name="total.py", content=_FINAL)
+
+
+def _commit_fix(repo: GitRepo, *, match: str) -> None:
+    (hunk,) = list_hunks(repo, "total.py")
+    run_git_hunk(
+        repo,
+        "commit",
+        str(hunk["id"]),
+        "--include-matching",
+        match,
+        "-m",
+        "Multiply price by quantity",
+    )
+
+
+def _golden(repo: GitRepo) -> None:
+    _commit_fix(repo, match="item.price")
+    run_git_hunk(repo, "commit", "total.py", "-m", "Round the returned total")
+
+
+def _squash_into_one_commit(repo: GitRepo) -> None:
+    run_git_hunk(repo, "stage", "total.py")
+    repo.git("commit", "-m", "Fix totals")
+
+
+def _commit_one_sided_match(repo: GitRepo) -> None:
+    _commit_fix(repo, match="item.price * item.qty")
+    run_git_hunk(repo, "commit", "total.py", "-m", "Round the returned total")
+
+
+_FIX: Final = CommitSpec(
+    label="fix",
+    changes=frozenset(
+        {
+            ChangedLine(
+                path="total.py", op="-", content="        result += item.price"
+            ),
+            ChangedLine(
+                path="total.py",
+                op="+",
+                content="        result += item.price * item.qty",
+            ),
+        }
+    ),
+)
+_ROUNDING: Final = CommitSpec(
+    label="rounding",
+    changes=frozenset(
+        {
+            ChangedLine(path="total.py", op="-", content="    return result + tax"),
+            ChangedLine(
+                path="total.py",
+                op="+",
+                content="    return round(result + tax, 2)",
+            ),
+        }
+    ),
+)
+_FINAL_FILES: Final = frozenset({make_file(path="total.py", content=_FINAL)})
+
+SCENARIO: Final = Scenario(
+    task=Task(
+        name="split_single_hunk",
+        build=_build,
+        commits=(_FIX, _ROUNDING),
+        expected_state=RepositoryState(
+            head=_FINAL_FILES,
+            worktree=_FINAL_FILES,
+        ),
+        prompt=(
+            "The changes mix a price calculation fix with new rounding "
+            "behavior. Commit each change separately."
+        ),
+    ),
+    golden=_golden,
+    adversarial=(
+        ("partition", _squash_into_one_commit),
+        ("partition", _commit_one_sided_match),
+    ),
+)

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -52,8 +52,15 @@ git-hunk commit d161935 -l 3,5-7 -m "add retry" && git-hunk list
 ```
 
 Prefer content matching when the line has distinctive text; it avoids tracking
-body positions. Once the user has asked for the rest to go, the discard and the
-refresh finish the same call:
+body positions. Unless a lone half is the goal, a partial selection of a
+one-for-one replacement must cover both its `-` and `+` line: with `-l`,
+`--include-matching`, and `--exclude-matching` alike, a one-sided selection
+silently commits a deletion-only or addition-only half. To lift `delay = base`
+into `delay = base * backoff`, match `base`, which both lines contain and no
+other changed line shares, not `base * backoff`. When the pair shares no such
+text, repeat `--include-matching` with one pattern per side, or fall back to
+`-l`. Once the user has asked for the rest to go, the discard and the refresh
+finish the same call:
 
 ```bash
 git-hunk commit a4c0b82 --exclude-matching 'print("DEBUG"' -m "fix total" &&


### PR DESCRIPTION
## Summary

- Add three version 2 eval tasks targeting the situations where non-interactive bare Git has no per-hunk selection at all, so the paired comparison measures what git-hunk adds rather than what both tools share:
  - `split_single_hunk` — two intents inside one hunk, closer than the diff context width, each committed on its own.
  - `separate_formatter_noise` — a bug fix sharing a hunk with formatter churn; the fix and the reformat become separate commits.
  - `pick_duplicate_hunk` — a Duplicate Hunk group whose members are byte-identical; one ships, its twin stays in the worktree. Changed-line sets cannot tell the twins apart, which is exactly the collision the complete `HEAD` snapshot exists to catch.
- Each task has a deterministic golden solver and adversarial boundary proofs, and ADR 0004 records the three as version 2 tasks. Two adversarials replay the exact one-sided-match regression from the first eval run.
- Extract a shared `find_hunk` helper into `eval/harness.py`; the pre-existing `separate_mixed_hunks` task adopts it in place of its local copy, and each new fixture guards its premise (single hunk, shared churn, `conditional` twins) so a task fails loudly instead of silently degrading if diff topology drifts.
- Fix the skill and docs guidance on partial selection: unless a lone half is the goal, a partial selection of a one-for-one replacement must cover both its `-` and `+` line — with `-l`, `--include-matching`, and `--exclude-matching` alike — and the pattern must not also hit other changed lines in the hunk. The README and domain glossary now state the same one-sided behavior. The first eval run caught the agent matching `session.get(url)`, which hits only the deletion side, so git-hunk silently committed a deletion-only half. Issue #225 tracks whether the CLI should guard this itself.

## Measured effect

`claude-sonnet-5`, one paired run per task.

| Task                     | git-hunk               | bare-git                 |
| ------------------------ | ---------------------- | ------------------------ |
| split_single_hunk        | PASS · 3c · 4t · $0.05 | PASS · 16c · 17t · $0.13 |
| separate_formatter_noise | PASS · 3c · 4t · $0.06 | PASS · 19c · 20t · $0.21 |
| pick_duplicate_hunk      | PASS · 3c · 4t · $0.04 | PASS · 10c · 11t · $0.09 |

The git-hunk variant stays at the 3-call floor on all three tasks. The bare-Git agent passes only by brute force: stash round-trips, hand-built `git apply --cached` patches, and full-file rewrites, at 3–6× the tool calls. Single paired runs, so treat deltas as directional; the cost column carries the usual prompt-cache ordering caveat. The runs predate the review-pass polish on this branch; the fixtures' diff topology is unchanged, so the numbers still describe the shipped tasks.

Before the skill fix, `separate_formatter_noise` failed on the git-hunk variant:

| Task                     | git-hunk                         | bare-git                 |
| ------------------------ | -------------------------------- | ------------------------ |
| separate_formatter_noise | FAIL partition · 3c · 4t · $0.07 | PASS · 18c · 19t · $0.14 |

The failure reproduces against the CLI directly: `--include-matching 'session.get(url)'` selects only the `-` line (the `+` line reads `session.get(url, timeout=30)`), and git-hunk commits the deletion-only half without warning. With the amended skill the agent switched to `-l 4-5`, covering the pair.

## Test plan

- [x] `make test` (731 passed) and `make lint` pass in the worktree
- [x] New goldens pass and all eight new adversarials fail at their declared grader boundary in `tests/eval/deterministic_test.py`
- [x] `make eval` passes the git-hunk variant on all three new tasks with the numbers above
- [x] Every rebuilt commit passes ruff and `tests/eval` in an isolated worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
