### PR TITLE
feat: sample each eval task variant N times and report spread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ### Added
 
+- `python -m eval --repeat N` samples every selected task variant N times from
+  the same prepared state. Each cell reports the median with its observed range
+  for tool calls, turns, and cost, a variant that failed only some repeats reads
+  `MIXED j/k` instead of a pass, and the run manifest keeps every individual
+  repeat. `--repeat 1` stays the default and is unchanged (#237).
 - Three hard agent eval tasks covering the cases where non-interactive bare Git
   has no per-hunk answer: splitting two intents inside one hunk, lifting a fix
   out of formatter churn that shares its hunk, and committing one member of a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,10 +79,21 @@
   code. The git-hunk variant is the subject; bare Git is the comparison baseline, so its
   graded outcome is evidence and never fails the run.
 
-- **Agent demonstration**: one side-by-side scenario run by the same pinned agent
+- **Agent demonstration**: a side-by-side scenario run by the same pinned agent
   from the same Repository state with bare Git and with the git-hunk toolchain. It
   illustrates the difference between the resulting commit series but is not a
   statistical benchmark.
+
+- **Repeat**: one complete sample of a task variant. A run can take several from
+  the same prepared Repository state; they differ only in the model run.
+
+- **Spread**: what a summary cell reports across its Repeats, as the median with
+  the observed minimum-to-maximum range. It describes run-to-run variation, not
+  a confidence interval.
+
+- **Mixed cell**: a summary cell whose task variant passed some Repeats and
+  failed others. It is neither a pass nor a plain failure and reads as
+  `MIXED j/k`.
 
 ## Key decisions
 

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -36,7 +36,8 @@ distribution metadata.
 
 ### Compare git-hunk with bare Git
 
-Every selected task runs twice, first with `git-hunk` and then with bare Git.
+Every selected task runs both variants, first with `git-hunk` and then with bare
+Git, once per repeat.
 Both variants use the same initial Repository state, model, task-specific
 prompt, and grader. The task is built once, then its complete repository is
 copied back to the same temporary checkout path before each variant so Git
@@ -166,13 +167,14 @@ not `passed`, because it reports the exit-code gate below rather than every
 graded outcome.
 
 The run ends with one Markdown table: a row per task, a column per variant, and
-a cell holding that variant's outcome, turn count, and cost. A multi-task run
-adds a total row whose per-variant count is how many of those distinct tasks
-that variant got right. Because each cell is one sample, that count is a
-demonstration tally and not a success rate over repeated trials. Grading is the
-headline, so a failed cell names the grader's failure reason verbatim and a
-legend below the table glosses only the reasons that occurred. That keeps one
-vocabulary across grader, manifest, transcript, and table. The legend is a
+a cell holding that variant's outcome, tool-call count, turn count, and cost. A
+multi-task run adds a total row whose per-variant count is how many of those
+distinct tasks that variant got right. That count is a demonstration tally and
+not a success rate over repeated trials, whether the run sampled each cell once
+or the several times the next section allows. Grading is the headline, so a
+failed cell names the grader's failure reason verbatim and a legend below the
+table glosses only the reasons that occurred. That keeps one vocabulary across
+grader, manifest, transcript, and table. The legend is a
 Markdown list: consecutive bare lines collapse into one rendered paragraph,
 which would make a pasted legend unreadable. A cell whose run reported no usage
 shows the outcome with its metrics collapsed, and the total then states how many
@@ -193,6 +195,65 @@ infrastructure rather than a graded result. Each selected task is an independent
 paired comparison; passing it does not depend on running any other task in the
 same invocation.
 
+### Sample each task variant a chosen number of times
+
+`--repeat N` samples every selected task variant N times. The task is built
+once, so every repeat starts from the same prepared initial state and differs
+only in the model run. The repeats of one task are consecutive and each keeps
+the fixed git-hunk-then-bare-Git order, so the prompt-cache caveat holds within
+every repeat. It also compounds across them: only the first repeat starts cold,
+so a cost range mixes cache warmup with run-to-run noise. The runner prints that
+second caveat next to the first whenever a run repeated anything. Each repeat
+writes its own trace and transcript, under an `.rN` artifact name when the run
+repeats at all.
+
+A repeated cell reports the median of its repeats with the observed range in
+brackets, for tool calls, turns, and cost alike. The range is dropped when the
+minimum and maximum render identically, so a cell widens only where there is
+noise a reader could see: two costs that both round to the same cent report one
+figure rather than a range from it to itself. The median is the central value
+because a handful of repeats is too few for a standard deviation to mean
+anything, and the minimum and maximum are the whole of what was observed rather
+than a summary of it. The range separator is ASCII, so the range adds no
+ambiguous-width character to a row. The total row sums the per-task medians and
+brackets the sum of the per-task minima and maxima: an envelope for the
+selection rather than an observed run.
+
+The pass column reports how many repeats passed. A variant that passed every
+repeat reads `PASS k/k`, and one that passed some or none reads `MIXED j/k` or
+`FAIL 0/k` followed by every failure reason that occurred, in grader order. The
+word itself changes rather than only the fraction beside it, so a variant that
+failed a repeat cannot be skimmed as a clean pass. The total row counts a task
+only when every one of its repeats passed, and states separately how many tasks
+were mixed. A cell whose repeats did not all report usage says so, so a median
+over the repeats that did report cannot pass for a median over all of them. The
+metrics cover every repeat, passed or failed, because they report what the runs
+cost rather than what a success costs; a mixed cell's median therefore mixes
+both outcomes and is read next to its `MIXED j/k`. A repeat that failed before
+grading counts in the fraction and names `solver-error` like any other reason,
+because the fraction reports repeats rather than grades; the gate still fails
+the whole run on it, so it never reads as a tolerable flake.
+
+The exit-code gate reads every repeat, so a mixed subject variant exits nonzero
+just as a failed one does. Repeating therefore makes the gate strictly harder to
+pass: it asks the subject to succeed every time rather than once. That is the
+intended reading, because the gate answers whether git-hunk works and a variant
+that fails one repeat in three has not shown that.
+
+The run manifest records every repeat as its own task entry carrying its repeat
+index, trace, transcript, graded outcome, and usage, next to a run-level repeat
+count. Nothing is collapsed into the summary, so a surprising cell can be traced
+back to the individual run that produced it.
+
+A repeated run reports how stable one pinned agent, model, and checkout are over
+consecutive attempts at the same prepared state. It still does not claim a
+success rate: the repeats share a session's warm cache rather than being
+independent, N is chosen for cost rather than for statistical power, no interval
+is computed, and no difference between the two variants is tested for
+significance. It remains an agent demonstration. `--repeat 1` is the default and
+produces the single-sample run this ADR described before this section, output
+and artifact names included.
+
 ### Keep this ADR Proposed in the integration ticket
 
 This integration adds the deterministic evaluation and the model-pinned runner.
@@ -210,8 +271,12 @@ gates pass.
 - A line-set collision cannot hide an incorrect final tree.
 - Staged, tracked, and untracked leftovers have separate diagnoses.
 - A bare-Git failure is a published result, not a red run.
-- The table reports one sample per cell. It is an agent demonstration, not a
+- The table reports one sample per cell by default and a median with its
+  observed range when a cell was repeated. It is an agent demonstration, not a
   statistical benchmark, so its totals count distinct tasks rather than repeated
   trials of one task.
+- Repeating separates run-to-run noise from a real workflow change in one
+  invocation, at N times the model usage of a single-sample run, and at a gate
+  that the subject variant must clear on every repeat.
 - A later change to the CLI, either skill, an eval task, the runner, or the
   Claude Code version makes an earlier model result stale.

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -13,8 +13,10 @@ from eval.config import TASK_SCHEMA_VERSION
 from eval.environment import EvalEnvironment
 from eval.environment import resolve_environment
 from eval.grader import SOLVER_ERROR
+from eval.harness import PreparedTask
 from eval.harness import prepare_task
 from eval.model import VARIANTS
+from eval.model import EvalVariant
 from eval.model import TaskRun
 from eval.model import TraceUsage
 from eval.model import TranscriptReporter
@@ -43,7 +45,20 @@ def main(argv: list[str] | None = None) -> int:
         metavar="NAME",
         help="run one named task",
     )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "sample every selected task variant N times from the same prepared "
