### PR TITLE
feat(eval): grade a commit that does not parse, and a task that tempts one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ### Added
 
+- Agent eval task and grader criterion for a partial selection that would
+  commit syntactically broken code: one hunk interleaves the change to keep
+  with debug scaffolding, so every tempting whole-noise selection stages
+  Python that no longer parses, and the grader now fails any commit in the
+  graded range whose own tree holds an unparsable `.py` file, ahead of the
+  commit-partition check (#242).
 - `python -m eval --repeat N` samples every selected task variant N times from
   the same prepared state. Each cell reports the median with its observed range
   for tool calls, turns, and cost, a variant that failed only some repeats reads

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,6 +79,11 @@
   code. The git-hunk variant is the subject; bare Git is the comparison baseline, so its
   graded outcome is evidence and never fails the run.
 
+- **Broken commit**: an eval grader verdict — a commit in the graded range whose own
+  tree holds a `.py` file that does not parse. Checked before the commit partition,
+  because a commit nobody can check out and run is a worse fault than a wrongly grouped
+  one, and checked on every commit in the series rather than only on `HEAD`.
+
 - **Agent demonstration**: a side-by-side scenario run by the same pinned agent
   from the same Repository state with bare Git and with the git-hunk toolchain. It
   illustrates the difference between the resulting commit series but is not a

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -80,12 +80,23 @@ The grader checks the first failed invariant in this order:
 
 | Check              | Required state                                                   | Failure reason       |
 | ------------------ | ---------------------------------------------------------------- | -------------------- |
+| Commit parses      | Every `.py` blob in each commit's own tree parses                | `broken-commit`      |
 | Partition          | Actual commits match the declared changed-line groups            | `partition`          |
 | Order              | Required before and after constraints hold                       | `order`              |
 | Final commit       | The complete `HEAD` tree matches the declared files              | `final-tree`         |
 | Index              | Its tree and exact paths equal `HEAD`                            | `leftover-index`     |
 | Tracked worktree   | Exact bytes and modes match the declared tracked state           | `leftover-worktree`  |
 | Untracked worktree | Exact paths, bytes, and modes match the declared untracked state | `leftover-untracked` |
+
+The parse check is first because a partial selection that splits a syntactic
+structure produces a commit nobody can check out and run, and that is a worse
+fault than a wrongly grouped one. Reporting it as `partition` would name a
+line-set mismatch when the real defect is a file that does not compile. It
+reads each commit's own tree, not just `HEAD`, so a broken intermediate state
+cannot hide behind a correct final tree, and it names the commit, the path, and
+the syntax error. Only regular-file `.py` blobs are parsed: the task
+repositories are Python, and a symlink or a text fixture is not source the
+grader can judge.
 
 The complete snapshots make absence exact. They also detect duplicate lines,
 binary bytes, empty files, executable files, symlinks, and deletions. Changed
@@ -116,6 +127,19 @@ adds rather than what both tools share:
    the worktree. Changed-line sets cannot tell the twins apart, which is
    exactly the collision the complete `HEAD` snapshot exists to catch, and the
    agent must address the right member through a Conditional Hunk ID.
+
+One version 3 task targets the selection that is easy to make and impossible to
+verify by reading the diff alone:
+
+8. Commit the one change worth keeping out of a hunk whose debug scaffolding is
+   interleaved with it, leaving valid Python. Dropping the `print` lines by
+   content or by number strands the `if` header whose only body they are, and
+   any single line range covering both of them also swallows the `continue` the
+   kept change needs, so all three tempting selections stage a file that does
+   not parse. Its golden solver runs the stage-then-verify dance an agent has to
+   perform by hand today: stage the selection, parse the bytes the index now
+   holds, and commit from that verified index. The criterion is the backstop
+   either way, since it fails the run whether or not the agent thought to check.
 
 Every task has a deterministic golden solver. The adversarial matrix proves all
 grader boundaries. It includes a duplicate added line, a staged leftover, an
@@ -269,6 +293,9 @@ gates pass.
   diagnostic data, not durable evidence.
 - Release artifacts cannot include evaluator code or run data.
 - A line-set collision cannot hide an incorrect final tree.
+- A commit that does not parse is diagnosed as such, in every commit of the
+  series, rather than as a partition failure. Adding a non-Python task, or a
+  Python fixture that is deliberately invalid, needs this criterion revisited.
 - Staged, tracked, and untracked leftovers have separate diagnoses.
 - A bare-Git failure is a published result, not a red run.
 - The table reports one sample per cell by default and a median with its

--- a/eval/grader.py
+++ b/eval/grader.py
@@ -1,6 +1,8 @@
+import ast
 import dataclasses
 import os
 import stat
+from collections.abc import Iterator
 from typing import Final
 from typing import Literal
 from typing import cast
@@ -13,6 +15,7 @@ from eval.task import FileState
 from eval.task import Task
 
 FailureReason = Literal[
+    "broken-commit",
     "partition",
     "order",
     "final-tree",
@@ -23,6 +26,9 @@ FailureReason = Literal[
 ]
 
 SOLVER_ERROR: Final[FailureReason] = "solver-error"
+
+# Symlinks are blobs too, and their target is not Python source.
+_REGULAR_FILE_MODES: Final = frozenset({b"100644", b"100755"})
 
 
 @dataclasses.dataclass(frozen=True)
@@ -38,6 +44,12 @@ class Result:
 
 def grade(repo: GitRepo, task: Task, base: str) -> Result:
     shas = repo.git("rev-list", "--reverse", f"{base}..HEAD").split()
+    # A commit nobody can run is worse than a wrongly grouped one, so this reads
+    # every commit's own tree before the partition is even considered.
+    broken = _find_broken_commit(repo=repo, shas=shas)
+    if broken is not None:
+        return broken
+
     if len(shas) != len(task.commits):
         return _fail(
             reason="partition",
@@ -113,6 +125,37 @@ def grade(repo: GitRepo, task: Task, base: str) -> Result:
         )
 
     return Result(passed=True)
+
+
+def _find_broken_commit(*, repo: GitRepo, shas: list[str]) -> Result | None:
+    for sha in shas:
+        for path, object_id in _iter_python_blobs(repo=repo, sha=sha):
+            content = repo.git_bytes("cat-file", "blob", object_id)
+            try:
+                ast.parse(content)
+            except SyntaxError as error:
+                return _fail(
+                    reason="broken-commit",
+                    detail=f"commit {sha} leaves {path!r} unparsable: {error}",
+                )
+    return None
+
+
+def _iter_python_blobs(*, repo: GitRepo, sha: str) -> Iterator[tuple[str, str]]:
+    listing = repo.git_bytes("ls-tree", "-rz", "--full-tree", sha)
+    for record in listing.rstrip(b"\0").split(b"\0"):
+        if not record:
+            continue
+        metadata, raw_path = record.split(b"\t", maxsplit=1)
+        raw_mode, object_type, object_id = metadata.split(b" ")
+        path = os.fsdecode(raw_path)
+        if (
+            object_type != b"blob"
+            or raw_mode not in _REGULAR_FILE_MODES
+            or not path.endswith(".py")
+        ):
+            continue
+        yield path, object_id.decode()
 
 
 def _extract_changes(repo: GitRepo, sha: str) -> frozenset[ChangedLine]:

--- a/eval/grader.py
+++ b/eval/grader.py
@@ -133,7 +133,9 @@ def _find_broken_commit(*, repo: GitRepo, shas: list[str]) -> Result | None:
             content = repo.git_bytes("cat-file", "blob", object_id)
             try:
                 ast.parse(content)
-            except SyntaxError as error:
+            # ast.parse raises ValueError, not SyntaxError, for source it
+            # refuses to read at all, such as null bytes.
+            except (SyntaxError, ValueError) as error:
                 return _fail(
                     reason="broken-commit",
                     detail=f"commit {sha} leaves {path!r} unparsable: {error}",

--- a/eval/summary.py
+++ b/eval/summary.py
@@ -20,6 +20,7 @@ _REPEAT_CAVEAT: Final = (
 )
 
 REASON_LEGEND: Final[dict[FailureReason, str]] = {
+    "broken-commit": "a commit leaves a Python file that does not parse",
     "partition": "commits do not match the required change groups",
     "order": "a required commit order constraint is violated",
     "final-tree": "the final HEAD tree does not match the expected files",

--- a/eval/tasks/__init__.py
+++ b/eval/tasks/__init__.py
@@ -1,6 +1,7 @@
 from typing import Final
 
 from eval.scenario import Scenario
+from eval.tasks import commit_parseable_subset
 from eval.tasks import drop_debug_lines
 from eval.tasks import pick_duplicate_hunk
 from eval.tasks import protect_unrelated_work
@@ -17,4 +18,5 @@ SCENARIOS: Final[tuple[Scenario, ...]] = (
     split_single_hunk.SCENARIO,
     separate_formatter_noise.SCENARIO,
     pick_duplicate_hunk.SCENARIO,
+    commit_parseable_subset.SCENARIO,
 )

--- a/eval/tasks/commit_parseable_subset.py
+++ b/eval/tasks/commit_parseable_subset.py
@@ -131,9 +131,10 @@ SCENARIO: Final = Scenario(
             worktree=_FINAL_FILES,
         ),
         prompt=(
-            "Keep the skip for voided rows. The temporary debug tracing goes: "
-            "the print statements and the threshold check that exists only to "
-            "print. Every commit must leave the file valid Python."
+            "Commit the skip for voided rows. Delete the temporary debug "
+            "tracing instead of committing it: the print statements and the "
+            "threshold check that exists only to print. Every commit must "
+            "leave the file valid Python."
         ),
     ),
     golden=_golden,

--- a/eval/tasks/commit_parseable_subset.py
+++ b/eval/tasks/commit_parseable_subset.py
@@ -1,0 +1,146 @@
+import ast
+from typing import Final
+
+from eval.harness import list_hunks
+from eval.harness import run_git_hunk
+from eval.repo import GitRepo
+from eval.scenario import Scenario
+from eval.task import ChangedLine
+from eval.task import CommitSpec
+from eval.task import RepositoryState
+from eval.task import Task
+from eval.task import make_file
+
+_PATH: Final = "report.py"
+_MESSAGE: Final = "Skip voided rows"
+# The hunk body interleaves the change to keep with debug scaffolding:
+#
+#   4 +        if row.voided:
+#   5 +            print("DEBUG", "voided", row)
+#   6 +            continue
+#   7 +        if total > 1000:
+#   8 +            print("DEBUG", "large total", total)
+#
+# Only lines 4 and 6 belong in the commit. Dropping the two `print` lines by
+# content or by number strands line 7, and any single range covering both of
+# them also swallows line 6, so all three tempting selections stage a file that
+# no longer parses.
+_KEEP_LINES: Final = "4,6"
+_DEBUG_PATTERN: Final = 'print("DEBUG"'
+_STRANDING_RANGE: Final = "^5-8"
+
+_BASE: Final = (
+    "def summarize(rows):\n"
+    "    total = 0\n"
+    "    for row in rows:\n"
+    "        total += row.amount\n"
+    "    return total\n"
+)
+_DIRTY: Final = (
+    "def summarize(rows):\n"
+    "    total = 0\n"
+    "    for row in rows:\n"
+    "        if row.voided:\n"
+    '            print("DEBUG", "voided", row)\n'
+    "            continue\n"
+    "        if total > 1000:\n"
+    '            print("DEBUG", "large total", total)\n'
+    "        total += row.amount\n"
+    "    return total\n"
+)
+_FINAL: Final = (
+    "def summarize(rows):\n"
+    "    total = 0\n"
+    "    for row in rows:\n"
+    "        if row.voided:\n"
+    "            continue\n"
+    "        total += row.amount\n"
+    "    return total\n"
+)
+
+
+def _build(repo: GitRepo) -> None:
+    repo.write_file(name=_PATH, content=_BASE)
+    repo.git("add", _PATH)
+    repo.git("commit", "-m", "Initial state")
+    repo.write_file(name=_PATH, content=_DIRTY)
+
+
+def _single_hunk_id(repo: GitRepo) -> str:
+    # The trap only exists while both intents share one hunk.
+    (hunk,) = list_hunks(repo, _PATH)
+    return str(hunk["id"])
+
+
+def _commit_selection(repo: GitRepo, *selection: str) -> None:
+    hunk_id = _single_hunk_id(repo)
+    run_git_hunk(repo, "commit", hunk_id, *selection, "-m", _MESSAGE)
+
+
+def _golden(repo: GitRepo) -> None:
+    # Stage, read back what the index now holds, and only commit once it parses
+    # — the check an agent has to perform by hand today, and the one #58 wants
+    # to fold into `stage --verify`. Committing from the verified index means
+    # nothing can change between the check and the commit.
+    hunk_id = _single_hunk_id(repo)
+    run_git_hunk(repo, "stage", hunk_id, "-l", _KEEP_LINES)
+    try:
+        ast.parse(repo.git("show", f":{_PATH}"))
+    except SyntaxError as error:
+        run_git_hunk(repo, "unstage", _PATH)
+        raise RuntimeError(f"the selection staged unparsable Python: {error}")
+    repo.git("commit", "-m", _MESSAGE)
+    run_git_hunk(repo, "discard", _PATH)
+
+
+def _commit_without_matching_debug_lines(repo: GitRepo) -> None:
+    _commit_selection(repo, "--exclude-matching", _DEBUG_PATTERN)
+
+
+def _commit_without_the_debug_range(repo: GitRepo) -> None:
+    _commit_selection(repo, "-l", _STRANDING_RANGE)
+
+
+def _commit_everything(repo: GitRepo) -> None:
+    run_git_hunk(repo, "stage", _PATH)
+    repo.git("commit", "-m", _MESSAGE)
+
+
+def _forget_to_drop_the_scaffolding(repo: GitRepo) -> None:
+    _commit_selection(repo, "-l", _KEEP_LINES)
+
+
+_SKIP_VOIDED: Final = CommitSpec(
+    label="skip-voided",
+    changes=frozenset(
+        {
+            ChangedLine(path=_PATH, op="+", content="        if row.voided:"),
+            ChangedLine(path=_PATH, op="+", content="            continue"),
+        }
+    ),
+)
+_FINAL_FILES: Final = frozenset({make_file(path=_PATH, content=_FINAL)})
+
+SCENARIO: Final = Scenario(
+    task=Task(
+        name="commit_parseable_subset",
+        build=_build,
+        commits=(_SKIP_VOIDED,),
+        expected_state=RepositoryState(
+            head=_FINAL_FILES,
+            worktree=_FINAL_FILES,
+        ),
+        prompt=(
+            "Keep the skip for voided rows. The temporary debug tracing goes: "
+            "the print statements and the threshold check that exists only to "
+            "print. Every commit must leave the file valid Python."
+        ),
+    ),
+    golden=_golden,
+    adversarial=(
+        ("broken-commit", _commit_without_matching_debug_lines),
+        ("broken-commit", _commit_without_the_debug_range),
+        ("partition", _commit_everything),
+        ("leftover-worktree", _forget_to_drop_the_scaffolding),
+    ),
+)

--- a/tests/eval/grader_test.py
+++ b/tests/eval/grader_test.py
@@ -110,6 +110,24 @@ def test_grade_reports_an_intermediate_commit_that_does_not_parse(
     assert "expected an indented block" in (result.detail or "")
 
 
+def test_grade_reports_a_python_file_ast_refuses_to_read(
+    eval_repo: GitRepo,
+) -> None:
+    eval_repo.write_file(name="a.py", content="value = 1\n")
+    eval_repo.git("add", "a.py")
+    eval_repo.git("commit", "-m", "Initial state")
+    base = eval_repo.git("rev-parse", "HEAD").strip()
+    # ast.parse raises ValueError, not SyntaxError, for null bytes.
+    eval_repo.write_file(name="a.py", content=b"value = 1\x00\n")
+    eval_repo.git("commit", "--all", "-m", "Null byte")
+    task = _single_commit_task(path="a.py", content="value = 1\n")
+
+    result = grade(repo=eval_repo, task=task, base=base)
+
+    assert result.reason == "broken-commit"
+    assert "null bytes" in (result.detail or "")
+
+
 def test_grade_parses_only_python_files(eval_repo: GitRepo) -> None:
     eval_repo.write_file(name="notes.txt", content="")
     eval_repo.git("add", "notes.txt")

--- a/tests/eval/grader_test.py
+++ b/tests/eval/grader_test.py
@@ -70,6 +70,58 @@ def test_grade_accepts_exact_repository_state(eval_repo: GitRepo) -> None:
     assert grade(repo=eval_repo, task=task, base=base).passed
 
 
+def _single_commit_task(*, path: str, content: str) -> Task:
+    expected_file = make_file(path=path, content=content)
+    return Task(
+        name="single-commit",
+        build=lambda repo: None,
+        commits=(
+            CommitSpec(
+                label="update",
+                changes=frozenset(
+                    {ChangedLine(path=path, op="+", content=content.rstrip("\n"))}
+                ),
+            ),
+        ),
+        expected_state=RepositoryState(
+            head=frozenset({expected_file}),
+            worktree=frozenset({expected_file}),
+        ),
+    )
+
+
+def test_grade_reports_an_intermediate_commit_that_does_not_parse(
+    eval_repo: GitRepo,
+) -> None:
+    eval_repo.write_file(name="a.py", content="value = 1\n")
+    eval_repo.git("add", "a.py")
+    eval_repo.git("commit", "-m", "Initial state")
+    base = eval_repo.git("rev-parse", "HEAD").strip()
+    eval_repo.write_file(name="a.py", content="if value:\n")
+    eval_repo.git("commit", "--all", "-m", "Half a conditional")
+    eval_repo.write_file(name="a.py", content="if value:\n    pass\n")
+    eval_repo.git("commit", "--all", "-m", "The other half")
+    task = _single_commit_task(path="a.py", content="if value:\n    pass\n")
+
+    result = grade(repo=eval_repo, task=task, base=base)
+
+    # The commit count is wrong too; the unparsable tree is the worse fault.
+    assert result.reason == "broken-commit"
+    assert "expected an indented block" in (result.detail or "")
+
+
+def test_grade_parses_only_python_files(eval_repo: GitRepo) -> None:
+    eval_repo.write_file(name="notes.txt", content="")
+    eval_repo.git("add", "notes.txt")
+    eval_repo.git("commit", "-m", "Initial state")
+    base = eval_repo.git("rev-parse", "HEAD").strip()
+    eval_repo.write_file(name="notes.txt", content="def (\n")
+    eval_repo.git("commit", "--all", "-m", "Not Python")
+    task = _single_commit_task(path="notes.txt", content="def (\n")
+
+    assert grade(repo=eval_repo, task=task, base=base).passed
+
+
 @pytest.mark.parametrize("task,solver,expected_reason", _FAILURE_PARAMS)
 def test_grade_reports_each_repository_failure_reason(
     eval_repo: GitRepo,

--- a/tests/eval/grader_test.py
+++ b/tests/eval/grader_test.py
@@ -141,6 +141,7 @@ def test_grade_reports_each_repository_failure_reason(
 
 def test_failure_cases_cover_every_repository_boundary() -> None:
     assert set(_FAILURE_CASES) == {
+        "broken-commit",
         "partition",
         "order",
         "final-tree",


### PR DESCRIPTION
## Summary

Stacks on #239 (base `feat/57-preview-staged-content`); GitHub retargets this to
`main` when #239 merges. Nothing here depends on #239 any more — the stack only
keeps the review order.

- New grader criterion `broken-commit`: for every commit in `base..HEAD`, every
  `.py` blob in that commit's own tree must parse. It runs **before** the
  partition check, because a commit nobody can check out and run is a worse
  fault than a wrongly grouped one, and reporting it as `partition` would name a
  line-set mismatch when the real defect is a file that does not compile. It
  reads each commit's own tree, so a broken intermediate state cannot hide
  behind a correct final tree, and the detail names the commit, the path, and
  the syntax error.
- New eval task `commit_parseable_subset`. One hunk interleaves the change worth
  keeping with debug scaffolding:

  ```text
  4 +        if row.voided:
  5 +            print("DEBUG", "voided", row)
  6 +            continue
  7 +        if total > 1000:
  8 +            print("DEBUG", "large total", total)
  ```

  Only lines 4 and 6 belong in the commit, and every tempting whole-noise
  selection stages Python that does not parse:
  `--exclude-matching 'print("DEBUG"'` and `-l ^5,^8` both strand line 7, the
  `if` header whose only body is a debug print, and any single range covering
  both prints (`-l ^5-8`) also swallows the `continue` the kept change needs.
  The trap is structural, not the one-sided replacement-pair case the `core`
  skill already warns about.
- The golden solver runs the stage-then-verify dance an agent has to perform by
  hand today: stage `-l 4,6`, `ast.parse` the bytes `git show :report.py` then
  returns, and commit from that verified index. That is the sequence #58 wants
  to fold into `stage --verify`; the grader criterion is the backstop either
  way, since it fails the run whether or not the agent thought to check.
- Adversarials: two `broken-commit` (the match trap and the range trap, proving
  the new boundary fires ahead of `partition`), one `partition` (everything in
  one commit), one `leftover-worktree` (correct commit, scaffolding left
  behind).

Every pre-existing adversarial still fails at its originally declared boundary
after the ordering change — all existing task commits hold parseable Python, so
nothing shifted, and `tests/eval/deterministic_test.py` (which auto-discovers
`SCENARIOS`) proves it rather than assuming it.

## What changed since the last review

Only the golden solver, and the prose that described it. The task fixture, the
prompt, the adversarial matrix, and the grader are unchanged in what they
enforce.

The earlier golden shelled `git-hunk preview`. That command is not shipping —
see #239, where a 30-sample ablation found zero outcome difference from having
it — so the golden now performs the same check with `stage` plus
`git show :<path>` instead.

## Measured effect

The paired `claude-sonnet-5` run reported earlier (git-hunk PASS · 5 calls ·
$0.10 vs bare-git PASS · 15 calls · $0.14) was measured with the `preview`
command available to the agent, so it no longer reproduces and has been dropped
rather than restated. Both variants passed then, so the task measured workflow
rather than capability; the bare-Git agent reached the same end state only after
overwriting the dirty working tree by hand and rebuilding it from a hand-written
`git apply` patch.

The evidence that matters for this PR is that the task and criterion catch a
selection that produces a commit which does not compile, which the deterministic
adversarials prove without spending model usage.

## Test plan

- [x] `make test` (772 passed) and `make lint` green
- [x] New golden passes and all four new adversarials fail at their declared
      boundary; the grader gains two focused unit tests (a broken *intermediate*
      commit is reported as `broken-commit` even though the commit count is
      wrong too, and non-Python files are never parsed)
- [x] Each commit is green on its own
