### PR TITLE
test: pin that a staged hunk ignores unstaged peers in other files

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,4 +125,6 @@
 - A Conditional Hunk ID can change when its Duplicate Hunk group changes.
 - A Duplicate Hunk group keeps its Conditional Hunk IDs when complete Hunks outside
   the group are committed.
+- Ordering a Duplicate Hunk group's members counts only the unstaged Hunks with the
+  same Repository path, so an unstaged change elsewhere cannot renumber the group.
 - Each Hunk ID in an inventory addresses exactly one Hunk.

--- a/tests/e2e/hunk_identity/duplicate_test.py
+++ b/tests/e2e/hunk_identity/duplicate_test.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import pytest
 
+from git_hunk._hunk import parse_hunk_range
+
 from ..conftest import GitHunkCLI
 
 
@@ -87,6 +89,61 @@ def test_duplicate_group_keeps_ids_when_a_non_member_is_committed(
     # A list, not a set: the two members swapping IDs is a renumbering too.
     assert [hunk["id"] for hunk in after] == group_ids
     assert {hunk["id_stability"] for hunk in after} == {"conditional"}
+
+
+def test_staged_duplicate_member_ignores_unstaged_hunks_in_other_files(
+    duplicate_hunks: GitHunkCLI,
+) -> None:
+    # Ordering a Duplicate Hunk group's members adds the net line delta of the
+    # unstaged Hunks that start before a staged member, and only Hunks with the
+    # same Repository path can contribute one. Counting another path's would
+    # move a staged member against its twin and renumber the group.
+    members = duplicate_hunks.run_list_json("list", "--json")
+    assert [hunk["id_stability"] for hunk in members] == ["conditional", "conditional"]
+    first_start, second_start = (
+        parse_hunk_range(hunk["header"]).new_start for hunk in members
+    )
+    assert first_start < second_start
+    # Size the unrelated files from the fixture's own geometry. A miscount only
+    # renumbers the group when it drags the staged member past its twin, so a
+    # literal tuned to today's separation would leave the test passing and
+    # detecting nothing the moment that separation grew.
+    other_file_lines = second_start - first_start + 5
+    # One unrelated path sorts before f.txt and one after. The guard compares
+    # Repository paths rather than their order, so a half-guard that leaked only
+    # one direction would survive a single unrelated path.
+    for name in ("a.txt", "z.txt"):
+        duplicate_hunks.repo.write_file(
+            name, "".join(f"old {n}\n" for n in range(other_file_lines))
+        )
+        duplicate_hunks.repo.git("add", name)
+        duplicate_hunks.repo.git("commit", "-m", f"add {name}")
+
+    # Stage the later member: only a member whose position is adjusted at all
+    # can be moved by a miscounted peer, and only the staged branch adjusts.
+    duplicate_hunks.run_ok("stage", members[1]["id"])
+
+    staged = duplicate_hunks.run_list_json("list", "--staged", "--json")
+    assert len(staged) == 1
+    # second_start was read before the member was staged, so pin that staging
+    # did not move it. Given that, collapsing either unrelated path to one line
+    # deletes four more lines than separate the pair, which is what makes a
+    # miscount reorder them.
+    assert parse_hunk_range(staged[0]["header"]).new_start == second_start
+    # --json reports canonical IDs, so no prefix length can hide a renumbering.
+    staged_id = staged[0]["id"]
+    unstaged_id = duplicate_hunks.get_only_hunk_id("--unstaged")
+    for name in ("a.txt", "z.txt"):
+        duplicate_hunks.repo.write_file(name, "new\n")
+
+    after_staged = duplicate_hunks.run_list_json("list", "--staged", "--json")
+    after_unstaged = duplicate_hunks.run_list_json("list", "--unstaged", "--json")
+    # Filtering on stability also fails if the group collapses to stable IDs.
+    assert [
+        hunk["id"]
+        for hunk in after_staged + after_unstaged
+        if hunk["id_stability"] == "conditional"
+    ] == [staged_id, unstaged_id]
 
 
 @pytest.mark.parametrize("ordinal", [0, 1])


### PR DESCRIPTION
Closes #241.

Ordering a Duplicate Hunk group's members adds the net line delta of the unstaged Hunks ahead of a staged member, counting only the ones with the same Repository path. Dropping that condition left the entire suite green, so a staged group member could be renumbered by an edit to an unrelated path with nothing to catch it.

## Why the scenario looks the way it does

Ordinals depend only on members' *relative* order, so a miscount is invisible unless it actually reorders them. That rules out an unrelated hunk that adds lines — it only pushes the staged member further from its twin. The peer has to **delete** more lines than separate the two members, and precede the staged one.

Two details are load-bearing rather than incidental:

- The deletion is sized from the fixture's own geometry, not a literal. An earlier revision hard-coded it against today's 37-line separation with three lines of slack; widening the shared `duplicate_hunks` fixture's separator to `range(50)` made the test pass while detecting nothing.
- One unrelated path sorts before the group's and one after, matching the sibling test for #222. With only an earlier-sorting path, a half-guard that leaks later-sorting peers survives.

## Mutation evidence

Each mutation applied to the guard in `_compute_worktree_position`, run against the full suite and reverted:

| mutation | meaning | result |
| --- | --- | --- |
| `if peer.status != "unstaged":` | guard deleted | killed |
| `... or peer.file > hunk.file:` | leaks earlier-sorting paths | killed |
| `... or peer.file < hunk.file:` | leaks later-sorting paths | killed |

The first is also killed at fixture separator `range(30)`, `range(50)`, and `range(200)`, confirming the derived sizing holds beyond the geometry it was written against.

## Known gap, out of scope

The other half of the same guard stays uncovered: mutating it to `if peer.file != hunk.file:`, so staged peers get counted too, leaves all 746 tests green. Same shape as #241, pre-existing, and not what this ticket asked for. Filed separately.

## Test plan

- [x] `make test` — 746 passed
- [x] `make lint` — clean
- [x] Mutation matrix above, with `git_hunk/_hunk.py` verified byte-identical afterwards
- [x] The commit verified in isolation in a detached worktree

No `CHANGELOG.md` entry: test-only plus an internal domain-doc line, matching `3e937eb` (#238) and prior test-only merges.
