### PR TITLE
feat(eval): pin the solver effort level to high

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to
 
 ### Changed
 
+- Agent evals pin the solver's reasoning effort to `high` instead of relying
+  on the claude CLI's default, and report the requested effort in the startup
+  line and the run manifest (#257).
 - **Breaking:** Selecting exactly one side of a one-for-one replacement now
   exits 1 with an error naming the pair's line numbers, instead of exiting 0
   after silently staging, committing, or discarding the deletion-only or

--- a/eval/__main__.py
+++ b/eval/__main__.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from eval.config import EFFORT
 from eval.config import MODEL
 from eval.config import TASK_SCHEMA_VERSION
 from eval.environment import EvalEnvironment
@@ -88,7 +89,7 @@ def _run_scenarios(
     )
     run_dir = Path(tempfile.mkdtemp(prefix=run_directory_prefix))
     print(
-        f"eval: model={MODEL} "
+        f"eval: model={MODEL} effort={EFFORT} "
         f"claude={environment.claude_code_version.split()[0]} "
         f"commit={environment.commit[:7]} dirty={str(environment.dirty).lower()}",
         flush=True,
@@ -258,6 +259,7 @@ def _make_manifest(
         "skill_sha256": environment.skill_sha256,
         "claude_code_version": environment.claude_code_version,
         "requested_model": MODEL,
+        "requested_effort": EFFORT,
         "repeats": repeats,
         "gate_passed": gate_passed,
         "usage": usage.to_dict() if usage is not None else None,

--- a/eval/config.py
+++ b/eval/config.py
@@ -1,4 +1,5 @@
 from typing import Final
 
 MODEL: Final = "claude-sonnet-5"
+EFFORT: Final = "high"
 TASK_SCHEMA_VERSION: Final = 1

--- a/eval/model.py
+++ b/eval/model.py
@@ -12,6 +12,7 @@ from typing import Final
 from typing import TextIO
 from typing import cast
 
+from eval.config import EFFORT
 from eval.config import MODEL
 from eval.grader import Result
 from eval.repo import GitRepo
@@ -149,6 +150,8 @@ def build_command_flags(*, variant: EvalVariant) -> list[str]:
     return [
         "--model",
         MODEL,
+        "--effort",
+        EFFORT,
         "--tools",
         "Bash",
         "--allowedTools",

--- a/tests/eval/model_test.py
+++ b/tests/eval/model_test.py
@@ -8,6 +8,7 @@ from typing import NoReturn
 
 import pytest
 
+from eval.config import EFFORT
 from eval.config import MODEL
 from eval.model import VARIANTS
 from eval.model import aggregate_usage
@@ -97,6 +98,7 @@ def test_command_pins_model_and_isolates_claude() -> None:
 
     assert command[:3] == ["claude", "-p", "Do the task"]
     assert command[command.index("--model") + 1] == MODEL
+    assert command[command.index("--effort") + 1] == EFFORT
     assert command[command.index("--tools") + 1] == "Bash"
     assert command[command.index("--permission-mode") + 1] == "dontAsk"
     assert command[command.index("--output-format") + 1] == "stream-json"

--- a/tests/eval/runner_test.py
+++ b/tests/eval/runner_test.py
@@ -230,7 +230,8 @@ def test_run_reports_context_usage_and_artifacts(
     assert exit_code == 0
     assert output.err == ""
     expected_lines = [
-        "eval: model=claude-sonnet-5 claude=2.1.226 commit=61e2c19 dirty=true",
+        "eval: model=claude-sonnet-5 effort=high "
+        "claude=2.1.226 commit=61e2c19 dirty=true",
     ]
     for index, scenario in enumerate(SCENARIOS[:scenario_count], start=1):
         progress = f" {index}/{scenario_count}" if scenario_count > 1 else ""


### PR DESCRIPTION
The eval previously relied on the claude CLI's default reasoning effort, so results could shift silently if that default changed. This pins `--effort high` via a new `EFFORT` constant in `eval/config.py`, and records the requested effort in the startup line and the run manifest for traceability.

## Test plan
- [x] `uv run pytest tests/eval/` (110 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)