### PR TITLE
test: pin duplicate group IDs across a non-member commit

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -111,4 +111,6 @@
 - Moving a complete Hunk between staged and unstaged state does not change its Hunk ID.
 - A partial-line operation creates new Hunks with new Hunk IDs.
 - A Conditional Hunk ID can change when its Duplicate Hunk group changes.
+- A Duplicate Hunk group keeps its Conditional Hunk IDs when complete Hunks outside
+  the group are committed.
 - Each Hunk ID in an inventory addresses exactly one Hunk.

--- a/tests/e2e/hunk_identity/duplicate_test.py
+++ b/tests/e2e/hunk_identity/duplicate_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ..conftest import GitHunkCLI
@@ -41,6 +43,50 @@ def test_duplicate_ids_share_one_address_space_across_statuses(
     remaining_id = next(hunk_id for hunk_id in before_ids if hunk_id != before[0]["id"])
     duplicate_hunks.run_ok("stage", remaining_id)
     assert duplicate_hunks.repo.git("diff") == ""
+
+
+def test_duplicate_group_keeps_ids_when_a_non_member_is_committed(
+    duplicate_hunks: GitHunkCLI,
+) -> None:
+    # A Conditional Hunk ID survives a commit of a Hunk outside its group, so a
+    # plan may queue complete-hunk operations ahead of an operation on one.
+    for name in ("a.txt", "z.txt"):
+        duplicate_hunks.repo.write_file(name, "old\n")
+        duplicate_hunks.repo.git("add", name)
+        duplicate_hunks.repo.git("commit", "-m", f"add {name}")
+        duplicate_hunks.repo.write_file(name, "new\n")
+    group_file = Path(duplicate_hunks.repo.path) / "f.txt"
+    # The insertion goes in the middle of the duplicate_hunks fixture's
+    # separator block, far enough from both members to stay its own hunk.
+    # Adding a line rather than editing one also moves the second member's
+    # pre-image coordinates once the non-member is committed.
+    duplicate_hunks.repo.write_file(
+        "f.txt",
+        group_file.read_text().replace("separator 15\n", "separator 15\ninserted\n"),
+    )
+    before = duplicate_hunks.run_list_json("list", "--json")
+    # The non-members sit in an earlier file, a later file, and between the two
+    # members, so an ordinal counting hunks outside the group would move the
+    # recorded IDs.
+    assert [hunk["id_stability"] for hunk in before] == [
+        "stable",
+        "conditional",
+        "stable",
+        "conditional",
+        "stable",
+    ]
+    # --json reports canonical IDs, so no prefix length can hide a renumbering.
+    group_ids = [hunk["id"] for hunk in before if hunk["id_stability"] == "conditional"]
+    non_member_ids = [hunk["id"] for hunk in before if hunk["id_stability"] == "stable"]
+
+    duplicate_hunks.run_ok("commit", *non_member_ids, "-m", "unrelated")
+
+    assert duplicate_hunks.repo.git("show", "HEAD:a.txt") == "new\n"
+    assert duplicate_hunks.repo.git("show", "HEAD:z.txt") == "new\n"
+    after = duplicate_hunks.run_list_json("list", "--json")
+    # A list, not a set: the two members swapping IDs is a renumbering too.
+    assert [hunk["id"] for hunk in after] == group_ids
+    assert {hunk["id_stability"] for hunk in after} == {"conditional"}
 
 
 @pytest.mark.parametrize("ordinal", [0, 1])


### PR DESCRIPTION
An agent may queue complete-hunk ID operations ahead of an operation on a
Conditional Hunk ID in one Bash call only while committing a Hunk outside a
Duplicate Hunk group leaves that group's Conditional Hunk IDs byte-identical.
That held, but the existing duplicate coverage only moves group members between
staged and unstaged state, so nothing failed if ordinals started counting hunks
outside the group. This records the invariant in `CONTEXT.md` and pins it.

The test puts non-members in an earlier-sorting file, a later-sorting file, and
between the group's two members, commits them by Hunk ID, and asserts the
group's IDs are unchanged. IDs come from `--json`, so they are canonical and no
prefix length can hide a renumbering, and they are compared as an ordered list
so a swap between the two members counts as a renumbering too.

## Test plan

- [x] tests added: `tests/e2e/hunk_identity/duplicate_test.py::test_duplicate_group_keeps_ids_when_a_non_member_is_committed`
- [x] `make test` (721 passed) and `make lint`
- [x] mutation-checked: the new test is the only failure under six perturbations
      of the ordinal assignment in `git_hunk/_hunk.py` (offset by total hunk
      count, rank among all hunks, rank among same-file hunks, salt by pre-image
      start line, salt by earlier-file count, salt by later-file count), and the
      suite is green again once each is reverted

Closes #222
