### PR TITLE
feat: materialize would-be-staged content without touching the index (groundwork for #58)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,12 @@
   `{"text": s}` when the bytes are valid UTF-8, else `{"bytes": base64}`. Always an object
   (even for valid UTF-8) so consumers have one code path. The ripgrep `--json` idiom.
 
+- **Materialized staged content**: the exact bytes one file would hold in the index
+  after a given selection was staged. Produced by applying the selected patch to a
+  throwaway copy of the index, so the real index and worktree never change. Internal
+  only (`_staged_content.materialize_staged_content`): it is the unit a validator
+  would check before a partial selection is committed, not something a command emits.
+
 - **git-hunk toolchain**: the git-hunk CLI together with the bundled `core` and
   `logical-commits` skills as presented to an agent.
 

--- a/docs/adr/0002-repository-path.md
+++ b/docs/adr/0002-repository-path.md
@@ -64,7 +64,8 @@ An operand names one exact changed Repository path. Directories, globs, and Git
 pathspec magic are not expanded. A leading `./` and internal `..` components are
 normalized; absolute paths and paths that escape the worktree are rejected.
 
-`git add` and `git restore` are the only calls that hand Git a path as a pathspec, so
+`git add`, `git rm`, `git restore`, and the `git ls-files` that reads a materialized
+blob out of the scratch index are the only calls that hand Git a path as a pathspec, so
 they alone pass `--literal-pathspecs`. The path they receive is `Hunk.file`, taken from
 Git's own diff output rather than from the operand, so this guards any filename
 containing pathspec punctuation however the Hunk was selected. The flag is deliberately

--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -1,4 +1,6 @@
+import os
 import subprocess
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Final
 
@@ -16,25 +18,49 @@ class UnsupportedChange:
     destination: str
 
 
-def run_git(*args: str, worktree_root: str | None, input: str | None = None) -> str:
+def run_git_bytes(
+    *args: str,
+    worktree_root: str | None,
+    input: bytes | None = None,
+    env: Mapping[str, str] | None = None,
+) -> bytes:
     # worktree_root=None is for bootstrap only: the rev-parse that discovers
     # the root runs in the invocation directory. Every other call anchors there.
-    # Git output and input may contain bytes that are not valid UTF-8 (e.g. a
-    # Latin-1 source file). surrogateescape round-trips those bytes losslessly
-    # so a rebuilt patch hands git back exactly what it emitted.
+    # env holds overrides layered onto the ambient environment (e.g. the
+    # GIT_INDEX_FILE that points a command at a scratch index), never a
+    # replacement for it: git still needs PATH, HOME, and the caller's config.
     try:
         result = subprocess.run(
             ["git", "-c", "core.quotePath=false"] + list(args),
             capture_output=True,
             cwd=worktree_root,
-            input=input.encode(errors="surrogateescape") if input is not None else None,
+            input=input,
+            env={**os.environ, **env} if env is not None else None,
         )
     except FileNotFoundError as exc:
         raise RuntimeError("git executable not found on PATH") from exc
     if result.returncode != 0:
         stderr = result.stderr.decode(errors="surrogateescape").strip()
         raise GitCommandError(args, stderr)
-    return result.stdout.decode(errors="surrogateescape")
+    return result.stdout
+
+
+def run_git(
+    *args: str,
+    worktree_root: str | None,
+    input: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    # Git output and input may contain bytes that are not valid UTF-8 (e.g. a
+    # Latin-1 source file). surrogateescape round-trips those bytes losslessly
+    # so a rebuilt patch hands git back exactly what it emitted.
+    stdout = run_git_bytes(
+        *args,
+        worktree_root=worktree_root,
+        input=input.encode(errors="surrogateescape") if input is not None else None,
+        env=env,
+    )
+    return stdout.decode(errors="surrogateescape")
 
 
 def get_diff(*, worktree_root: str, staged: bool) -> str:
@@ -135,6 +161,7 @@ def apply_patch(
     cached: bool,
     reverse: bool,
     dry_run: bool,
+    env: Mapping[str, str] | None = None,
 ) -> None:
     args = ["apply", "--whitespace=nowarn"]
     if cached:
@@ -143,7 +170,7 @@ def apply_patch(
         args.append("--reverse")
     if dry_run:
         args.append("--check")
-    run_git(*args, worktree_root=worktree_root, input=patch)
+    run_git(*args, worktree_root=worktree_root, input=patch, env=env)
 
 
 # These file-level commands hand git paths as pathspecs, so they ask for literal

--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -1,5 +1,9 @@
+import contextlib
 import os
+import shutil
 import subprocess
+import tempfile
+from collections.abc import Iterator
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Final
@@ -173,10 +177,77 @@ def apply_patch(
     run_git(*args, worktree_root=worktree_root, input=patch, env=env)
 
 
-# These file-level commands hand git paths as pathspecs, so they ask for literal
-# ones. Setting this globally would also change how a commit hook interprets its
+@contextlib.contextmanager
+def scratch_index(*, worktree_root: str) -> Iterator[Mapping[str, str]]:
+    """Yield an env overlay aiming git at a throwaway copy of the index.
+
+    Commands run with the overlay read the current index content but write only
+    to the copy, so the real index and working tree are never touched. Objects
+    they create still land in the repository's object database, unreferenced
+    until `git gc` reclaims them.
+    """
+    index_path = os.path.join(
+        worktree_root,
+        run_git(
+            "rev-parse", "--git-path", "index", worktree_root=worktree_root
+        ).removesuffix("\n"),
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        scratch_path = os.path.join(tmpdir, "index")
+        # A repository whose index has never been written has no index file
+        # yet; leaving the copy absent gives git the same empty starting point.
+        # Tolerate a concurrent writer replacing it between the two calls.
+        try:
+            shutil.copyfile(index_path, scratch_path)
+        except FileNotFoundError:
+            pass
+        yield {"GIT_INDEX_FILE": scratch_path}
+
+
+# The commands below hand git a path as a pathspec, so they ask for a literal
+# one. Setting this globally would also change how a commit hook interprets its
 # own pathspecs.
 _LITERAL_PATHSPECS: Final = "--literal-pathspecs"
+
+
+def read_index_blob(
+    path: str, *, worktree_root: str, env: Mapping[str, str] | None = None
+) -> bytes | None:
+    """Return the bytes an index entry holds, or None when it has no entry.
+
+    Reads the blob through ls-files rather than a `:<path>` revision so the
+    Repository path stays a literal pathspec instead of gaining `git show`'s
+    cwd-relative quirks.
+    """
+    output = run_git(
+        _LITERAL_PATHSPECS,
+        "ls-files",
+        "--stage",
+        "--full-name",
+        "-z",
+        "--",
+        path,
+        worktree_root=worktree_root,
+        env=env,
+    )
+    records = [record for record in output.split("\0") if record]
+    if not records:
+        return None
+    # One path yields several records only when it is unmerged, and then no
+    # single record is "the" content; refuse rather than return a merge stage.
+    if len(records) != 1:
+        raise RuntimeError(f"unmerged index entry for '{path}'")
+    metadata, separator, _ = records[0].partition("\t")
+    fields = metadata.split(" ")
+    if not separator or len(fields) != 3:
+        raise RuntimeError("cannot parse git index entry")
+    mode, object_id, _ = fields
+    # A gitlink entry points at a commit, not a blob (see _hunk.is_submodule_hunk).
+    if mode == "160000":
+        raise RuntimeError(f"'{path}' is a submodule, not a file")
+    return run_git_bytes(
+        "cat-file", "blob", object_id, worktree_root=worktree_root, env=env
+    )
 
 
 def stage_files(files: list[str], *, worktree_root: str, dry_run: bool) -> None:

--- a/git_hunk/_staged_content.py
+++ b/git_hunk/_staged_content.py
@@ -1,0 +1,93 @@
+"""Materialize the file content a stage selection would produce.
+
+The real index and working tree stay untouched: the selected patch is applied
+to a throwaway copy of the index (see `_git.scratch_index`) and the resulting
+blob is read back from that copy. Applying the patch does write the resulting
+blob into the repository's object database, where it stays unreferenced until
+`git gc` reclaims it.
+
+`materialize_staged_content` is the whole seam, guards included, so a caller
+gets the rejections rather than an opaque `git apply` failure.
+"""
+
+from ._git import GitCommandError
+from ._git import apply_patch
+from ._git import read_index_blob
+from ._git import scratch_index
+from ._hunk import Hunk
+from ._hunk import is_submodule_hunk
+from ._hunk import is_whole_file_hunk
+from ._patch import build_patch
+
+
+class StagedContentError(ValueError):
+    """A selection with no materializable content, with a user-facing tip."""
+
+    def __init__(self, message: str, *, tip: str | None = None) -> None:
+        super().__init__(message)
+        self.tip = tip
+
+
+_NO_TEXT_TIP = "there is no text content to materialize"
+
+
+def _check_materializable(hunks: list[Hunk]) -> str:
+    files = {hunk.file for hunk in hunks}
+    if len(files) != 1:
+        raise StagedContentError(
+            "staged content requires hunks from exactly one file",
+            tip="one file's content is materialized at a time",
+        )
+    if any(hunk.binary or hunk.change_kind == "T" for hunk in hunks):
+        raise StagedContentError(
+            "staged content is not available for binary or type changes",
+            tip=_NO_TEXT_TIP,
+        )
+    if any(is_submodule_hunk(hunk) for hunk in hunks):
+        raise StagedContentError(
+            "staged content is not available for submodule changes", tip=_NO_TEXT_TIP
+        )
+    if all(is_whole_file_hunk(hunk) for hunk in hunks):
+        raise StagedContentError(
+            "staged content is not available for mode-only changes or empty "
+            "tracked file additions and deletions",
+            tip=_NO_TEXT_TIP,
+        )
+    return files.pop()
+
+
+def materialize_staged_content(
+    hunks: list[Hunk], diff_output: str, *, worktree_root: str
+) -> bytes:
+    """Return the bytes staging `hunks` would leave in the index.
+
+    `hunks` is a resolved selection (already line-filtered); `diff_output` is
+    the unstaged diff it came from. Raises StagedContentError when the
+    selection has no content to materialize or its patch does not apply.
+    """
+    filepath = _check_materializable(hunks)
+    patch = build_patch(hunks, diff_output, reverse=False)
+    with scratch_index(worktree_root=worktree_root) as env:
+        try:
+            apply_patch(
+                patch,
+                worktree_root=worktree_root,
+                cached=True,
+                reverse=False,
+                dry_run=False,
+                env=env,
+            )
+        # The scratch index is an implementation detail, so git's "apply
+        # --cached" wording would point at an index this never writes. Its
+        # stderr still says what was wrong with the patch, so keep it.
+        except GitCommandError as exc:
+            raise StagedContentError(
+                f"cannot build the staged content for '{filepath}'", tip=exc.stderr
+            ) from exc
+        content = read_index_blob(filepath, worktree_root=worktree_root, env=env)
+    if content is None:
+        raise StagedContentError(
+            f"the selection removes '{filepath}' from the index",
+            tip="staging it leaves no file, so there is no content to emit",
+        )
+    return content

--- a/tests/unit/_staged_content_test.py
+++ b/tests/unit/_staged_content_test.py
@@ -1,0 +1,265 @@
+"""`materialize_staged_content` produces staged bytes without staging them."""
+
+import os
+import subprocess
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from git_hunk._git import apply_patch
+from git_hunk._git import get_diff
+from git_hunk._hunk import Hunk
+from git_hunk._hunk import parse_diff
+from git_hunk._lines import count_hunk_body_lines
+from git_hunk._lines import filter_hunk_lines
+from git_hunk._lines import parse_line_spec
+from git_hunk._patch import build_patch
+from git_hunk._staged_content import StagedContentError
+from git_hunk._staged_content import materialize_staged_content
+from tests.conftest import GitRepo
+
+
+@pytest.fixture
+def repo(git_repo: GitRepo) -> Generator[GitRepo]:
+    # Exact bytes are compared, so keep git from rewriting line endings on
+    # Windows.
+    git_repo.git("config", "core.autocrlf", "false")
+    yield git_repo
+
+
+def _write(repo: GitRepo, name: str, content: bytes) -> None:
+    # Byte-for-byte writes: GitRepo.write_file opens in text mode, which turns
+    # every LF into CRLF on Windows and would make these expectations
+    # platform-dependent.
+    path = Path(repo.path) / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def _commit(repo: GitRepo, message: str = "init") -> None:
+    repo.git("add", "-A")
+    repo.git("commit", "-m", message)
+
+
+def _index_bytes(repo: GitRepo, path: str) -> bytes:
+    # GitRepo.git decodes with universal newlines, so it cannot say what bytes
+    # the index actually holds; read them as bytes instead.
+    result = subprocess.run(
+        ["git", "--literal-pathspecs", "show", f":{path}"],
+        capture_output=True,
+        cwd=repo.path,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _unstaged(repo: GitRepo) -> tuple[list[Hunk], str]:
+    diff_output = get_diff(worktree_root=repo.path, staged=False)
+    return parse_diff(diff_output), diff_output
+
+
+def _select(hunks: list[Hunk], line_spec: str | None) -> list[Hunk]:
+    if line_spec is None:
+        return hunks
+    assert len(hunks) == 1
+    lines, exclude = parse_line_spec(line_spec, total=count_hunk_body_lines(hunks[0]))
+    return [filter_hunk_lines(hunks[0], lines, exclude=exclude, reverse=False)]
+
+
+def _materialize(repo: GitRepo, line_spec: str | None = None) -> bytes:
+    hunks, diff_output = _unstaged(repo)
+    return materialize_staged_content(
+        _select(hunks, line_spec), diff_output, worktree_root=repo.path
+    )
+
+
+def _stage(repo: GitRepo, line_spec: str | None = None) -> None:
+    hunks, diff_output = _unstaged(repo)
+    apply_patch(
+        build_patch(_select(hunks, line_spec), diff_output, reverse=False),
+        worktree_root=repo.path,
+        cached=True,
+        reverse=False,
+        dry_run=False,
+    )
+
+
+@pytest.fixture
+def modified(repo: GitRepo) -> GitRepo:
+    _write(repo, "f.py", b"a = 1\nb = 2\nc = 3\n")
+    _commit(repo)
+    _write(repo, "f.py", b"a = 10\nb = 2\nc = 30\n")
+    return repo
+
+
+def _state(repo: GitRepo) -> tuple[str, str, bytes]:
+    return (
+        repo.git("diff", "--cached"),
+        repo.git("diff"),
+        (Path(repo.path) / "f.py").read_bytes(),
+    )
+
+
+def test_whole_hunk_materializes_the_worktree_content(modified: GitRepo) -> None:
+    assert _materialize(modified) == b"a = 10\nb = 2\nc = 30\n"
+
+
+def test_line_selection_materializes_the_partial_result(modified: GitRepo) -> None:
+    # Body: 1=-a 2=+a10 3= b 4=-c 5=+c30. Take only the first change.
+    assert _materialize(modified, "1,2") == b"a = 10\nb = 2\nc = 3\n"
+
+
+def test_exclude_line_selection_materializes_the_partial_result(
+    modified: GitRepo,
+) -> None:
+    assert _materialize(modified, "^4,^5") == b"a = 10\nb = 2\nc = 3\n"
+
+
+def test_the_real_index_and_worktree_stay_untouched(modified: GitRepo) -> None:
+    before = _state(modified)
+
+    _materialize(modified, "1,2")
+
+    assert _state(modified) == before
+
+
+@pytest.mark.parametrize(
+    "line_spec", [None, "1,2", "^4,^5"], ids=["whole-hunk", "include", "exclude"]
+)
+def test_result_matches_the_content_a_real_stage_produces(
+    modified: GitRepo, line_spec: str | None
+) -> None:
+    materialized = _materialize(modified, line_spec)
+
+    _stage(modified, line_spec)
+
+    assert _index_bytes(modified, "f.py") == materialized
+
+
+def test_result_builds_on_what_is_already_staged(repo: GitRepo) -> None:
+    # The scratch index is a copy of the current index, not of HEAD, so an
+    # earlier partial stage of the same file must show through in the result.
+    body = [f"line {number}" for number in range(1, 31)]
+    _write(repo, "f.txt", ("\n".join(body) + "\n").encode())
+    _commit(repo)
+    changed = body[:]
+    changed[1] = "changed 2"
+    changed[27] = "changed 28"
+    _write(repo, "f.txt", ("\n".join(changed) + "\n").encode())
+
+    hunks, diff_output = _unstaged(repo)
+    assert len(hunks) == 2
+    apply_patch(
+        build_patch(hunks[:1], diff_output, reverse=False),
+        worktree_root=repo.path,
+        cached=True,
+        reverse=False,
+        dry_run=False,
+    )
+
+    materialized = _materialize(repo)
+
+    assert materialized == ("\n".join(changed) + "\n").encode()
+
+
+def test_works_before_the_first_commit(repo: GitRepo) -> None:
+    # An unborn HEAD: every hunk is an addition and the scratch index is copied
+    # from an index that holds nothing but the intent-to-add entry.
+    _write(repo, "new.txt", b"x\ny\n")
+    repo.git("add", "-N", "new.txt")
+
+    assert _materialize(repo, "1") == b"x\n"
+
+
+def test_is_byte_exact_for_non_utf8_content_without_a_trailing_newline(
+    repo: GitRepo,
+) -> None:
+    # 0xe9 is "e-acute" in Latin-1 and an invalid standalone UTF-8 byte.
+    _write(repo, "latin1.txt", b"pass\xe9\ntail")
+    _commit(repo)
+    _write(repo, "latin1.txt", b"PASS\xe9\ntail")
+
+    assert _materialize(repo) == b"PASS\xe9\ntail"
+
+
+def test_is_byte_exact_for_crlf_content(repo: GitRepo) -> None:
+    _write(repo, "crlf.txt", b"one\r\ntwo\r\nthree\r\n")
+    _commit(repo)
+    _write(repo, "crlf.txt", b"ONE\r\ntwo\r\nTHREE\r\n")
+
+    assert _materialize(repo, "1,2") == b"ONE\r\ntwo\r\nthree\r\n"
+
+
+def test_a_binary_change_is_rejected(repo: GitRepo) -> None:
+    _write(repo, "a.bin", b"\x00\x01bin\xff")
+    _commit(repo)
+    _write(repo, "a.bin", b"\x00\x02BIN\xfe")
+
+    with pytest.raises(StagedContentError, match="binary or type changes"):
+        _materialize(repo)
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="git does not track the executable bit on Windows"
+)
+def test_a_mode_only_change_is_rejected(repo: GitRepo) -> None:
+    _write(repo, "m.sh", b"m\n")
+    _commit(repo)
+    (Path(repo.path) / "m.sh").chmod(0o755)
+
+    with pytest.raises(StagedContentError, match="empty tracked file additions"):
+        _materialize(repo)
+
+
+def test_an_empty_added_file_is_rejected(repo: GitRepo) -> None:
+    _write(repo, "seed.txt", b"seed\n")
+    _commit(repo)
+    _write(repo, "empty.txt", b"")
+    repo.git("add", "-N", "empty.txt")
+
+    with pytest.raises(StagedContentError, match="empty tracked file additions"):
+        _materialize(repo)
+
+
+def test_hunks_from_two_files_are_rejected(repo: GitRepo) -> None:
+    _write(repo, "one.txt", b"1\n")
+    _write(repo, "two.txt", b"2\n")
+    _commit(repo)
+    _write(repo, "one.txt", b"1X\n")
+    _write(repo, "two.txt", b"2X\n")
+
+    hunks, diff_output = _unstaged(repo)
+    assert len(hunks) == 2
+
+    with pytest.raises(StagedContentError, match="exactly one file"):
+        materialize_staged_content(hunks, diff_output, worktree_root=repo.path)
+
+
+def test_a_selection_that_removes_the_file_from_the_index_is_rejected(
+    repo: GitRepo,
+) -> None:
+    _write(repo, "gone.txt", b"p\nq\nr\n")
+    _commit(repo)
+    (Path(repo.path) / "gone.txt").unlink()
+
+    with pytest.raises(StagedContentError, match="removes 'gone.txt' from the index"):
+        _materialize(repo)
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="git does not track the executable bit on Windows"
+)
+def test_a_mode_change_alongside_text_edits_materializes_the_text(
+    modified: GitRepo,
+) -> None:
+    # A mode hunk carries no content, so it must not veto the file's text.
+    (Path(modified.path) / "f.py").chmod(0o755)
+
+    hunks, diff_output = _unstaged(modified)
+    assert len(hunks) == 2
+
+    assert (
+        materialize_staged_content(hunks, diff_output, worktree_root=modified.path)
+        == b"a = 10\nb = 2\nc = 30\n"
+    )


### PR DESCRIPTION
## Summary

Adds one internal seam and the plumbing it needs. Nothing calls it yet.

`materialize_staged_content(hunks, diff_output, worktree_root=...)` returns the
exact bytes one file would hold in the index after a selection was staged. It
applies the selected patch to a throwaway copy of the index via `GIT_INDEX_FILE`
and reads the blob back out of that copy, so the real index and working tree are
untouched. (The blob does land in the object database, unreferenced until
`git gc` reclaims it; the docstring says so rather than claiming "changes
nothing".)

The seam carries its own guards, so a caller gets a diagnosis instead of an
opaque `git apply` failure: the selection must cover exactly one file, must not
be binary, a type change, a submodule, or mode-only, and must not remove the file
from the index. It returns raw `bytes`, so non-UTF-8 content, CRLF, and a missing
trailing newline survive unchanged.

This is groundwork for `stage --verify` (#58): automatic verification at stage
time, where the check is not something the agent has to remember.

## Why this is not the `preview` command #57 asked for

#57 asked for a user-facing `git-hunk preview` command. An earlier revision of
this PR shipped it. A controlled ablation says it does not earn its place, so
this PR keeps only the machinery.

`claude-sonnet-5`, 30 samples, including 10 + 10 repeats on a scaled trap fixture
where the tempting exclusions provably stage unparseable Python:

| Variant           | Outcome | Tool calls (median) | Cost (median) | Broken commits |
| ----------------- | ------- | ------------------- | ------------- | -------------- |
| with `preview`    | 10/10   | 8                   | $0.09         | 0              |
| without `preview` | 10/10   | 5                   | $0.07         | 0              |

Zero outcome difference. The command cost +3 tool calls and +$0.02 median for
verification the model did not need: the agents without it avoided the trap by
selecting carefully in the first place, not by checking afterwards.

So the user-facing surface is declined, and the seam that a real fix can build on
is kept. The real-world incident evidence supports verification happening
automatically at stage time (#58), not an extra command an agent must think to
run.

## Commits

1. `refactor(git)` — add a bytes-returning core under `run_git` and thread an env
   overlay through, layered onto `os.environ` rather than replacing it, so git
   keeps `PATH`, `HOME`, and the caller's config. Behavior is unchanged.
2. `feat` — `_staged_content.py`, plus `scratch_index` and `read_index_blob` in
   `_git.py`.

Each commit builds and passes the full suite on its own.

## Notes

- The module is `git_hunk/_staged_content.py`, not `_preview.py`, and the error
  type is `StagedContentError`. With no `preview` command, "preview" in the error
  strings would name something that does not exist; these messages surface
  through `stage --verify` later.
- `docs/adr/0002` gains the `git ls-files` that reads the materialized blob to
  the list of calls that pass `--literal-pathspecs`, and corrects a pre-existing
  omission (`git rm`).
- No `CHANGELOG.md` entry: there is no user-facing change to document.

## Test plan

- [x] tests added: `tests/unit/_staged_content_test.py` (17 cases) — byte
      exactness for whole-hunk, include, and exclude selections; non-UTF-8
      content with no trailing newline; CRLF; equality with what a real staging
      apply produces across three selection forms; building on an already-staged
      index; unborn HEAD; the real index and worktree unchanged; and every
      rejection path (binary, mode-only, empty tracked addition, two files,
      index deletion)
- [x] `make test` (763 passed) and `make lint` green on each of the two commits

Refs #57
