### PR TITLE
chore: prepare and prove the v0.3.0 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 ### Added
 
+- README Eval section recording the qualifying run's per-task comparison —
+  the same agent, model, and eight tasks attempted with git-hunk's bundled
+  skills versus bare Git — with the checked-in harness linked for reproduction
+  (#255).
 - Agent eval task and grader criterion for a partial selection that would
   commit syntactically broken code: one hunk interleaves the change to keep
   with debug scaffolding, so every tempting whole-noise selection stages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,20 +39,28 @@ and this project adheres to
   available tasks (#216).
 - Agent evals stream composed prompts and Bash calls, report normalized token
   and cost usage, and write human-readable transcripts (#215).
+- A repository-only agent eval (`python -m eval`): synthetic logical-commit tasks
+  solved by a pinned model and graded from the exact resulting Repository
+  state, with deterministic golden and adversarial coverage in the normal test
+  suite and nothing added to the installed package (#203), plus a `make eval`
+  entry point that forwards optional `EVAL_ARGS` to the evaluator (#207).
 - `skills` subcommand (`git-hunk skills list|get|path`) serving the bundled,
-  version-matched core usage guide for AI agents.
-- Examples section in `--help` for every subcommand.
+  version-matched core usage guide for AI agents (#8).
+- Examples section in `--help` for every subcommand (#7).
 - Accept a file path as shorthand for all hunks in a file, so
-  `git-hunk stage src/foo.py` stages every hunk in that file (#21).
+  `git-hunk stage src/foo.py` stages every hunk in that file (#43).
 - `--dry-run` for `stage`, `unstage`, and `discard`, previewing what would
-  change without touching the index or working tree (#25).
+  change without touching the index or working tree (#45).
+- `commit` command, staging exactly the selected hunks and committing them in
+  one step, and aborting when anything is already staged (#46).
 - `context_before` field in `list --json`, exposing the function/section heading
-  git names after the `@@` header (#27).
+  git names after the `@@` header; the heading is kept whole even when it
+  itself contains `@@` (#48, #51).
 - `--include-matching` / `--exclude-matching` for `stage`, `unstage`, and
   `discard`, selecting changed lines by content instead of by line number
   (literal substring by default, `--regex` for regular expressions; repeatable
   and OR'd), so an agent can drop a line by what it contains without a
-  `show` round trip (#55).
+  `show` round trip (#71).
 - `--include-matching` / `--exclude-matching` and `--regex` for `commit`, so an
   agent can commit a content-selected part of one Hunk without a separate
   staging command (#214).
@@ -60,6 +68,7 @@ and this project adheres to
   to group hunks into logical commits and order them so each is independently
   valid, kept separate from `core` so a project that already defines its own
   commit conventions can load `core` alone (#178).
+- Python 3.14 support (#76).
 
 ### Changed
 
@@ -112,7 +121,7 @@ and this project adheres to
   path, so a file literally named `"   "` is addressable (#194).
 - **Breaking:** `list --json` now wraps its output in a versioned envelope,
   `{"schema_version": 2, "hunks": [...]}`, instead of a bare array, so consumers
-  can depend on a documented, versioned shape (#23).
+  can depend on a documented, versioned shape (#49).
 - **Breaking:** `--json` output is now the typed v2 hunk schema defined in
   ADR 0001, so consumers read typed fields instead of regex-parsing free text:
   the file-level fields `change_kind`, `a_mode`, `b_mode`, and `binary` are
@@ -122,8 +131,9 @@ and this project adheres to
   and is `null` for a whole-file (binary, mode-only, or type change) hunk;
   `show --json`
   carries a structured per-line `lines[]` body (each `{n, op, content}`, with an
-  optional `no_newline`) and the raw `diff` string is dropped (#67).
-- README image paths are rewritten to absolute URLs so they render on PyPI.
+  optional `no_newline`) and the raw `diff` string is dropped (#72).
+- README image paths are rewritten to absolute URLs so they render on PyPI
+  (#5).
 - The `core` skill documents the tool only. Guidance on grouping and ordering
   commits moved to the new `logical-commits` skill, and the conventional-commits
   message-format opinion is dropped entirely, so a project's own conventions
@@ -150,31 +160,37 @@ and this project adheres to
   repository. `git apply` drops patched paths outside its working directory
   without a word, so the command printed its success line and exited `0` while
   the index was never touched. Every git call is now anchored to the worktree
-  root (#159).
+  root (#194).
 - Accept a file operand from a subdirectory in `stage`, `unstage`, `discard`,
   and `commit`, which previously reported `no changed file matches` for a path
-  that `list` and `show` accepted (#127).
+  that `list` and `show` accepted (#194).
 - `commit --help` no longer advertises `--include-matching`,
   `--exclude-matching`, and `--regex`, which the command never accepted; the
   help now lists only the options `commit` actually supports (#105).
 - Preserve `\ No newline at end of file` markers so staging the last line of a
   file without a trailing newline no longer fails or silently stages nothing
-  (#9).
+  (#29).
 - Parse git's quoted and octal-escaped paths, so files with non-ASCII names or
-  names containing ` b/` appear and stage correctly (#10).
+  names containing ` b/` appear and stage correctly (#31, #68).
 - Decode git output with `surrogateescape`, so a diff containing non-UTF-8 bytes
-  no longer crashes with `UnicodeDecodeError` (#11).
+  no longer crashes with `UnicodeDecodeError` (#32).
 - Apply partial line selection (`-l`) correctly for `unstage` and `discard` on
-  hunks with more than one change group (#12).
+  hunks with more than one change group (#33).
 - Escape user-controlled text in Rich output, so a path like `src/[id].tsx`
-  renders verbatim instead of being swallowed as markup (#14).
+  renders verbatim instead of being swallowed as markup (#34).
 - Reject empty or whitespace-only hunk ids, and report malformed `-l` ranges
-  with a readable error (#15).
+  with a readable error (#35).
 - Constrain the source distribution to the package and metadata so it no longer
-  ships unrelated `tmp/` files (#16).
+  ships unrelated `tmp/` files (#36).
+- Surface binary and mode-only changes as actionable whole-file Hunks and
+  reject line selection on them cleanly, instead of crashing or corrupting the
+  patch (#41).
+- Skip unreadable or non-UTF-8 skill files with a warning and treat unclosed
+  frontmatter as absent, so one malformed `SKILL.md` cannot break the `skills`
+  subcommand (#42).
 - Split the no-newline last line when partial line-staging (`-l`) gives it a
   trailing newline, so staging only the addition no longer merges it with the
-  added line and corrupts the file (#54).
+  added line and corrupts the file (#60).
 - Reject an empty `--include-matching` / `--exclude-matching` pattern, which
   previously matched every line and silently selected the whole hunk, so an
   accidentally-empty pattern now errors like an empty `-l` spec (#87).
@@ -195,6 +211,9 @@ and this project adheres to
   restoring "from HEAD" when it restores from the index: discarding an unstaged
   hunk reverts it to the staged content, leaving a staged sibling edit intact
   (#109).
+- Repair the mangled sentence in the core skill that ran the
+  `git-hunk stage` and `git commit` steps together into one unreadable
+  instruction (#146).
 - Correct the skill guide and README's claim that a partially staged hunk's
   leftover keeps the same id, so the guide now says to re-run `git-hunk list` to
   get the leftover's new id (#149).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-09
+
 ### Added
 
 - Agent eval task and grader criterion for a partial selection that would
@@ -234,4 +236,5 @@ and this project adheres to
   working across multiple hunks when they share the same single-hunk
   constraint as `-l` (#155).
 
-[unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...HEAD
+[0.3.0]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...v0.3.0
+[unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.3.0...HEAD

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,6 +110,9 @@
   converges #127/#159.
 - **ADR 0003**: Hunk IDs are durable for unchanged Hunks, unique in the combined
   staged and unstaged inventory, and conditional for Duplicate Hunk groups.
+- **ADR 0004** — agent eval. Grades agent judgment from exact Repository state,
+  compares git-hunk with bare Git from the same prepared state, and pins the
+  model.
 
 ## Invariants
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,35 @@ Conditional IDs.
 `git-hunk` solves this by assigning each staged or unstaged Hunk a durable ID
 and exposing simple stage/unstage/discard commands.
 
+## Eval
+
+One agent (Claude Code 2.1.226, `claude-sonnet-5`, reasoning effort `high`)
+attempted the same eight tasks twice from identical repository state: organize a
+dirty working tree into correct, focused commits, once following git-hunk's
+bundled skills and once restricted to bare Git. The
+[checked-in eval harness](https://github.com/wkentaro/git-hunk/tree/5a05866e801d9d379fd79f3c117fb383b1056acf/eval)
+grades the exact resulting repository state — commit partition and order, final
+tree, index, and leftovers. This table records the qualifying run; `make eval`
+reruns the protocol and prints a table in the same format.
+
+| Task                                                                                                                                                    | git-hunk                    | bare Git                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ---------------------------------- |
+| [split_refactor_vs_feature](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/split_refactor_vs_feature.py) | PASS · 3c · 4t · $0.04      | PASS · 2c · 3t · $0.02             |
+| [separate_mixed_hunks](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/separate_mixed_hunks.py)           | PASS · 4c · 5t · $0.05      | FAIL partition · 10c · 11t · $0.11 |
+| [drop_debug_lines](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/drop_debug_lines.py)                   | PASS · 3c · 4t · $0.05      | PASS · 8c · 9t · $0.07             |
+| [protect_unrelated_work](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/protect_unrelated_work.py)       | PASS · 3c · 4t · $0.04      | PASS · 4c · 5t · $0.02             |
+| [split_single_hunk](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/split_single_hunk.py)                 | PASS · 4c · 5t · $0.06      | PASS · 9c · 10t · $0.10            |
+| [separate_formatter_noise](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/separate_formatter_noise.py)   | PASS · 4c · 5t · $0.08      | PASS · 25c · 26t · $0.26           |
+| [pick_duplicate_hunk](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/pick_duplicate_hunk.py)             | PASS · 3c · 4t · $0.04      | PASS · 9c · 10t · $0.09            |
+| [commit_parseable_subset](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/commit_parseable_subset.py)     | PASS · 5c · 6t · $0.08      | PASS · 11c · 12t · $0.13           |
+| **total**                                                                                                                                               | **8/8 · 29c · 37t · $0.45** | **7/8 · 78c · 86t · $0.80**        |
+
+`c` = tool calls, `t` = turns; `partition` = wrong commit partition. Costs
+include a small amount of harness-internal `claude-haiku-4-5` spend. Bare Git
+ran second in each pair, so its cost partly reads the prompt cache the git-hunk
+run warmed; the gap in tool calls is the sturdier signal. Single sample per
+task, dated 2026-08-09 at commit `5a05866`.
+
 ## Install
 
 Requires Git 2.28 or later. `git-hunk` forces canonical diff paths with

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -1,7 +1,8 @@
 # ADR 0004: grade agent judgment from exact Repository state
 
-**Status:** Proposed\
-**Date:** 2026-08-07
+**Status:** Accepted\
+**Proposed:** 2026-08-07\
+**Accepted:** 2026-08-09
 
 ## Context
 
@@ -278,19 +279,39 @@ significance. It remains an agent demonstration. `--repeat 1` is the default and
 produces the single-sample run this ADR described before this section, output
 and artifact names included.
 
-### Keep this ADR Proposed in the integration ticket
+### Accepted on the v0.3.0 qualifying run
 
-This integration adds the deterministic evaluation and the model-pinned runner.
-It does not claim a model result. A later evaluation study can archive redacted
-evidence for independently run tasks under `docs/eval/runs/<run-id>/` and change
-this ADR to Accepted after its deterministic, lint, package, and pinned model
-gates pass.
+The integration ticket added the deterministic evaluation and the model-pinned
+runner without claiming a model result, so this ADR stayed Proposed there. Run
+evidence is not checked into the repository. A qualifying study records its
+summary — run id, candidate commit, model and Claude Code versions, per-task
+grades, and usage — on the release pull request and the release ticket after
+its deterministic, lint, package, and pinned model gates pass; the raw
+manifest, traces, and transcripts stay with the maintainer outside git, and
+any re-qualification records a new summary the same way.
+
+A first qualifying study passed 8/8 on 2026-08-09 at candidate commit
+`64861ae2b5ddf3e50ccfbf92c95bd4d588bcf281`; #257 then changed the runner by
+pinning the solver's reasoning effort to `high`, which makes an earlier result
+stale under this ADR, so the qualifier was re-run rather than the rule
+narrowed. The qualifying study ran on 2026-08-09 at commit
+`5a05866e801d9d379fd79f3c117fb383b1056acf` — the release-candidate branch
+after that runner change, whose CLI and bundled skills are byte-identical to
+the first candidate: one uninterrupted `python -m eval` invocation with the
+pinned `high` effort passed all eight subject variants with exit code 0, after
+the deterministic test and lint gates passed on the same clean checkout. The
+package gates, first passed on the frozen candidate, were then re-run on
+`5a05866` to cover its hatch-vcs-derived metadata. Both summaries are recorded on
+[pull request #255](https://github.com/wkentaro/git-hunk/pull/255) and
+[issue #192](https://github.com/wkentaro/git-hunk/issues/192), and this ADR is
+Accepted on that evidence.
 
 ## Consequences
 
 - Normal tests stay deterministic and model-free.
-- Raw model runs do not modify the checkout. Their temporary directories are
-  diagnostic data, not durable evidence.
+- Raw model runs do not modify the checkout. Their directories back a recorded
+  qualifying-run summary and are retained outside the repository; git carries
+  the summary trail, not the artifacts.
 - Release artifacts cannot include evaluator code or run data.
 - A line-set collision cannot hide an incorrect final tree.
 - A commit that does not parse is diagnosed as such, in every commit of the


### PR DESCRIPTION
Closes #192

Proves the v0.3.0 release candidate without touching the CLI or either bundled skill — the shipped surface is byte-identical to the frozen `main` (#232 freeze, #251 merge). Per maintainer decision, run evidence is **not** checked into git: this PR body and comments on #192 carry the summaries, ADR 0004 states that policy, and the raw artifacts stay with the maintainer outside the repository (locations at the bottom).

## Summary

- **Changelog corrected and promoted.** Every user-facing entry now cites its implementing PR (the checklist's 14 issue-number swaps, plus `#8`/`#7`/`#5` added to previously unreferenced entries), and a first-parent audit of `v0.2.0..64861ae` added the omitted entries: the `commit` command (#46), binary/mode-only hardening (#41), the robust skills loader (#42), the `@@`-in-heading fix joined to the `context_before` entry (#51), Python 3.14 (#76), the core-skill sentence repair (#146), and the agent eval itself (#203). `Unreleased` is promoted to `0.3.0 - 2026-08-09` (with #257's entry folded in after the rebase) and an empty `Unreleased` is restored with the `v0.2.0...v0.3.0` compare link.
- **ADR 0004 accepted** (`Proposed:` 2026-08-07, `Accepted:` 2026-08-09) on the qualifying evidence below, with the maintainer's evidence policy written in: summaries on the release PR/ticket, raw artifacts outside git, re-qualification records a new summary the same way. `CONTEXT.md` gains the ADR 0004 key-decision line.
- **README Eval section** added from the qualifying high-effort run — a per-task table mirroring `make eval`'s output, same agent, model, and eight tasks with git-hunk versus bare Git, harness linked for reproduction — with a changelog entry under 0.3.0.

## Qualifying run 20260809T113654Z-5a05866 (current)

After #257 pinned the solver's reasoning effort to `high` — a runner change that makes an earlier model result stale under ADR 0004 — the maintainer chose to re-run the qualifier rather than narrow the rule. One uninterrupted `python -m eval`, all eight tasks, both variants, no retry:

- **Commit:** `5a05866e801d9d379fd79f3c117fb383b1056acf` (this branch rebased onto main with #257; `git_hunk/` byte-identical to the frozen candidate — skill hashes unchanged)
- **Started:** 2026-08-09T11:36:54Z, duration 552.7 s; clean worktree (`clean_worktree: true`)
- **Model:** requested and reported `claude-sonnet-5`, **effort `high`** (both runner-enforced); Claude Code 2.1.226; repeats 1
- **Gate:** `gate_passed: true`, exit code 0

| Task                      | git-hunk                    | bare-git                           |
| ------------------------- | --------------------------- | ---------------------------------- |
| split_refactor_vs_feature | PASS · 3c · 4t · $0.04      | PASS · 2c · 3t · $0.02             |
| separate_mixed_hunks      | PASS · 4c · 5t · $0.05      | FAIL partition · 10c · 11t · $0.11 |
| drop_debug_lines          | PASS · 3c · 4t · $0.05      | PASS · 8c · 9t · $0.07             |
| protect_unrelated_work    | PASS · 3c · 4t · $0.04      | PASS · 4c · 5t · $0.02             |
| split_single_hunk         | PASS · 4c · 5t · $0.06      | PASS · 9c · 10t · $0.10            |
| separate_formatter_noise  | PASS · 4c · 5t · $0.08      | PASS · 25c · 26t · $0.26           |
| pick_duplicate_hunk       | PASS · 3c · 4t · $0.04      | PASS · 9c · 10t · $0.09            |
| commit_parseable_subset   | PASS · 5c · 6t · $0.08      | PASS · 11c · 12t · $0.13           |
| **total**                 | **8/8 · 29c · 37t · $0.45** | **7/8 · 78c · 86t · $0.80**        |

(`c` = tool calls, `t` = turns; bare-git runs second and may read cache the git-hunk run wrote, so costs are not order-neutral. Totals include a small amount of harness-internal `claude-haiku-4-5` spend. The bare-git `separate_mixed_hunks` failure is a graded comparison result — the exit-code gate reads only the git-hunk subject variants, per ADR 0004.)

## First qualifying run 20260809T091738Z-64861ae (superseded by #257)

Same protocol at the frozen candidate `64861ae2b5ddf3e50ccfbf92c95bd4d588bcf281` with the then-default effort: **8/8 subject PASS and 8/8 bare-git PASS**, exit 0, started 2026-08-09T09:17:38Z, 583.4 s, git-hunk 32c/40t/$0.48 vs bare-git 96c/104t/$0.90. Full table in the #192 comment. Skill hashes in both manifests are identical (core `025c2dfe...`, logical-commits `7bae7012...`), pinning that both runs evaluated the same shipped surface.

**Deterministic gates on the frozen candidate SHA `64861ae`** (macOS 26.5.2, Python 3.10.19, git 2.55.0): `make test` 810 passed; `make lint` all seven checks clean; package-content test; `SOURCE_DATE_EPOCH=1786266506 uv build` (wheel SHA-256 `134916135aacbf796fec0f75f4b5e0ad3dbcf2caae0388e73494bd232a583503`, sdist SHA-256 `98513ceb1a3b506a582362008da8cbc61019c6b9ea7b2991afff0c0737366a41`); `twine check --strict` PASSED; archive lists and wheel `METADATA`/sdist `PKG-INFO` verified against the allowlist (both skills shipped; no `eval/`, `tests/`, logs, traces, worktrees); fresh-venv installs of both artifacts with `--version`/`--help`/`skills list`/`skills get` green; the exact `list`/`show`/`stage`/`unstage`-by-full-JSON-ID repository-state smoke; CI [Test 31305195665](https://github.com/wkentaro/git-hunk/actions/runs/31305195665) and [Lint 31305195672](https://github.com/wkentaro/git-hunk/actions/runs/31305195672) green for `64861ae`. `make test` and `make lint` re-ran green at every branch state since, including after the rebase onto #252/#253/#257 and the README benchmark commit.

**Raw artifacts** (maintainer to stash somewhere durable if wanted):

- Current run, redacted: `/Users/wkentaro/ghq/github.com/wkentaro/git-hunk/.claude/worktrees/agent-a39c93ad21440606d/.wt/eval-run-20260809T113654Z-5a05866/`
- Current run, raw: `/var/folders/xj/kncl6x9x0mq0bt4qg0hrq_zw0000gn/T/git-hunk-agent-eval-20260809T113654Z-5a05866-ytn0iy0o/` (system temp — volatile)
- First run, redacted: `/Users/wkentaro/ghq/github.com/wkentaro/git-hunk/.claude/worktrees/agent-a39c93ad21440606d/.wt/eval-run-20260809T091738Z-64861ae/`
- First run, raw: `/var/folders/xj/kncl6x9x0mq0bt4qg0hrq_zw0000gn/T/git-hunk-agent-eval-20260809T091738Z-64861ae-r__9zj23/` (system temp — volatile)

## Checklist deviations, stated

- **"Change ADR 0002 to Accepted"** (issue text): the checklist's numbering predates the ADR landing as **0004** (ADR 0002, Repository path, has been Accepted since 2026-08-06). The eval-design ADR — the one whose own text promised to flip on a qualifying run — is what this PR accepts.
- **"Pinned 4/4 model eval"**: the checklist predates #226/#242/#257, which grew the task set from four to eight and pinned model and effort. The run clears the current, stricter bar.
- **"Check in the redacted run evidence"**: superseded by maintainer decision on this PR — evidence summary on the PR/ticket, raw artifacts outside git, ADR 0004 amended to match.
- **"The pull request closes issue 163"**: #163 was already resolved and closed by #202 on 2026-08-07; the README `header`/`context_before` rows already name untracked entries as a separate `null` cause on `main`. Nothing to close here, so no `Closes #163` trailer.

## What remains before tagging (not in this PR)

Stopping before tag creation as the issue requires. After this PR merges, the release step (checklist step 10, ticket G) must repeat `make test`, `make lint`, the package build, and the content inspection **on the exact merged SHA** — the recorded wheel/sdist hashes describe the `64861ae` tree, and both artifacts change on the merged tree (hatch-vcs derives the version from Git metadata). Tag creation and tag push then require explicit maintainer permission.

## Test plan

- [x] `make test` — 810 passed, and `make lint` — all seven checks clean, at the candidate SHA and again at branch HEAD after the rebase and README commit
- [x] qualifying run gate: `python -m eval` exit 0, `gate_passed: true`, effort `high`, summaries cross-checked against both run manifests
- [x] branch history contains no `docs/eval/` paths (evidence stays outside git per maintainer decision)