+            "state, so the summary reports spread instead of one sample "
+            "(default: 1)"
+        ),
+    )
     args = parser.parse_args(argv)
+    if args.repeat < 1:
+        parser.error("--repeat must be at least 1")
 
     try:
         environment = resolve_environment()
@@ -55,13 +70,16 @@ def main(argv: list[str] | None = None) -> int:
     selected = tuple(
         scenario for scenario in SCENARIOS if scenario.task.name in selected_names
     )
-    return _run_scenarios(environment=environment, scenarios=selected)
+    return _run_scenarios(
+        environment=environment, scenarios=selected, repeats=args.repeat
+    )
 
 
 def _run_scenarios(
     *,
     environment: EvalEnvironment,
     scenarios: tuple[Scenario, ...],
+    repeats: int,
 ) -> int:
     started_at = datetime.datetime.now(datetime.timezone.utc)
     started_clock = time.monotonic()
@@ -82,45 +100,23 @@ def _run_scenarios(
         name = scenario.task.name
         progress = f" {index}/{len(scenarios)}" if multiple_tasks else ""
         print(f"running{progress}: {name}", flush=True)
+        # One prepared task feeds every repeat, so the repeats differ only in
+        # the model run and not in the initial Repository state.
         with prepare_task(scenario.task) as prepared:
-            for variant in VARIANTS:
-                print(flush=True)
-                artifact_stem = f"{name}.{variant.name}"
-                trace_path = run_dir / f"{artifact_stem}.jsonl"
-                transcript_path = run_dir / f"{artifact_stem}.transcript.txt"
-                solver = make_claude_solver(
-                    task=scenario.task,
-                    variant=variant,
-                    trace_path=trace_path,
-                    transcript_path=transcript_path,
-                )
-                result = prepared.run_and_grade(solver)
-                usage = read_trace_usage(trace_path=trace_path)
-                mark = "PASS" if result.passed else "FAIL"
-                detail = f": {result.reason}" if result.reason else ""
-                if result.detail:
-                    detail += f": {result.detail}"
-                result_line = f"{mark} {name} [{variant.name}]{detail}"
-                usage_line = (
-                    format_usage(usage=usage)
-                    if usage is not None
-                    else "usage: unavailable"
-                )
-                with transcript_path.open("a", encoding="utf-8") as transcript:
-                    TranscriptReporter(transcript=transcript).report_result(
-                        result_line=result_line,
-                        usage_line=usage_line,
-                    )
-                results.append(
-                    TaskRun(
+            for repeat in range(1, repeats + 1):
+                if repeats > 1:
+                    print(f"repeat {repeat}/{repeats}: {name}", flush=True)
+                results += [
+                    _run_variant(
                         scenario=scenario,
                         variant=variant,
-                        result=result,
-                        trace_path=trace_path,
-                        transcript_path=transcript_path,
-                        usage=usage,
+                        prepared=prepared,
+                        run_dir=run_dir,
+                        repeat=repeat,
+                        repeats=repeats,
                     )
-                )
+                    for variant in VARIANTS
+                ]
 
     gate_passed = _gate_passed(results=results)
     exit_code = 0 if gate_passed else 1
@@ -130,6 +126,7 @@ def _run_scenarios(
     manifest = _make_manifest(
         environment=environment,
         results=results,
+        repeats=repeats,
         started_at=started_at,
         duration_seconds=duration_seconds,
         exit_code=exit_code,
@@ -149,6 +146,60 @@ def _run_scenarios(
     return exit_code
 
 
+def _run_variant(
+    *,
+    scenario: Scenario,
+    variant: EvalVariant,
+    prepared: PreparedTask,
+    run_dir: Path,
+    repeat: int,
+    repeats: int,
+) -> TaskRun:
+    print(flush=True)
+    name = scenario.task.name
+    artifact_stem = _artifact_stem(
+        name=name, variant=variant.name, repeat=repeat, repeats=repeats
+    )
+    trace_path = run_dir / f"{artifact_stem}.jsonl"
+    transcript_path = run_dir / f"{artifact_stem}.transcript.txt"
+    solver = make_claude_solver(
+        task=scenario.task,
+        variant=variant,
+        trace_path=trace_path,
+        transcript_path=transcript_path,
+    )
+    result = prepared.run_and_grade(solver)
+    usage = read_trace_usage(trace_path=trace_path)
+    mark = "PASS" if result.passed else "FAIL"
+    detail = f": {result.reason}" if result.reason else ""
+    if result.detail:
+        detail += f": {result.detail}"
+    usage_line = (
+        format_usage(usage=usage) if usage is not None else "usage: unavailable"
+    )
+    with transcript_path.open("a", encoding="utf-8") as transcript:
+        TranscriptReporter(transcript=transcript).report_result(
+            result_line=f"{mark} {name} [{variant.name}]{detail}",
+            usage_line=usage_line,
+        )
+    return TaskRun(
+        scenario=scenario,
+        variant=variant,
+        result=result,
+        trace_path=trace_path,
+        transcript_path=transcript_path,
+        usage=usage,
+        repeat=repeat,
+    )
+
+
+def _artifact_stem(*, name: str, variant: str, repeat: int, repeats: int) -> str:
+    # A single-repeat run keeps the unsuffixed artifact names, so its printed
+    # output and artifacts match runs made before repeats existed.
+    suffix = f".r{repeat}" if repeats > 1 else ""
+    return f"{name}.{variant}{suffix}"
+
+
 def _gate_passed(*, results: list[TaskRun]) -> bool:
     if any(run.result.reason == SOLVER_ERROR for run in results):
         return False
@@ -159,6 +210,7 @@ def _make_manifest(
     *,
     environment: EvalEnvironment,
     results: list[TaskRun],
+    repeats: int,
     started_at: datetime.datetime,
     duration_seconds: float,
     exit_code: int,
@@ -179,6 +231,7 @@ def _make_manifest(
             {
                 "name": run.scenario.task.name,
                 "variant": run.variant.name,
+                "repeat": run.repeat,
                 "passed": run.result.passed,
                 "reason": run.result.reason,
                 "detail": run.result.detail,
@@ -205,6 +258,7 @@ def _make_manifest(
         "skill_sha256": environment.skill_sha256,
         "claude_code_version": environment.claude_code_version,
         "requested_model": MODEL,
+        "repeats": repeats,
         "gate_passed": gate_passed,
         "usage": usage.to_dict() if usage is not None else None,
         "tasks": task_results,

--- a/eval/model.py
+++ b/eval/model.py
@@ -130,6 +130,8 @@ class TaskRun:
     trace_path: Path
     transcript_path: Path
     usage: TraceUsage | None
+    # 1-based index of this sample within its task variant's repeats.
+    repeat: int
 
 
 def build_prompt(*, task_prompt: str, variant: EvalVariant) -> str:

--- a/eval/summary.py
+++ b/eval/summary.py
@@ -1,4 +1,8 @@
+import dataclasses
+import statistics
+from collections.abc import Callable
 from collections.abc import Iterable
+from collections.abc import Sequence
 from typing import Final
 
 from eval.grader import FailureReason
@@ -8,6 +12,11 @@ from eval.model import TraceUsage
 _CACHE_CAVEAT: Final = (
     "{second} runs second and may read cache written by the {first} run; "
     "costs are not order-neutral."
+)
+
+_REPEAT_CAVEAT: Final = (
+    "Only the first repeat starts cold, so a cost range mixes cache warmup with "
+    "run-to-run noise."
 )
 
 REASON_LEGEND: Final[dict[FailureReason, str]] = {
@@ -27,19 +36,81 @@ _MISSING_METRICS: Final = "—"
 _ROUNDS_TO_ZERO_USD: Final = 0.005
 
 
+@dataclasses.dataclass(frozen=True)
+class _Spread:
+    """One metric over the repeats of a cell: a median and the observed range."""
+
+    median: float
+    minimum: float
+    maximum: float
+
+    @classmethod
+    def of(cls, *, values: Sequence[float]) -> "_Spread":
+        return cls(
+            median=statistics.median(values),
+            minimum=min(values),
+            maximum=max(values),
+        )
+
+    @classmethod
+    def total(cls, *, spreads: list["_Spread"]) -> "_Spread":
+        # Summing each statistic separately keeps the total's centre a sum of
+        # typical tasks and its bracket the best and worst case of the whole
+        # selection, rather than pairing repeats of unrelated tasks.
+        return cls(
+            median=sum(spread.median for spread in spreads),
+            minimum=sum(spread.minimum for spread in spreads),
+            maximum=sum(spread.maximum for spread in spreads),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class _Metrics:
+    tool_calls: _Spread
+    turns: _Spread
+    cost_usd: _Spread
+
+    @classmethod
+    def of(cls, *, usages: list[TraceUsage]) -> "_Metrics":
+        return cls(
+            tool_calls=_Spread.of(values=[usage.tool_calls for usage in usages]),
+            turns=_Spread.of(values=[usage.turns for usage in usages]),
+            cost_usd=_Spread.of(values=[usage.cost_usd for usage in usages]),
+        )
+
+    @classmethod
+    def total(cls, *, metrics: list["_Metrics"]) -> "_Metrics":
+        return cls(
+            tool_calls=_Spread.total(spreads=[metric.tool_calls for metric in metrics]),
+            turns=_Spread.total(spreads=[metric.turns for metric in metrics]),
+            cost_usd=_Spread.total(spreads=[metric.cost_usd for metric in metrics]),
+        )
+
+    def render(self) -> str:
+        return " · ".join(
+            (
+                _format_spread(spread=self.tool_calls, render=_format_count, unit="c"),
+                _format_spread(spread=self.turns, render=_format_count, unit="t"),
+                _format_spread(spread=self.cost_usd, render=_format_cost),
+            )
+        )
+
+
 def render_summary(*, runs: list[TaskRun]) -> str:
     if not runs:
         return ""
     variant_names = _unique_in_order(values=(run.variant.name for run in runs))
     task_names = _unique_in_order(values=(run.scenario.task.name for run in runs))
-    by_cell = {(run.scenario.task.name, run.variant.name): run for run in runs}
+    cells: dict[tuple[str, str], list[TaskRun]] = {}
+    for run in runs:
+        cells.setdefault((run.scenario.task.name, run.variant.name), []).append(run)
 
     rows = [["Task", *variant_names]]
     rows += [
         [
             task_name,
             *(
-                _format_cell(run=by_cell[(task_name, variant_name)])
+                _format_cell(runs=cells[(task_name, variant_name)])
                 for variant_name in variant_names
             ),
         ]
@@ -51,7 +122,9 @@ def render_summary(*, runs: list[TaskRun]) -> str:
                 "**total**",
                 *(
                     _format_total(
-                        runs=[run for run in runs if run.variant.name == variant_name]
+                        task_cells=[
+                            cells[(task_name, variant_name)] for task_name in task_names
+                        ]
                     )
                     for variant_name in variant_names
                 ),
@@ -59,9 +132,16 @@ def render_summary(*, runs: list[TaskRun]) -> str:
         )
 
     lines = _format_table(rows=rows)
+    caveats: list[str] = []
     if len(variant_names) == 2:
         first, second = variant_names
-        lines += ["", _CACHE_CAVEAT.format(first=first, second=second)]
+        caveats.append(_CACHE_CAVEAT.format(first=first, second=second))
+    if any(len(cell) > 1 for cell in cells.values()):
+        caveats.append(_REPEAT_CAVEAT)
+    if caveats:
+        # One paragraph, not one line each: consecutive bare lines would render
+        # as a single paragraph anyway, so join them deliberately.
+        lines += ["", " ".join(caveats)]
     legend = _format_legend(runs=runs)
     if legend:
         lines += ["", *legend]
@@ -72,42 +152,109 @@ def _unique_in_order(*, values: Iterable[str]) -> list[str]:
     return list(dict.fromkeys(values))
 
 
-def _format_cell(*, run: TaskRun) -> str:
-    outcome = "PASS" if run.result.passed else f"FAIL {run.result.reason}"
-    usages = [] if run.usage is None else [run.usage]
-    return f"{outcome} · {_format_metrics(usages=usages)}"
+def _format_cell(*, runs: list[TaskRun]) -> str:
+    usages = _reported_usages(runs=runs)
+    metrics = _MISSING_METRICS if not usages else _Metrics.of(usages=usages).render()
+    cell = f"{_format_outcome(runs=runs)} · {metrics}"
+    if len(runs) == 1:
+        # A single sample says all it can with `—`; the note below would be new
+        # output for an unrepeated run.
+        return cell
+    # Without this the median of the repeats that did report would read as the
+    # median of every repeat.
+    return cell + _format_reported_note(reported=len(usages), total=len(runs))
 
 
-def _format_total(*, runs: list[TaskRun]) -> str:
+def _format_outcome(*, runs: list[TaskRun]) -> str:
     passed = sum(run.result.passed for run in runs)
-    usages = [run.usage for run in runs if run.usage is not None]
-    total = f"**{passed}/{len(runs)} · {_format_metrics(usages=usages)}**"
-    if len(usages) != len(runs):
-        total += f" ({len(usages)}/{len(runs)} reported)"
-    return total
+    if len(runs) == 1:
+        # A single sample keeps the historical wording: there is no fraction to
+        # report and no repeat that could disagree with it.
+        return "PASS" if passed else f"FAIL {runs[0].result.reason}"
+    if _cell_passed(cell=runs):
+        return f"PASS {passed}/{len(runs)}"
+    # A variant that failed any repeat must never read as a clean pass, so the
+    # word itself changes rather than only the fraction beside it.
+    label = "MIXED" if _cell_mixed(cell=runs) else "FAIL"
+    reasons = ", ".join(_failure_reasons(runs=runs))
+    return f"{label} {passed}/{len(runs)} {reasons}"
 
 
-def _format_metrics(*, usages: list[TraceUsage]) -> str:
-    if not usages:
-        return _MISSING_METRICS
-    tool_calls = sum(usage.tool_calls for usage in usages)
-    turns = sum(usage.turns for usage in usages)
-    cost = _format_cost(value=sum(usage.cost_usd for usage in usages))
-    return f"{tool_calls}c · {turns}t · {cost}"
+def _format_total(*, task_cells: list[list[TaskRun]]) -> str:
+    reported = [_reported_usages(runs=cell) for cell in task_cells]
+    metrics_by_cell = [_Metrics.of(usages=usages) for usages in reported if usages]
+    metrics = (
+        _MISSING_METRICS
+        if not metrics_by_cell
+        else _Metrics.total(metrics=metrics_by_cell).render()
+    )
+    passed = sum(_cell_passed(cell=cell) for cell in task_cells)
+    mixed = sum(_cell_mixed(cell=cell) for cell in task_cells)
+    mixed_note = f" ({mixed} mixed)" if mixed else ""
+    total = f"**{passed}/{len(task_cells)}{mixed_note} · {metrics}**"
+    return total + _format_reported_note(
+        reported=sum(len(usages) for usages in reported),
+        total=sum(len(cell) for cell in task_cells),
+    )
 
 
-def _format_cost(*, value: float) -> str:
+def _format_reported_note(*, reported: int, total: int) -> str:
+    if reported == total:
+        return ""
+    return f" ({reported}/{total} reported)"
+
+
+def _cell_passed(*, cell: list[TaskRun]) -> bool:
+    return all(run.result.passed for run in cell)
+
+
+def _cell_mixed(*, cell: list[TaskRun]) -> bool:
+    return any(run.result.passed for run in cell) and not _cell_passed(cell=cell)
+
+
+def _reported_usages(*, runs: list[TaskRun]) -> list[TraceUsage]:
+    return [run.usage for run in runs if run.usage is not None]
+
+
+def _failure_reasons(*, runs: list[TaskRun]) -> list[FailureReason]:
+    reasons = {run.result.reason for run in runs if not run.result.passed}
+    return [reason for reason in REASON_LEGEND if reason in reasons]
+
+
+def _format_spread(
+    *, spread: _Spread, render: Callable[[float], str], unit: str = ""
+) -> str:
+    center = f"{render(spread.median)}{unit}"
+    minimum = render(spread.minimum)
+    maximum = render(spread.maximum)
+    # Compare what the reader sees, not the raw floats: two costs that both
+    # round to $0.21 would otherwise render as the range `[$0.21-$0.21]`.
+    if minimum == maximum:
+        return center
+    # An ASCII range separator keeps every table row the same rendered width in
+    # a terminal, where an en dash is an ambiguous-width character.
+    return f"{center} [{minimum}-{maximum}]"
+
+
+# The two renderers below take their value positionally, unlike the rest of this
+# module, because `_format_spread` accepts one as a plain `Callable[[float], str]`.
+
+
+def _format_count(value: float) -> str:
+    # An even number of repeats can put the median between two samples; keeping
+    # the half shows that rather than rounding it away.
+    return str(int(value)) if float(value).is_integer() else f"{value:.1f}"
+
+
+def _format_cost(value: float) -> str:
     if 0 < value < _ROUNDS_TO_ZERO_USD:
         return "<$0.01"
     return f"${value:.2f}"
 
 
 def _format_legend(*, runs: list[TaskRun]) -> list[str]:
-    reasons = {run.result.reason for run in runs if not run.result.passed}
     return [
-        f"- {reason}: {gloss}"
-        for reason, gloss in REASON_LEGEND.items()
-        if reason in reasons
+        f"- {reason}: {REASON_LEGEND[reason]}" for reason in _failure_reasons(runs=runs)
     ]
 
 

--- a/tests/eval/runner_test.py
+++ b/tests/eval/runner_test.py
@@ -22,16 +22,24 @@ _CACHE_CAVEAT: Final = (
     "bare-git runs second and may read cache written by the git-hunk run; "
     "costs are not order-neutral."
 )
+_REPEAT_CAVEAT: Final = (
+    "Only the first repeat starts cold, so a cost range mixes cache warmup with "
+    "run-to-run noise."
+)
+
+
+def _run_eval_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the runner as a user does, from the checkout root."""
+    return subprocess.run(
+        [sys.executable, "-m", "eval", *args],
+        capture_output=True,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+    )
 
 
 def test_runner_help_lists_available_tasks() -> None:
-    repository_root = Path(__file__).resolve().parents[2]
-    result = subprocess.run(
-        [sys.executable, "-m", "eval", "--help"],
-        capture_output=True,
-        cwd=repository_root,
-        text=True,
-    )
+    result = _run_eval_cli("--help")
 
     assert result.returncode == 0
     _, task_section = result.stdout.split("available tasks:\n", maxsplit=1)
@@ -40,14 +48,22 @@ def test_runner_help_lists_available_tasks() -> None:
     ]
 
 
+def test_runner_help_documents_the_repeat_count() -> None:
+    result = _run_eval_cli("--help")
+
+    assert result.returncode == 0
+    assert "--repeat N" in result.stdout
+
+
+def test_runner_rejects_a_repeat_count_below_one() -> None:
+    result = _run_eval_cli("--repeat", "0")
+
+    assert result.returncode == 2
+    assert "--repeat must be at least 1" in result.stderr
+
+
 def test_runner_rejects_model_override_before_running_tasks() -> None:
-    repository_root = Path(__file__).resolve().parents[2]
-    result = subprocess.run(
-        [sys.executable, "-m", "eval", "--model", "opus"],
-        capture_output=True,
-        cwd=repository_root,
-        text=True,
-    )
+    result = _run_eval_cli("--model", "opus")
 
     assert result.returncode == 2
     assert "unrecognized arguments: --model opus" in result.stderr
@@ -94,8 +110,13 @@ def _install_fake_run(
     run_dir: Path,
     next_result: Callable[[], Result],
     monotonic: Callable[[], float],
+    prepared_tasks: list[str] | None = None,
 ) -> EvalEnvironment:
-    """Drive `_run_scenarios` without a model: fake solver, grade, and clock."""
+    """Drive `_run_scenarios` without a model: fake solver, grade, and clock.
+
+    `prepared_tasks` collects the name of every task the runner prepares, so a
+    caller can check that repeats share one prepared initial state.
+    """
 
     def make_solver(
         *,
@@ -129,7 +150,8 @@ def _install_fake_run(
             return next_result()
 
     def prepare_task(task: Task) -> contextlib.AbstractContextManager[PreparedTask]:
-        del task
+        if prepared_tasks is not None:
+            prepared_tasks.append(task.name)
         return contextlib.nullcontext(PreparedTask())
 
     monkeypatch.setattr(eval_main.tempfile, "mkdtemp", lambda **kwargs: str(run_dir))
@@ -197,6 +219,7 @@ def test_run_reports_context_usage_and_artifacts(
     exit_code = eval_main._run_scenarios(
         environment=environment,
         scenarios=SCENARIOS[:scenario_count],
+        repeats=1,
     )
 
     expected_usage = (
@@ -226,6 +249,8 @@ def test_run_reports_context_usage_and_artifacts(
     manifest = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
     assert manifest["clean_worktree"] is False
     assert manifest["gate_passed"] is True
+    assert manifest["repeats"] == 1
+    assert [task["repeat"] for task in manifest["tasks"]] == [1] * run_count
     assert "passed" not in manifest
     assert "selected_run" not in manifest
     assert "complete" not in manifest
@@ -249,6 +274,109 @@ def test_run_reports_context_usage_and_artifacts(
         "  PASS split_refactor_vs_feature [git-hunk]",
         f"  {expected_usage}",
     ]
+
+
+def test_run_samples_each_variant_repeatedly_from_one_prepared_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    pending = [
+        Result(passed=True),
+        Result(passed=True),
+        Result(passed=True),
+        Result(passed=False, reason="order"),
+        Result(passed=True),
+        Result(passed=True),
+    ]
+    prepared: list[str] = []
+    environment = _install_fake_run(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        run_dir=run_dir,
+        next_result=lambda: pending.pop(0),
+        monotonic=lambda: 0.0,
+        prepared_tasks=prepared,
+    )
+
+    exit_code = eval_main._run_scenarios(
+        environment=environment,
+        scenarios=SCENARIOS[:1],
+        repeats=3,
+    )
+
+    output = capsys.readouterr()
+    name = SCENARIOS[0].task.name
+    # One prepared task serves all three repeats, so they share initial state.
+    assert prepared == [name]
+    assert exit_code == 0
+    assert [line for line in output.out.splitlines() if line.startswith("repeat ")] == [
+        f"repeat {repeat}/3: {name}" for repeat in (1, 2, 3)
+    ]
+    assert sorted(path.name for path in run_dir.glob("*.jsonl")) == [
+        f"{name}.{variant}.r{repeat}.jsonl"
+        for variant in ("bare-git", "git-hunk")
+        for repeat in (1, 2, 3)
+    ]
+    summary = [line for line in output.out.splitlines() if line.startswith("| ")]
+    # Identical repeats keep the cell at one sample's metrics rather than their
+    # sum: the cell reports a typical repeat, not the whole spend.
+    assert summary[2] == (
+        f"| {name} | PASS 3/3 · 2c · 8t · $0.09 | MIXED 2/3 order · 2c · 8t · $0.09 |"
+    )
+    manifest = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert manifest["repeats"] == 3
+    assert [(task["variant"], task["repeat"]) for task in manifest["tasks"]] == [
+        (variant, repeat)
+        for repeat in (1, 2, 3)
+        for variant in ("git-hunk", "bare-git")
+    ]
+    assert [task["trace"] for task in manifest["tasks"]] == [
+        f"{name}.{variant}.r{repeat}.jsonl"
+        for repeat in (1, 2, 3)
+        for variant in ("git-hunk", "bare-git")
+    ]
+    assert len({task["trace_sha256"] for task in manifest["tasks"]}) == 1
+    assert f"{_CACHE_CAVEAT} {_REPEAT_CAVEAT}" in output.out
+
+
+def test_run_gates_on_every_repeat_of_the_subject_variant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    # The subject variant passes two of its three repeats.
+    pending = [
+        Result(passed=True),
+        Result(passed=True),
+        Result(passed=False, reason="order"),
+        Result(passed=True),
+        Result(passed=True),
+        Result(passed=True),
+    ]
+    environment = _install_fake_run(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        run_dir=run_dir,
+        next_result=lambda: pending.pop(0),
+        monotonic=lambda: 0.0,
+    )
+
+    exit_code = eval_main._run_scenarios(
+        environment=environment,
+        scenarios=SCENARIOS[:1],
+        repeats=3,
+    )
+
+    output = capsys.readouterr()
+    assert exit_code == 1
+    assert "MIXED 2/3 order" in output.out
+    manifest = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert manifest["gate_passed"] is False
 
 
 @pytest.mark.parametrize(
@@ -282,6 +410,7 @@ def test_run_gates_on_subject_variant_outcomes_and_solver_errors(
     exit_code = eval_main._run_scenarios(
         environment=environment,
         scenarios=SCENARIOS[:1],
+        repeats=1,
     )
 
     capsys.readouterr()

--- a/tests/eval/summary_test.py
+++ b/tests/eval/summary_test.py
@@ -16,6 +16,10 @@ _CACHE_CAVEAT = (
     "bare-git runs second and may read cache written by the git-hunk run; "
     "costs are not order-neutral."
 )
+_REPEAT_CAVEAT = (
+    "Only the first repeat starts cold, so a cost range mixes cache warmup with "
+    "run-to-run noise."
+)
 
 
 def _make_usage(*, turns: int, cost_usd: float) -> TraceUsage:
@@ -42,6 +46,7 @@ def _make_run(
     passed: bool,
     reason: FailureReason | None = None,
     usage: TraceUsage | None,
+    repeat: int = 1,
 ) -> TaskRun:
     return TaskRun(
         scenario=scenario,
@@ -52,7 +57,27 @@ def _make_run(
         trace_path=Path("trace.jsonl"),
         transcript_path=Path("transcript.txt"),
         usage=usage,
+        repeat=repeat,
     )
+
+
+def _make_repeats(
+    *,
+    scenario: Scenario,
+    variant_index: int,
+    samples: list[tuple[bool, FailureReason | None, int, float]],
+) -> list[TaskRun]:
+    return [
+        _make_run(
+            scenario=scenario,
+            variant_index=variant_index,
+            passed=passed,
+            reason=reason,
+            usage=_make_usage(turns=turns, cost_usd=cost_usd),
+            repeat=repeat,
+        )
+        for repeat, (passed, reason, turns, cost_usd) in enumerate(samples, start=1)
+    ]
 
 
 def test_render_summary_pairs_variants_and_totals_reported_metrics() -> None:
@@ -233,6 +258,210 @@ def test_render_summary_lists_only_reasons_that_occurred_in_grader_order() -> No
         f"- partition: {REASON_LEGEND['partition']}",
         f"- leftover-untracked: {REASON_LEGEND['leftover-untracked']}",
     ]
+
+
+def test_render_summary_reports_a_median_and_range_over_repeats() -> None:
+    runs = [
+        *_make_repeats(
+            scenario=SCENARIOS[0],
+            variant_index=0,
+            samples=[
+                (True, None, 13, 0.21),
+                (True, None, 14, 0.23),
+                (True, None, 13, 0.22),
+            ],
+        ),
+        *_make_repeats(
+            scenario=SCENARIOS[0],
+            variant_index=1,
+            samples=[
+                (False, "order", 19, 0.31),
+                (True, None, 22, 0.36),
+                (False, "order", 20, 0.33),
+            ],
+        ),
+        *_make_repeats(
+            scenario=SCENARIOS[1],
+            variant_index=0,
+            samples=[
+                (True, None, 10, 0.19),
+                (True, None, 10, 0.19),
+                (True, None, 10, 0.19),
+            ],
+        ),
+        *_make_repeats(
+            scenario=SCENARIOS[1],
+            variant_index=1,
+            samples=[
+                (False, "leftover-worktree", 16, 0.28),
+                (False, "leftover-worktree", 17, 0.29),
+                (False, "leftover-worktree", 15, 0.26),
+            ],
+        ),
+    ]
+
+    assert render_summary(runs=runs).splitlines() == [
+        "| Task                      "
+        "| git-hunk                                                   "
+        "| bare-git                              "
+        "                                       |",
+        "| ------------------------- "
+        "| ---------------------------------------------------------- "
+        "| --------------------------------------"
+        "-------------------------------------- |",
+        "| split_refactor_vs_feature "
+        "| PASS 3/3 · 12c [12-13] · 13t [13-14] · $0.22 [$0.21-$0.23] "
+        "| MIXED 1/3 order · 19c [18-21] "
+        "· 20t [19-22] · $0.33 [$0.31-$0.36]            |",
+        "| separate_mixed_hunks      "
+        "| PASS 3/3 · 9c · 10t · $0.19                                "
+        "| FAIL 0/3 leftover-worktree · 15c [14-16] "
+        "· 16t [15-17] · $0.28 [$0.26-$0.29] |",
+        "| **total**                 "
+        "| **2/2 · 21c [21-22] · 23t [23-24] · $0.41 [$0.40-$0.42]**  "
+        "| **0/2 (1 mixed) · 34c [32-37] "
+        "· 36t [34-39] · $0.61 [$0.57-$0.65]**          |",
+        "",
+        f"{_CACHE_CAVEAT} {_REPEAT_CAVEAT}",
+        "",
+        f"- order: {REASON_LEGEND['order']}",
+        f"- leftover-worktree: {REASON_LEGEND['leftover-worktree']}",
+    ]
+
+
+def test_render_summary_never_shows_a_variant_that_failed_a_repeat_as_a_pass() -> None:
+    runs = _make_repeats(
+        scenario=SCENARIOS[0],
+        variant_index=0,
+        samples=[
+            (True, None, 10, 0.19),
+            (True, None, 10, 0.19),
+            (False, "order", 10, 0.19),
+        ],
+    )
+
+    cell = render_summary(runs=runs).splitlines()[2]
+
+    assert "MIXED 2/3 order" in cell
+    assert "PASS" not in cell
+
+
+def test_render_summary_names_every_reason_a_mixed_cell_hit_in_grader_order() -> None:
+    runs = _make_repeats(
+        scenario=SCENARIOS[0],
+        variant_index=0,
+        samples=[
+            (False, "order", 10, 0.19),
+            (True, None, 10, 0.19),
+            (False, "partition", 10, 0.19),
+        ],
+    )
+
+    lines = render_summary(runs=runs).splitlines()
+
+    assert "MIXED 1/3 partition, order" in lines[2]
+    assert lines[-2:] == [
+        f"- partition: {REASON_LEGEND['partition']}",
+        f"- order: {REASON_LEGEND['order']}",
+    ]
+
+
+def test_render_summary_reports_a_median_between_two_repeats() -> None:
+    runs = _make_repeats(
+        scenario=SCENARIOS[0],
+        variant_index=0,
+        samples=[(True, None, 13, 0.21), (True, None, 14, 0.23)],
+    )
+
+    assert render_summary(runs=runs).splitlines()[2] == (
+        "| split_refactor_vs_feature "
+        "| PASS 2/2 · 12.5c [12-13] · 13.5t [13-14] · $0.22 [$0.21-$0.23] |"
+    )
+
+
+def test_render_summary_omits_a_range_that_two_repeats_render_identically() -> None:
+    runs = _make_repeats(
+        scenario=SCENARIOS[0],
+        variant_index=0,
+        samples=[(True, None, 10, 0.2101), (True, None, 10, 0.2149)],
+    )
+
+    # Costs that both round to $0.21 must not render as the range $0.21-$0.21.
+    assert "PASS 2/2 · 9c · 10t · $0.21 |" in render_summary(runs=runs).splitlines()[2]
+
+
+def test_render_summary_says_when_only_some_repeats_reported_usage() -> None:
+    runs = [
+        *_make_repeats(
+            scenario=SCENARIOS[0],
+            variant_index=0,
+            samples=[(True, None, 10, 0.19), (True, None, 10, 0.19)],
+        ),
+        _make_run(
+            scenario=SCENARIOS[0], variant_index=0, passed=True, usage=None, repeat=3
+        ),
+    ]
+
+    assert (
+        "PASS 3/3 · 9c · 10t · $0.19 (2/3 reported)"
+        in (render_summary(runs=runs).splitlines()[2])
+    )
+
+
+def test_render_summary_keeps_the_sub_cent_floor_inside_a_repeat_range() -> None:
+    runs = _make_repeats(
+        scenario=SCENARIOS[0],
+        variant_index=0,
+        samples=[(True, None, 1, 0.0012), (True, None, 1, 0.02)],
+    )
+
+    assert (
+        "PASS 2/2 · 0c · 1t · $0.01 [<$0.01-$0.02]"
+        in (render_summary(runs=runs).splitlines()[2])
+    )
+
+
+def test_render_summary_keeps_a_mixed_task_out_of_the_total_pass_count() -> None:
+    runs = [
+        *_make_repeats(
+            scenario=SCENARIOS[0],
+            variant_index=0,
+            samples=[(True, None, 10, 0.19), (False, "order", 10, 0.19)],
+        ),
+        *_make_repeats(
+            scenario=SCENARIOS[1],
+            variant_index=0,
+            samples=[(True, None, 10, 0.19), (True, None, 10, 0.19)],
+        ),
+    ]
+
+    total = render_summary(runs=runs).splitlines()[4]
+
+    assert total == (
+        "| **total**                 | **1/2 (1 mixed) · 18c · 20t · $0.38** |"
+    )
+
+
+def test_render_summary_counts_reported_repeats_rather_than_task_variants() -> None:
+    runs = [
+        *_make_repeats(
+            scenario=SCENARIOS[0],
+            variant_index=0,
+            samples=[(True, None, 10, 0.19), (True, None, 10, 0.19)],
+        ),
+        *_make_repeats(
+            scenario=SCENARIOS[1],
+            variant_index=0,
+            samples=[(True, None, 10, 0.19), (True, None, 10, 0.19)],
+        ),
+    ]
+    runs[1] = _make_run(
+        scenario=SCENARIOS[0], variant_index=0, passed=True, usage=None, repeat=2
+    )
+
+    total = render_summary(runs=runs).splitlines()[4]
+
+    assert "**2/2 · 18c · 20t · $0.38** (3/4 reported)" in total
 
 
 def test_render_summary_is_empty_without_runs() -> None:


### PR DESCRIPTION
Closes #223.

## Summary

- `python -m eval --repeat N` samples every selected task variant N times. The
  task is prepared once per run, so the repeats differ only in the model run.
- Each summary cell reports the median of its repeats with the observed range in
  brackets, for tool calls, turns, and cost. The range is omitted when the
  minimum and maximum render identically, so a cell widens only where a reader
  can see noise.
- The pass column reads `PASS k/k`, `MIXED j/k`, or `FAIL 0/k`. A variant that
  failed any repeat changes word, not just fraction, and the total row keeps a
  mixed task out of its pass count while stating how many tasks were mixed.
- The run manifest records every repeat as its own entry with a repeat index and
  its own `.rN` trace and transcript, next to a run-level repeat count.
- `--repeat 1` is the default and reproduces the previous output and artifact
  names byte for byte.
- ADR 0004 gains a section on what a repeated run reports and what it still does
  not claim; `CONTEXT.md` gains Repeat, Spread, and Mixed cell.

## Why these two formats

**Spread as median with the observed range.** At the repeat counts this can
afford, a standard deviation would be false precision, while the minimum and
maximum are the whole of what was observed rather than a summary of it. The
range is dropped when every repeat renders the same, which keeps a stable cell
as narrow as it is today and spends width only on the metric that actually
moved.

**Partial success as a different word.** `MIXED j/k` cannot be skimmed as a
pass the way a `PASS 2/3` could, and it names every failure reason that
occurred, in grader order, so the existing legend still glosses them.

The exit-code gate now reads every repeat, so a subject variant that passes 2 of
3 exits nonzero. That is a behavior change for anything gating on the exit code
and is documented in the ADR.

## Rendered output

`--repeat 1` (unchanged from `main`):

```
| Task                      | git-hunk                    | bare-git                                 |
| ------------------------- | --------------------------- | ---------------------------------------- |
| split_refactor_vs_feature | PASS · 11c · 12t · $0.21    | FAIL order · 8c · 9t · $0.18             |
| separate_mixed_hunks      | PASS · 9c · 10t · $0.19     | FAIL leftover-worktree · 7c · 8t · $0.15 |
| **total**                 | **2/2 · 20c · 22t · $0.40** | **0/2 · 15c · 17t · $0.33**              |

bare-git runs second and may read cache written by the git-hunk run; costs are not order-neutral.

- order: a required commit order constraint is violated
- leftover-worktree: tracked worktree files do not match the expected state
```

`--repeat 3`:

```
| Task                      | git-hunk                                                   | bare-git                                                                     |
| ------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------- |
| split_refactor_vs_feature | PASS 3/3 · 12c [12-13] · 13t [13-14] · $0.22 [$0.21-$0.23] | MIXED 1/3 partition, order · 19c [18-21] · 20t [19-22] · $0.33 [$0.31-$0.36] |
| separate_mixed_hunks      | PASS 3/3 · 9c · 10t · $0.19                                | FAIL 0/3 leftover-worktree · 15c [14-16] · 16t [15-17] · $0.28 [$0.26-$0.29] |
| **total**                 | **2/2 · 21c [21-22] · 23t [23-24] · $0.41 [$0.40-$0.42]**  | **0/2 (1 mixed) · 34c [32-37] · 36t [34-39] · $0.61 [$0.57-$0.65]**          |

bare-git runs second and may read cache written by the git-hunk run; costs are not order-neutral. Only the first repeat starts cold, so a cost range mixes cache warmup with run-to-run noise.

- partition: commits do not match the required change groups
- order: a required commit order constraint is violated
- leftover-worktree: tracked worktree files do not match the expected state
```

## Not exercised against a live model

**This change has not been run against a live eval.** `make eval` spends real
model usage per run and a repeated run spends N times as much, so verification
is entirely through the deterministic, model-free tests in `tests/eval/` — the
separation ADR 0004 mandates. The rendered tables above come from
`render_summary` itself and are pinned in tests rather than hand-computed.
Someone should run `make eval EVAL_ARGS="--repeat 2 --task drop_debug_lines"`
once before relying on the numbers.

## Test plan

- [x] tests added: `tests/eval/summary_test.py` (median and range, range omitted
      when repeats render alike, `MIXED` never reads as a pass, reasons in
      grader order, even-count median, sub-cent floor inside a range, partial
      usage reporting, mixed task excluded from the total)
- [x] tests added: `tests/eval/runner_test.py` (`--repeat` in help, rejects 0,
      one prepared task feeds every repeat, `.rN` artifacts, per-repeat manifest
      entries, the gate fails on a mixed subject variant)
- [x] `--repeat 1` parity is pinned by the pre-existing table tests, unchanged
- [x] `make test` (733 passed) and `make lint`
- [x] each commit verified independently in a temporary worktree
- [x] `python -m eval --help` and `--repeat 0` smoked; no live eval run
