### PR TITLE
feat: reject one-sided selection of a one-for-one replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to
   lone-half case; it requires one of the selection options and does not relax
   the wider grouped-replacement rule. An eval run first caught the silent half,
   and the core skill, README, and domain glossary documented the hazard (#226)
-  before this release made it an error (#TBD).
+  before this release made it an error (#251).
 - Ask for a one-line-per-commit close in the core skill, so the agent's final
   report stops restating the diff it just committed (#220).
 - Condense the core skill to the rules an agent acts on, trimming the text it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,11 +57,16 @@ and this project adheres to
 
 ### Changed
 
-- The core skill, README, and domain glossary warn that a partial selection of
-  a one-for-one replacement covers only the lines it names, after an eval run
-  showed a one-sided match silently committing a deletion-only half. The
-  warning is documentation; a guard in the CLI itself is tracked by #225
-  (#226).
+- **Breaking:** Selecting exactly one side of a one-for-one replacement now
+  exits 1 with an error naming the pair's line numbers, instead of exiting 0
+  after silently staging, committing, or discarding the deletion-only or
+  addition-only half. `-l`, `--include-matching`, and `--exclude-matching` share
+  the guard, and nothing is mutated when it fires. `stage`, `unstage`,
+  `discard`, and `commit` take a new `--allow-one-sided` flag for the deliberate
+  lone-half case; it requires one of the selection options and does not relax
+  the wider grouped-replacement rule. An eval run first caught the silent half,
+  and the core skill, README, and domain glossary documented the hazard (#226)
+  before this release made it an error (#TBD).
 - Ask for a one-line-per-commit close in the core skill, so the agent's final
   report stops restating the diff it just committed (#220).
 - Condense the core skill to the rules an agent acts on, trimming the text it

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,10 +31,10 @@
   Hunk group. It can change when the group changes.
 
 - **Change group**: a maximal run of changed `-` and `+` lines with no context line
-  between them. Partial line selection is unrestricted for pure additions, pure
-  deletions, and one-for-one replacements; a one-sided selection of a one-for-one
-  replacement applies only that half. A larger grouped replacement is selected
-  as a whole or not selected.
+  between them. Partial line selection is unrestricted for pure additions and pure
+  deletions. A one-for-one replacement is selected whole, or one-sided only with
+  `--allow-one-sided`, which then applies just that half. A larger grouped
+  replacement is selected as a whole or not selected, whatever the flag says.
 
 - **Whole-file hunk**: a tracked Hunk with no `@@` text range: a binary change, a mode-only
   (chmod) change, a type change (e.g. file to symlink), or an empty tracked addition

--- a/README.md
+++ b/README.md
@@ -167,14 +167,15 @@ instead of line number (literal substring by default, `--regex` for regular
 expressions). Both are repeatable and OR'd, case-sensitive, and error if nothing
 matches. They are mutually exclusive with `-l` and with each other.
 
-Line selection accepts any subset of a pure addition, pure deletion, or
-one-for-one replacement. Selecting one side of a one-for-one replacement
-applies just that half, leaving a deletion-only or addition-only change. A
-grouped replacement with multiple deleted or added lines must be selected as a
-whole or not selected. Numeric range endpoints are checked against the Hunk
-before expansion, and no-newline state is preserved for each patch side.
-Submodule pointer changes and whole-file Hunks do not support line selection.
-Select the Hunk as a whole.
+Line selection accepts any subset of a pure addition or pure deletion. Selecting
+one side of a one-for-one replacement is rejected, because it would leave a
+deletion-only or addition-only half; select both lines, match text they share,
+or pass `--allow-one-sided` when that half is what you want. A grouped
+replacement with multiple deleted or added lines must be selected as a whole or
+not selected, and `--allow-one-sided` does not relax that. Numeric range
+endpoints are checked against the Hunk before expansion, and no-newline state is
+preserved for each patch side. Submodule pointer changes and whole-file Hunks do
+not support line selection. Select the Hunk as a whole.
 
 A binary, mode-only, type, or empty tracked file change is a whole-file Hunk.
 Plain output labels empty tracked changes as `Empty file (added)` or
@@ -192,7 +193,8 @@ git-hunk commit d161935 --exclude-matching debug -m "..."  # commit all but matc
 
 `commit` aborts if anything is already staged, so the commit contains exactly
 the selected hunks. It accepts the same `-l`, `--include-matching`,
-`--exclude-matching`, and `--regex` selection options as `stage`.
+`--exclude-matching`, `--regex`, and `--allow-one-sided` selection options as
+`stage`.
 
 ### JSON output
 

--- a/eval/tasks/separate_formatter_noise.py
+++ b/eval/tasks/separate_formatter_noise.py
@@ -84,12 +84,15 @@ def _commit_by_hunk_not_intent(repo: GitRepo) -> None:
 
 
 def _commit_one_sided_match(repo: GitRepo) -> None:
+    # The guard rejects a lone half by default, so the adversarial solver has to
+    # ask for it explicitly to still reproduce the broken partition.
     run_git_hunk(
         repo,
         "commit",
         find_hunk(repo, "client.py", "session.get"),
         "--include-matching",
         "session.get(url)",
+        "--allow-one-sided",
         "-m",
         "Add a request timeout",
     )

--- a/eval/tasks/split_single_hunk.py
+++ b/eval/tasks/split_single_hunk.py
@@ -35,7 +35,7 @@ def _build(repo: GitRepo) -> None:
     repo.write_file(name="total.py", content=_FINAL)
 
 
-def _commit_fix(repo: GitRepo, *, match: str) -> None:
+def _commit_fix(repo: GitRepo, *, match: str, allow_one_sided: bool = False) -> None:
     (hunk,) = list_hunks(repo, "total.py")
     run_git_hunk(
         repo,
@@ -43,6 +43,7 @@ def _commit_fix(repo: GitRepo, *, match: str) -> None:
         str(hunk["id"]),
         "--include-matching",
         match,
+        *(["--allow-one-sided"] if allow_one_sided else []),
         "-m",
         "Multiply price by quantity",
     )
@@ -59,7 +60,9 @@ def _squash_into_one_commit(repo: GitRepo) -> None:
 
 
 def _commit_one_sided_match(repo: GitRepo) -> None:
-    _commit_fix(repo, match="item.price * item.qty")
+    # The guard rejects a lone half by default, so the adversarial solver has to
+    # ask for it explicitly to still reproduce the broken partition.
+    _commit_fix(repo, match="item.price * item.qty", allow_one_sided=True)
     run_git_hunk(repo, "commit", "total.py", "-m", "Round the returned total")
 
 

--- a/git_hunk/_cli.py
+++ b/git_hunk/_cli.py
@@ -275,6 +275,7 @@ class _Selection:
     include_matching: tuple[str, ...]
     exclude_matching: tuple[str, ...]
     regex: bool
+    allow_one_sided: bool
 
     def is_active(self) -> bool:
         return (
@@ -299,8 +300,9 @@ def _build_selection(
     line_spec: str | None,
     include_matching: tuple[str, ...],
     exclude_matching: tuple[str, ...],
-    regex: bool,
     *,
+    regex: bool,
+    allow_one_sided: bool,
     usage: str,
 ) -> _Selection:
     mechanisms = [line_spec is not None, bool(include_matching), bool(exclude_matching)]
@@ -314,11 +316,17 @@ def _build_selection(
             "--regex requires --include-matching or --exclude-matching",
             usage=usage,
         )
+    if allow_one_sided and not any(mechanisms):
+        raise CliError(
+            "--allow-one-sided requires -l, --include-matching, or --exclude-matching",
+            usage=usage,
+        )
     return _Selection(
         line_spec=line_spec,
         include_matching=include_matching,
         exclude_matching=exclude_matching,
         regex=regex,
+        allow_one_sided=allow_one_sided,
     )
 
 
@@ -341,7 +349,15 @@ def _apply_line_filter(
         )
     try:
         lines, exclude = selection.resolve(hunks[0])
-        return [filter_hunk_lines(hunks[0], lines, exclude=exclude, reverse=reverse)]
+        return [
+            filter_hunk_lines(
+                hunks[0],
+                lines,
+                exclude=exclude,
+                reverse=reverse,
+                allow_one_sided=selection.allow_one_sided,
+            )
+        ]
     except ValueError as exc:
         raise CliError(str(exc)) from exc
 
@@ -682,6 +698,7 @@ def _add_patch_selection_options(command: Callable[..., None]) -> Callable[..., 
         click.option("--include-matching", "include_matching", multiple=True),
         click.option("--exclude-matching", "exclude_matching", multiple=True),
         click.option("--regex", "use_regex", is_flag=True),
+        click.option("--allow-one-sided", "allow_one_sided", is_flag=True),
         click.option("--dry-run", "dry_run", is_flag=True),
         click.option("-h", "--help", "show_help", is_flag=True),
         click.argument("targets", nargs=-1),
@@ -699,6 +716,7 @@ def cmd_stage(
     include_matching: tuple[str, ...],
     exclude_matching: tuple[str, ...],
     use_regex: bool,
+    allow_one_sided: bool,
     dry_run: bool,
     show_help: bool,
 ) -> None:
@@ -706,7 +724,12 @@ def cmd_stage(
         print_help(HELP_STAGE)
         return
     selection = _build_selection(
-        line_spec, include_matching, exclude_matching, use_regex, usage=USAGE_STAGE
+        line_spec,
+        include_matching,
+        exclude_matching,
+        regex=use_regex,
+        allow_one_sided=allow_one_sided,
+        usage=USAGE_STAGE,
     )
     _run_patch_command(
         list(targets),
@@ -729,6 +752,7 @@ def cmd_unstage(
     include_matching: tuple[str, ...],
     exclude_matching: tuple[str, ...],
     use_regex: bool,
+    allow_one_sided: bool,
     dry_run: bool,
     show_help: bool,
 ) -> None:
@@ -736,7 +760,12 @@ def cmd_unstage(
         print_help(HELP_UNSTAGE)
         return
     selection = _build_selection(
-        line_spec, include_matching, exclude_matching, use_regex, usage=USAGE_UNSTAGE
+        line_spec,
+        include_matching,
+        exclude_matching,
+        regex=use_regex,
+        allow_one_sided=allow_one_sided,
+        usage=USAGE_UNSTAGE,
     )
     _run_patch_command(
         list(targets),
@@ -759,6 +788,7 @@ def cmd_discard(
     include_matching: tuple[str, ...],
     exclude_matching: tuple[str, ...],
     use_regex: bool,
+    allow_one_sided: bool,
     dry_run: bool,
     show_help: bool,
 ) -> None:
@@ -766,7 +796,12 @@ def cmd_discard(
         print_help(HELP_DISCARD)
         return
     selection = _build_selection(
-        line_spec, include_matching, exclude_matching, use_regex, usage=USAGE_DISCARD
+        line_spec,
+        include_matching,
+        exclude_matching,
+        regex=use_regex,
+        allow_one_sided=allow_one_sided,
+        usage=USAGE_DISCARD,
     )
     _run_patch_command(
         list(targets),
@@ -787,6 +822,7 @@ def cmd_discard(
 @click.option("--include-matching", "include_matching", multiple=True)
 @click.option("--exclude-matching", "exclude_matching", multiple=True)
 @click.option("--regex", "use_regex", is_flag=True)
+@click.option("--allow-one-sided", "allow_one_sided", is_flag=True)
 @click.option("-h", "--help", "show_help", is_flag=True)
 @click.argument("targets", nargs=-1)
 def cmd_commit(
@@ -796,6 +832,7 @@ def cmd_commit(
     include_matching: tuple[str, ...],
     exclude_matching: tuple[str, ...],
     use_regex: bool,
+    allow_one_sided: bool,
     show_help: bool,
 ) -> None:
     if show_help:
@@ -822,7 +859,8 @@ def cmd_commit(
         line_spec,
         include_matching,
         exclude_matching,
-        use_regex,
+        regex=use_regex,
+        allow_one_sided=allow_one_sided,
         usage=USAGE_COMMIT,
     )
     selected = _apply_selection(

--- a/git_hunk/_lines.py
+++ b/git_hunk/_lines.py
@@ -165,22 +165,36 @@ def _render_body_lines(kept: list[_BodyLine]) -> list[str]:
     return rendered
 
 
-def _validate_group(group: list[tuple[int, str]], selected: set[int]) -> None:
+def _validate_group(
+    group: list[tuple[int, str]], selected: set[int], *, allow_one_sided: bool
+) -> None:
     """Reject a partial subset of a grouped replacement.
 
     Git pairs no old line with any new line inside a run of changed lines, so a
     subset of a replacement wider than one-for-one has no defined meaning. Pure
-    additions, pure deletions, and one-for-one replacements stay unrestricted.
+    additions and pure deletions stay unrestricted.
+
+    A one-for-one replacement has a defined half, but taking one is almost never
+    what the caller meant: it leaves the old line deleted with nothing put back,
+    or the new line added beside the old one. Reject it unless the caller asks
+    for that half deliberately with allow_one_sided; the wider grouped
+    replacement stays a hard error either way.
     """
     deletions = sum(prefix == "-" for _, prefix in group)
     additions = sum(prefix == "+" for _, prefix in group)
     if not deletions or not additions:
         return
-    if deletions == 1 and additions == 1:
-        return
     selected_count = sum(number in selected for number, _ in group)
     if selected_count in (0, len(group)):
         return
+    if deletions == 1 and additions == 1:
+        if allow_one_sided:
+            return
+        raise ValueError(
+            f"cannot select one side of lines {group[0][0]}-{group[-1][0]}: "
+            "one-for-one replacement; match text both lines share, select both "
+            "lines, or pass --allow-one-sided"
+        )
     raise ValueError(
         f"cannot partially select lines {group[0][0]}-{group[-1][0]}: "
         f"grouped replacement (deletions: {deletions}, additions: {additions}); "
@@ -188,15 +202,17 @@ def _validate_group(group: list[tuple[int, str]], selected: set[int]) -> None:
     )
 
 
-def _validate_group_selection(body: list[_BodyLine], selected: set[int]) -> None:
+def _validate_group_selection(
+    body: list[_BodyLine], selected: set[int], *, allow_one_sided: bool
+) -> None:
     group: list[tuple[int, str]] = []
     for line_num, line in enumerate(body, start=1):
         if line.prefix in ("+", "-"):
             group.append((line_num, line.prefix))
             continue
-        _validate_group(group, selected)
+        _validate_group(group, selected, allow_one_sided=allow_one_sided)
         group = []
-    _validate_group(group, selected)
+    _validate_group(group, selected, allow_one_sided=allow_one_sided)
 
 
 def resolve_matching_lines(
@@ -241,7 +257,12 @@ def resolve_matching_lines(
 
 
 def filter_hunk_lines(
-    hunk: Hunk, lines: set[int], *, exclude: bool, reverse: bool = False
+    hunk: Hunk,
+    lines: set[int],
+    *,
+    exclude: bool,
+    reverse: bool = False,
+    allow_one_sided: bool = False,
 ) -> Hunk:
     """Return a new Hunk with only the selected lines as changes.
 
@@ -265,7 +286,7 @@ def filter_hunk_lines(
     else:
         selected = lines
 
-    _validate_group_selection(body, selected)
+    _validate_group_selection(body, selected, allow_one_sided=allow_one_sided)
     # A forward apply matches OLD content, so unselected '-' lines become
     # context and unselected '+' lines drop. A reverse apply matches NEW
     # content, so the two sides swap.

--- a/git_hunk/_ui.py
+++ b/git_hunk/_ui.py
@@ -241,7 +241,8 @@ _LINE_OPT_ROW = f"""\
   [bold cyan]--include-matching[/bold cyan] [cyan]<pattern>[/cyan]  Select changed lines containing <pattern> (repeatable, OR'd)
   [bold cyan]--exclude-matching[/bold cyan] [cyan]<pattern>[/cyan]  Select every changed line except those matching (repeatable, OR'd)
              Line selection (-l, --include-matching, --exclude-matching) requires exactly one hunk.
-  [bold cyan]--regex[/bold cyan]    Treat matching patterns as regular expressions (default: literal substring)"""  # noqa: E501
+  [bold cyan]--regex[/bold cyan]    Treat matching patterns as regular expressions (default: literal substring)
+  [bold cyan]--allow-one-sided[/bold cyan]  Permit selecting one side of a one-for-one replacement (rejected by default)"""  # noqa: E501
 
 _LINE_OPTS = f"""\
 [bold green]Options:[/bold green]

--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -52,15 +52,15 @@ git-hunk commit d161935 -l 3,5-7 -m "add retry" && git-hunk list
 ```
 
 Prefer content matching when the line has distinctive text; it avoids tracking
-body positions. Unless a lone half is the goal, a partial selection of a
-one-for-one replacement must cover both its `-` and `+` line: with `-l`,
-`--include-matching`, and `--exclude-matching` alike, a one-sided selection
-silently commits a deletion-only or addition-only half. To lift `delay = base`
-into `delay = base * backoff`, match `base`, which both lines contain and no
-other changed line shares, not `base * backoff`. When the pair shares no such
-text, repeat `--include-matching` with one pattern per side, or fall back to
-`-l`. Once the user has asked for the rest to go, the discard and the refresh
-finish the same call:
+body positions. A partial selection of a one-for-one replacement must cover both
+its `-` and `+` line: with `-l`, `--include-matching`, and `--exclude-matching`
+alike, a one-sided selection is an error that changes nothing. To lift
+`delay = base` into `delay = base * backoff`, match `base`, which both lines
+contain and no other changed line shares, not `base * backoff`. When the pair
+shares no such text, repeat `--include-matching` with one pattern per side, or
+fall back to `-l`. Add `--allow-one-sided` only when a lone deletion-only or
+addition-only half is genuinely the goal. Once the user has asked for the rest
+to go, the discard and the refresh finish the same call:
 
 ```bash
 git-hunk commit a4c0b82 --exclude-matching 'print("DEBUG"' -m "fix total" &&

--- a/tests/e2e/grouped_replacement_test.py
+++ b/tests/e2e/grouped_replacement_test.py
@@ -78,6 +78,23 @@ def test_commit_rejection_is_atomic(grouped_replacement: GitHunkCLI) -> None:
     assert _capture_repo_state(cli) == before
 
 
+@pytest.mark.parametrize("spec", ["2,4", "^3,^5"])
+def test_allow_one_sided_does_not_relax_the_group_rule(
+    grouped_replacement: GitHunkCLI, spec: str
+) -> None:
+    # --allow-one-sided covers a one-for-one pair only; a wider grouped
+    # replacement stays a hard error.
+    cli = grouped_replacement
+    before = _capture_repo_state(cli)
+
+    result = cli.run(
+        "stage", cli.get_only_hunk_id("--unstaged"), "-l", spec, "--allow-one-sided"
+    )
+
+    _assert_group_error(result.returncode, result.stderr)
+    assert _capture_repo_state(cli) == before
+
+
 @pytest.mark.parametrize(
     "selector",
     [

--- a/tests/e2e/help_test.py
+++ b/tests/e2e/help_test.py
@@ -41,3 +41,12 @@ def test_hunk_command_help_describes_prefix_lookup(
 
     assert "unambiguous" in output
     assert "case-insensitive" in output
+
+
+@pytest.mark.parametrize("command", ["stage", "unstage", "discard", "commit"])
+def test_selection_command_help_documents_allow_one_sided(
+    cli: GitHunkCLI, command: str
+) -> None:
+    output = cli.run_ok(command, "--help")
+
+    assert "--allow-one-sided" in output

--- a/tests/e2e/no_newline_test.py
+++ b/tests/e2e/no_newline_test.py
@@ -115,7 +115,9 @@ def test_stage_addition_of_no_newline_to_newline_keeps_lines_separate(
     cli.repo.write_file("f.txt", "a\nB\n")
 
     # Body lines: 1= a 2=-b 3=+B. Stage only the addition.
-    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"), "-l", "3")
+    cli.run_ok(
+        "stage", cli.get_only_hunk_id("--unstaged"), "-l", "3", "--allow-one-sided"
+    )
 
     assert cli.repo.git("show", ":f.txt") == "a\nb\nB\n"
 
@@ -124,7 +126,9 @@ def test_stage_addition_then_remainder_reaches_working_tree(cli: GitHunkCLI) -> 
     _commit(cli, "a\nb")
     cli.repo.write_file("f.txt", "a\nB\n")
 
-    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"), "-l", "3")
+    cli.run_ok(
+        "stage", cli.get_only_hunk_id("--unstaged"), "-l", "3", "--allow-one-sided"
+    )
     assert cli.repo.git("show", ":f.txt") == "a\nb\nB\n"
 
     remaining = cli.run_list_json("list", "--unstaged", "--json")
@@ -140,7 +144,9 @@ def test_stage_addition_both_sides_no_newline_keeps_lines_separate(
     cli.repo.write_file("f.txt", "a\nB")
 
     # Body lines: 1= a 2=-b 3=+B, both last lines lack a trailing newline.
-    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"), "-l", "3")
+    cli.run_ok(
+        "stage", cli.get_only_hunk_id("--unstaged"), "-l", "3", "--allow-one-sided"
+    )
 
     assert cli.repo.git("show", ":f.txt") == "a\nb\nB"
 
@@ -151,7 +157,9 @@ def test_discard_addition_of_no_newline_to_newline_keeps_lines_separate(
     _commit(cli, "a\nb")
     cli.repo.write_file("f.txt", "a\nB\n")
 
-    cli.run_ok("discard", cli.get_only_hunk_id("--unstaged"), "-l", "3")
+    cli.run_ok(
+        "discard", cli.get_only_hunk_id("--unstaged"), "-l", "3", "--allow-one-sided"
+    )
 
     # Discarding only the +B addition reverts it; the -b deletion stays.
     assert (Path(cli.repo.path) / "f.txt").read_text() == "a\n"
@@ -167,7 +175,7 @@ def test_unstage_addition_of_no_newline_to_newline_keeps_lines_separate(
     staged = cli.run_list_json("list", "--staged", "--json")
 
     # Body lines: 1= a 2=-b 3=+B. Unstage only the addition from the index.
-    cli.run_ok("unstage", staged[0]["id"], "-l", "3")
+    cli.run_ok("unstage", staged[0]["id"], "-l", "3", "--allow-one-sided")
 
     assert cli.repo.git("show", ":f.txt") == "a\n"
     assert (Path(cli.repo.path) / "f.txt").read_text() == "a\nB\n"
@@ -178,7 +186,9 @@ def test_stage_deletion_preserves_each_side_newline_state(
 ) -> None:
     cli = newline_change.cli
 
-    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"), "-l", "2")
+    cli.run_ok(
+        "stage", cli.get_only_hunk_id("--unstaged"), "-l", "2", "--allow-one-sided"
+    )
 
     assert cli.repo.git("show", ":f.txt").encode() == b"a\n"
 
@@ -188,7 +198,9 @@ def test_stage_addition_preserves_each_side_newline_state(
 ) -> None:
     cli = newline_change.cli
 
-    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"), "-l", "3")
+    cli.run_ok(
+        "stage", cli.get_only_hunk_id("--unstaged"), "-l", "3", "--allow-one-sided"
+    )
 
     new = newline_change.new_text
     assert cli.repo.git("show", ":f.txt").encode() == b"a\nb\n" + new.encode()
@@ -211,7 +223,7 @@ def test_unstage_deletion_preserves_each_side_newline_state(
     cli = staged_newline_change.cli
     staged_id = cli.run_list_json("list", "--staged", "--json")[0]["id"]
 
-    cli.run_ok("unstage", staged_id, "-l", "2")
+    cli.run_ok("unstage", staged_id, "-l", "2", "--allow-one-sided")
 
     new = staged_newline_change.new_text
     assert cli.repo.git("show", ":f.txt").encode() == b"a\nb\n" + new.encode()
@@ -222,7 +234,9 @@ def test_discard_deletion_preserves_each_side_newline_state(
 ) -> None:
     cli = newline_change.cli
 
-    cli.run_ok("discard", cli.get_only_hunk_id("--unstaged"), "-l", "2")
+    cli.run_ok(
+        "discard", cli.get_only_hunk_id("--unstaged"), "-l", "2", "--allow-one-sided"
+    )
 
     # read_text, not read_bytes: the working tree holds CRLF on Windows, and
     # universal newlines normalize it while still telling the two trailing
@@ -236,7 +250,15 @@ def test_commit_addition_preserves_each_side_newline_state(
 ) -> None:
     cli = newline_change.cli
 
-    cli.run_ok("commit", cli.get_only_hunk_id("--unstaged"), "-l", "3", "-m", "partial")
+    cli.run_ok(
+        "commit",
+        cli.get_only_hunk_id("--unstaged"),
+        "-l",
+        "3",
+        "--allow-one-sided",
+        "-m",
+        "partial",
+    )
 
     new = newline_change.new_text
     assert cli.repo.git("show", "HEAD:f.txt").encode() == b"a\nb\n" + new.encode()
@@ -249,7 +271,7 @@ def test_unstage_addition_preserves_each_side_newline_state(
     cli = staged_newline_change.cli
     staged_id = cli.run_list_json("list", "--staged", "--json")[0]["id"]
 
-    cli.run_ok("unstage", staged_id, "-l", "3")
+    cli.run_ok("unstage", staged_id, "-l", "3", "--allow-one-sided")
 
     assert cli.repo.git("show", ":f.txt").encode() == b"a\n"
 

--- a/tests/e2e/one_sided_selection_test.py
+++ b/tests/e2e/one_sided_selection_test.py
@@ -1,0 +1,307 @@
+from pathlib import Path
+
+import pytest
+
+from .conftest import GitHunkCLI
+
+# Regression for #225. HEAD holds `return session.get(url)`; the working tree
+# replaces it with `return session.get(url, timeout=30)`. That is one hunk whose
+# body lines are 1=" def fetch(...)", 2="-...session.get(url)",
+# 3="+...session.get(url, timeout=30)": a one-for-one replacement pair.
+
+_HEAD: str = "def fetch(session, url):\n    return session.get(url)\n"
+_WORKING: str = "def fetch(session, url):\n    return session.get(url, timeout=30)\n"
+
+# `session.get(url)` matches only the deleted line: the added line continues
+# with a comma, so it has no `url)` substring. That is exactly the trap #225
+# describes.
+_ONE_SIDED_PATTERN: str = "session.get(url)"
+# `session.get(url` matches both sides of the pair.
+_BOTH_SIDES_PATTERN: str = "session.get(url"
+
+_ONE_SIDED_SELECTORS = pytest.mark.parametrize(
+    "selector",
+    [
+        ("-l", "2"),
+        ("-l", "3"),
+        ("--include-matching", _ONE_SIDED_PATTERN),
+        ("--exclude-matching", "timeout=30"),
+    ],
+    ids=["line-deletion", "line-addition", "include-matching", "exclude-matching"],
+)
+
+
+@pytest.fixture
+def one_for_one(cli: GitHunkCLI) -> GitHunkCLI:
+    cli.repo.write_file("client.py", _HEAD)
+    cli.repo.git("add", "client.py")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("client.py", _WORKING)
+    return cli
+
+
+def _capture_repo_state(cli: GitHunkCLI) -> tuple[str, str, str, str]:
+    return (
+        cli.repo.git("rev-parse", "HEAD"),
+        cli.repo.git("show", ":client.py"),
+        (Path(cli.repo.path) / "client.py").read_text(),
+        cli.repo.git("status", "--short"),
+    )
+
+
+def _assert_one_sided_error(returncode: int, stderr: str) -> None:
+    assert returncode == 1
+    assert "cannot select one side of lines 2-3" in stderr
+    assert "one-for-one replacement" in stderr
+    assert "--allow-one-sided" in stderr
+
+
+@_ONE_SIDED_SELECTORS
+def test_stage_rejects_one_sided_selection(
+    one_for_one: GitHunkCLI, selector: tuple[str, ...]
+) -> None:
+    cli = one_for_one
+    before = _capture_repo_state(cli)
+
+    result = cli.run("stage", cli.get_only_hunk_id("--unstaged"), *selector)
+
+    _assert_one_sided_error(result.returncode, result.stderr)
+    assert _capture_repo_state(cli) == before
+
+
+@_ONE_SIDED_SELECTORS
+def test_commit_rejects_one_sided_selection(
+    one_for_one: GitHunkCLI, selector: tuple[str, ...]
+) -> None:
+    cli = one_for_one
+    before = _capture_repo_state(cli)
+
+    result = cli.run(
+        "commit", cli.get_only_hunk_id("--unstaged"), *selector, "-m", "half"
+    )
+
+    _assert_one_sided_error(result.returncode, result.stderr)
+    assert _capture_repo_state(cli) == before
+
+
+@_ONE_SIDED_SELECTORS
+def test_unstage_rejects_one_sided_selection(
+    one_for_one: GitHunkCLI, selector: tuple[str, ...]
+) -> None:
+    cli = one_for_one
+    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"))
+    before = _capture_repo_state(cli)
+
+    result = cli.run("unstage", cli.get_only_hunk_id("--staged"), *selector)
+
+    _assert_one_sided_error(result.returncode, result.stderr)
+    assert _capture_repo_state(cli) == before
+
+
+@_ONE_SIDED_SELECTORS
+def test_discard_rejects_one_sided_selection(
+    one_for_one: GitHunkCLI, selector: tuple[str, ...]
+) -> None:
+    cli = one_for_one
+    before = _capture_repo_state(cli)
+
+    result = cli.run("discard", cli.get_only_hunk_id("--unstaged"), *selector)
+
+    _assert_one_sided_error(result.returncode, result.stderr)
+    assert _capture_repo_state(cli) == before
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        ("-l", "2"),
+        ("--include-matching", _ONE_SIDED_PATTERN),
+        ("--exclude-matching", "timeout=30"),
+    ],
+    ids=["line-spec", "include-matching", "exclude-matching"],
+)
+def test_stage_allow_one_sided_stages_the_deletion_half(
+    one_for_one: GitHunkCLI, selector: tuple[str, ...]
+) -> None:
+    cli = one_for_one
+
+    cli.run_ok(
+        "stage", cli.get_only_hunk_id("--unstaged"), *selector, "--allow-one-sided"
+    )
+
+    assert cli.repo.git("show", ":client.py") == "def fetch(session, url):\n"
+    assert (Path(cli.repo.path) / "client.py").read_text() == _WORKING
+
+
+def test_commit_allow_one_sided_commits_the_deletion_half(
+    one_for_one: GitHunkCLI,
+) -> None:
+    cli = one_for_one
+
+    cli.run_ok(
+        "commit",
+        cli.get_only_hunk_id("--unstaged"),
+        "--include-matching",
+        _ONE_SIDED_PATTERN,
+        "--allow-one-sided",
+        "-m",
+        "drop the untimed call",
+    )
+
+    assert cli.repo.git("show", "HEAD:client.py") == "def fetch(session, url):\n"
+    assert (Path(cli.repo.path) / "client.py").read_text() == _WORKING
+
+
+def test_stage_allow_one_sided_stages_the_addition_half(
+    one_for_one: GitHunkCLI,
+) -> None:
+    cli = one_for_one
+
+    cli.run_ok(
+        "stage", cli.get_only_hunk_id("--unstaged"), "-l", "3", "--allow-one-sided"
+    )
+
+    assert cli.repo.git("show", ":client.py") == (
+        "def fetch(session, url):\n"
+        "    return session.get(url)\n"
+        "    return session.get(url, timeout=30)\n"
+    )
+    assert (Path(cli.repo.path) / "client.py").read_text() == _WORKING
+
+
+def test_unstage_allow_one_sided_smoke(one_for_one: GitHunkCLI) -> None:
+    cli = one_for_one
+    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"))
+
+    cli.run_ok(
+        "unstage", cli.get_only_hunk_id("--staged"), "-l", "3", "--allow-one-sided"
+    )
+
+    assert cli.repo.git("show", ":client.py") == "def fetch(session, url):\n"
+
+
+def test_discard_allow_one_sided_smoke(one_for_one: GitHunkCLI) -> None:
+    cli = one_for_one
+
+    cli.run_ok(
+        "discard", cli.get_only_hunk_id("--unstaged"), "-l", "3", "--allow-one-sided"
+    )
+
+    assert (Path(cli.repo.path) / "client.py").read_text() == (
+        "def fetch(session, url):\n"
+    )
+
+
+def test_error_names_the_group_the_selection_lands_in(cli: GitHunkCLI) -> None:
+    # Two one-for-one pairs separated by context. Body lines: 1=" alpha"
+    # 2="-one" 3="+ONE" 4=" beta" 5="-two" 6="+TWO" 7=" gamma". A one-sided
+    # selection in the second pair must name that pair, not the first.
+    cli.repo.write_file("f.txt", "alpha\none\nbeta\ntwo\ngamma\n")
+    cli.repo.git("add", "f.txt")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "alpha\nONE\nbeta\nTWO\ngamma\n")
+
+    result = cli.run("stage", cli.get_only_hunk_id("--unstaged"), "-l", "5")
+
+    assert result.returncode == 1
+    assert "cannot select one side of lines 5-6" in result.stderr
+    assert "lines 2-3" not in result.stderr
+    assert cli.repo.git("show", ":f.txt") == "alpha\none\nbeta\ntwo\ngamma\n"
+
+
+def test_dry_run_reports_the_rejection_instead_of_a_preview(
+    one_for_one: GitHunkCLI,
+) -> None:
+    cli = one_for_one
+    before = _capture_repo_state(cli)
+
+    result = cli.run(
+        "stage", cli.get_only_hunk_id("--unstaged"), "-l", "3", "--dry-run"
+    )
+
+    _assert_one_sided_error(result.returncode, result.stderr)
+    assert "would stage" not in result.stdout + result.stderr
+    assert _capture_repo_state(cli) == before
+
+
+def test_dry_run_with_allow_one_sided_previews_without_mutating(
+    one_for_one: GitHunkCLI,
+) -> None:
+    cli = one_for_one
+    before = _capture_repo_state(cli)
+
+    result = cli.run(
+        "stage",
+        cli.get_only_hunk_id("--unstaged"),
+        "-l",
+        "3",
+        "--allow-one-sided",
+        "--dry-run",
+    )
+
+    assert result.returncode == 0
+    assert "would stage" in result.stdout + result.stderr
+    assert _capture_repo_state(cli) == before
+
+
+def test_pattern_matching_both_lines_needs_no_flag(one_for_one: GitHunkCLI) -> None:
+    cli = one_for_one
+
+    cli.run_ok(
+        "stage",
+        cli.get_only_hunk_id("--unstaged"),
+        "--include-matching",
+        _BOTH_SIDES_PATTERN,
+    )
+
+    assert cli.repo.git("show", ":client.py") == _WORKING
+
+
+def test_full_pair_line_selection_needs_no_flag(one_for_one: GitHunkCLI) -> None:
+    cli = one_for_one
+
+    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"), "-l", "2,3")
+
+    assert cli.repo.git("show", ":client.py") == _WORKING
+
+
+def test_pure_addition_selection_needs_no_flag(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.txt", "keep\n")
+    cli.repo.git("add", "f.txt")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "keep\nfirst\nsecond\n")
+
+    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"), "-l", "2")
+
+    assert cli.repo.git("show", ":f.txt") == "keep\nfirst\n"
+
+
+def test_pure_deletion_selection_needs_no_flag(cli: GitHunkCLI) -> None:
+    cli.repo.write_file("f.txt", "keep\nfirst\nsecond\n")
+    cli.repo.git("add", "f.txt")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("f.txt", "keep\n")
+
+    cli.run_ok("stage", cli.get_only_hunk_id("--unstaged"), "-l", "2")
+
+    assert cli.repo.git("show", ":f.txt") == "keep\nsecond\n"
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["stage", "unstage", "discard", "commit"],
+)
+def test_allow_one_sided_without_a_selection_mechanism_is_a_usage_error(
+    one_for_one: GitHunkCLI, command: str
+) -> None:
+    cli = one_for_one
+    before = _capture_repo_state(cli)
+    extra = ["-m", "half"] if command == "commit" else []
+
+    result = cli.run(
+        command, cli.get_only_hunk_id("--unstaged"), "--allow-one-sided", *extra
+    )
+
+    assert result.returncode == 2
+    assert "--allow-one-sided requires" in result.stderr
+    assert _capture_repo_state(cli) == before

--- a/tests/unit/_lines/filter_test.py
+++ b/tests/unit/_lines/filter_test.py
@@ -72,7 +72,7 @@ def test_header_recalculated(make_hunk: Callable[[str], Hunk]) -> None:
 def test_one_for_one_addition(make_hunk: Callable[[str], Hunk]) -> None:
     diff = "@@ -1,2 +1,2 @@ def foo():\n ctx\n-old\n+new"
     hunk = make_hunk(diff)
-    result = filter_hunk_lines(hunk, {3}, exclude=False)
+    result = filter_hunk_lines(hunk, {3}, exclude=False, allow_one_sided=True)
     assert result.additions == 1
     assert result.deletions == 0
     assert "+new" in result.diff
@@ -117,7 +117,7 @@ def test_keep_addition_splits_stale_no_newline_context(
     # kept '+B' now follows it: it must split into -b/+b so the marker stays on
     # the old side and 'b' gains a newline rather than merging with 'B'.
     hunk = make_hunk(_NO_NEWLINE_TO_NEWLINE)
-    result = filter_hunk_lines(hunk, {3}, exclude=False)
+    result = filter_hunk_lines(hunk, {3}, exclude=False, allow_one_sided=True)
     assert result.diff == (f"@@ -1,2 +1,3 @@\n a\n-b\n{NO_NEWLINE_MARKER}\n+b\n+B")
     assert result.additions == 2
     assert result.deletions == 1
@@ -129,7 +129,7 @@ def test_keep_deletion_drops_no_newline_marker_from_dropped_addition(
     # Keeping only '-b' drops '+B' and its marker; 'b' keeps no trailing newline
     # as the old side's final line, the new side ends at the ' a' context.
     hunk = make_hunk(_NO_NEWLINE_TO_NEWLINE)
-    result = filter_hunk_lines(hunk, {2}, exclude=False)
+    result = filter_hunk_lines(hunk, {2}, exclude=False, allow_one_sided=True)
     assert result.diff == f"@@ -1,2 +1,1 @@\n a\n-b\n{NO_NEWLINE_MARKER}"
     assert result.additions == 0
     assert result.deletions == 1
@@ -147,7 +147,9 @@ def test_reverse_keeps_no_newline_new_context_without_split(
     # context. It is always the last body line, so its marker stays put and it
     # never splits: the '+'-origin split branch of _render_body_lines is dead.
     hunk = make_hunk(_REVERSE_NEW_SIDE_NO_NEWLINE)
-    result = filter_hunk_lines(hunk, {3}, exclude=False, reverse=True)
+    result = filter_hunk_lines(
+        hunk, {3}, exclude=False, reverse=True, allow_one_sided=True
+    )
     assert result.diff == (f"@@ -1,3 +1,4 @@\n a\n+B\n c\n D\n{NO_NEWLINE_MARKER}")
     assert result.additions == 1
     assert result.deletions == 0

--- a/tests/unit/_lines/group_selection_test.py
+++ b/tests/unit/_lines/group_selection_test.py
@@ -12,8 +12,6 @@ from git_hunk._lines import filter_hunk_lines
     [
         ("@@ -1 +1,3 @@\n a\n+b\n+c", {2}),
         ("@@ -1,3 +1 @@\n a\n-b\n-c", {2}),
-        ("@@ -1,2 +1,2 @@\n a\n-b\n+B", {2}),
-        ("@@ -1,2 +1,2 @@\n a\n-b\n+B", {3}),
         ("@@ -1,2 +1,2 @@\n a\n-b\n+B", {2, 3}),
         ("@@ -1,3 +1,3 @@\n a\n-b\n-c\n+B\n+C", {2, 3, 4, 5}),
     ],
@@ -29,6 +27,66 @@ def test_allows_unambiguous_group_selection(
     )
 
     assert result.additions + result.deletions > 0
+
+
+_ONE_FOR_ONE = "@@ -1,2 +1,2 @@\n a\n-b\n+B"
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("selected", [{2}, {3}])
+def test_rejects_one_sided_one_for_one_replacement_by_default(
+    make_hunk: Callable[[str], Hunk],
+    selected: set[int],
+    reverse: bool,
+) -> None:
+    with pytest.raises(ValueError, match="cannot select one side of lines 2-3"):
+        filter_hunk_lines(
+            make_hunk(_ONE_FOR_ONE), selected, exclude=False, reverse=reverse
+        )
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("selected", [{2}, {3}])
+def test_allows_one_sided_one_for_one_replacement_when_opted_in(
+    make_hunk: Callable[[str], Hunk],
+    selected: set[int],
+    reverse: bool,
+) -> None:
+    result = filter_hunk_lines(
+        make_hunk(_ONE_FOR_ONE),
+        selected,
+        exclude=False,
+        reverse=reverse,
+        allow_one_sided=True,
+    )
+
+    assert result.additions + result.deletions == 1
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("selected", [{2}, {3}])
+def test_exclude_selection_rejects_the_other_side_of_a_pair(
+    make_hunk: Callable[[str], Hunk],
+    selected: set[int],
+    reverse: bool,
+) -> None:
+    # Excluding one side of the pair still leaves the other side alone.
+    with pytest.raises(ValueError, match="cannot select one side of lines 2-3"):
+        filter_hunk_lines(
+            make_hunk(_ONE_FOR_ONE), selected, exclude=True, reverse=reverse
+        )
+
+
+def test_one_for_one_error_names_both_lines_and_the_override(
+    make_hunk: Callable[[str], Hunk],
+) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        filter_hunk_lines(make_hunk(_ONE_FOR_ONE), {2}, exclude=False)
+
+    assert str(excinfo.value) == (
+        "cannot select one side of lines 2-3: one-for-one replacement; "
+        "match text both lines share, select both lines, or pass --allow-one-sided"
+    )
 
 
 @pytest.mark.parametrize("reverse", [False, True])
@@ -53,6 +111,31 @@ def test_rejects_partial_composite_replacement(
 ) -> None:
     with pytest.raises(ValueError, match=message):
         filter_hunk_lines(make_hunk(diff), selected, exclude=False, reverse=reverse)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    ("diff", "selected"),
+    [
+        ("@@ -1,2 +1,3 @@\n a\n-b\n+B\n+C", {2}),
+        ("@@ -1,3 +1,2 @@\n a\n-b\n-c\n+B", {2}),
+        ("@@ -1,3 +1,3 @@\n a\n-b\n-c\n+B\n+C", {2, 4}),
+    ],
+)
+def test_allow_one_sided_does_not_relax_the_wider_group_rule(
+    make_hunk: Callable[[str], Hunk],
+    diff: str,
+    selected: set[int],
+    reverse: bool,
+) -> None:
+    with pytest.raises(ValueError, match="cannot partially select"):
+        filter_hunk_lines(
+            make_hunk(diff),
+            selected,
+            exclude=False,
+            reverse=reverse,
+            allow_one_sided=True,
+        )
 
 
 @pytest.mark.parametrize("reverse", [False, True])

--- a/tests/unit/_lines/no_newline_test.py
+++ b/tests/unit/_lines/no_newline_test.py
@@ -10,7 +10,9 @@ def test_drops_old_marker_when_selected_deletion_has_later_old_line(
 ) -> None:
     diff = f"@@ -1,2 +1,2 @@\n a\n-b\n{NO_NEWLINE_MARKER}\n+B"
 
-    result = filter_hunk_lines(make_hunk(diff), {2}, exclude=False, reverse=True)
+    result = filter_hunk_lines(
+        make_hunk(diff), {2}, exclude=False, reverse=True, allow_one_sided=True
+    )
 
     assert result.diff == "@@ -1,3 +1,2 @@\n a\n-b\n B"
 
@@ -20,6 +22,8 @@ def test_drops_new_marker_when_selected_addition_has_later_new_line(
 ) -> None:
     diff = f"@@ -1,2 +1,2 @@\n a\n+b\n{NO_NEWLINE_MARKER}\n-B"
 
-    result = filter_hunk_lines(make_hunk(diff), {2}, exclude=False)
+    result = filter_hunk_lines(
+        make_hunk(diff), {2}, exclude=False, allow_one_sided=True
+    )
 
     assert result.diff == "@@ -1,2 +1,3 @@\n a\n+b\n B"


### PR DESCRIPTION
> *This was generated by AI.*

Closes #225. Implements the guard decided in #232 (the v0.3 admit list): this is the one freeze-restarting PR for v0.3.0, handed to #192.

## What changes

- A line selection (`-l`, `--include-matching`, `--exclude-matching`) covering exactly one side of a one-for-one replacement pair now **errors with exit 1** — `cannot select one side of lines N-M: one-for-one replacement; match text both lines share, select both lines, or pass --allow-one-sided` — instead of exiting 0 after silently staging/committing/discarding a broken half. Nothing is mutated on rejection.
- New **`--allow-one-sided`** flag on `stage`, `unstage`, `discard`, and `commit` permits the deliberate lone-half case (e.g. committing a pure deletion). Passing it without a selection mechanism is a usage error (exit 2), mirroring `--regex`.
- The wider grouped-replacement guard is **not** relaxed by the flag.
- Docs updated to match: core skill passage, README, CONTEXT.md glossary, help text, changelog (**Breaking:**, folded with the #226 entry as documented-then-enforced).
- The two adversarial eval solvers that deliberately produce one-sided halves now opt in via the flag, keeping their graded failure mode intact.

## Verification

- 801 tests pass (was 746 before the change; +55 covering all four selectors × rejection/override, non-mutation on rejection asserted against HEAD/index/worktree/status, per-group error scoping, `--dry-run`, usage errors, and the wider-guard non-relaxation).
- All lints clean: ruff format/check, ty, mdformat, taplo, yamlfix, typos.
- Independently reviewed (correctness, fail-closed paths, exclude-inversion, no-newline markers, docs truthfulness) with all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)