### PR TITLE
docs: publish the N=3 eval table and codify the publication bar (ADR 0005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to
 ### Added
 
 - README Eval section recording the qualifying run's per-task comparison —
-  the same agent, model, and eight tasks attempted with git-hunk's bundled
-  skills versus bare Git — with the checked-in harness linked for reproduction
-  (#255).
+  the same agent, model, and eight tasks attempted three times per variant
+  with git-hunk's bundled skills versus bare Git, each cell reporting the
+  median with its observed range and the cost column omitted until cost
+  accounting is order-neutral (#224) — with the checked-in harness linked for
+  reproduction (#255, #259).
 - Agent eval task and grader criterion for a partial selection that would
   commit syntactically broken code: one hunk interleaves the change to keep
   with debug scaffolding, so every tempting whole-noise selection stages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to
 - README Eval section recording the qualifying run's per-task comparison —
   the same agent, model, and eight tasks attempted three times per variant
   with git-hunk's bundled skills versus bare Git, each cell reporting the
-  median with its observed range and the cost column omitted until cost
-  accounting is order-neutral (#224) — with the checked-in harness linked for
+  median with its observed range and the cost column omitted because raw
+  costs are not order-neutral (#224) — with the checked-in harness linked for
   reproduction (#255, #259).
 - Agent eval task and grader criterion for a partial selection that would
   commit syntactically broken code: one hunk interleaves the change to keep

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,6 +113,9 @@
 - **ADR 0004** — agent eval. Grades agent judgment from exact Repository state,
   compares git-hunk with bare Git from the same prepared state, and pins the
   model.
+- **ADR 0005** — eval publication bar. One bar for every publicly visible eval
+  number: three repeats reported as median with observed range, cost omitted,
+  the pinned model named, and the README as the published table's home.
 
 ## Invariants
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ reruns the protocol and prints a table in the same format.
 
 `c` = tool calls, `t` = turns; a cell reports the median of its three repeats
 with the observed range in brackets, dropped where every repeat agreed, and the
-pass column counts passing repeats. The cost column is omitted until its
-accounting is order-neutral
-([#224](https://github.com/wkentaro/git-hunk/issues/224)): bare Git runs second
-in each pair and partly reads the prompt cache the git-hunk run warmed. Three
-samples per task variant, dated 2026-08-09 at commit `328392e`.
+pass column counts passing repeats. The cost column is omitted: bare Git runs
+second in each pair and partly reads the prompt cache the git-hunk run warmed,
+so raw costs are not order-neutral
+([#224](https://github.com/wkentaro/git-hunk/issues/224)). Three samples per
+task variant, dated 2026-08-09 at commit `328392e`.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -27,31 +27,33 @@ and exposing simple stage/unstage/discard commands.
 ## Eval
 
 One agent (Claude Code 2.1.226, `claude-sonnet-5`, reasoning effort `high`)
-attempted the same eight tasks twice from identical repository state: organize a
-dirty working tree into correct, focused commits, once following git-hunk's
-bundled skills and once restricted to bare Git. The
-[checked-in eval harness](https://github.com/wkentaro/git-hunk/tree/5a05866e801d9d379fd79f3c117fb383b1056acf/eval)
+attempted the same eight tasks from identical repository state, three times per
+variant: organize a dirty working tree into correct, focused commits, once
+following git-hunk's bundled skills and once restricted to bare Git. The
+[checked-in eval harness](https://github.com/wkentaro/git-hunk/tree/328392eae2856b38426e4918ac258edabc313201/eval)
 grades the exact resulting repository state — commit partition and order, final
 tree, index, and leftovers. This table records the qualifying run; `make eval`
 reruns the protocol and prints a table in the same format.
 
-| Task                                                                                                                                                    | git-hunk                    | bare Git                           |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- | ---------------------------------- |
-| [split_refactor_vs_feature](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/split_refactor_vs_feature.py) | PASS · 3c · 4t · $0.04      | PASS · 2c · 3t · $0.02             |
-| [separate_mixed_hunks](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/separate_mixed_hunks.py)           | PASS · 4c · 5t · $0.05      | FAIL partition · 10c · 11t · $0.11 |
-| [drop_debug_lines](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/drop_debug_lines.py)                   | PASS · 3c · 4t · $0.05      | PASS · 8c · 9t · $0.07             |
-| [protect_unrelated_work](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/protect_unrelated_work.py)       | PASS · 3c · 4t · $0.04      | PASS · 4c · 5t · $0.02             |
-| [split_single_hunk](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/split_single_hunk.py)                 | PASS · 4c · 5t · $0.06      | PASS · 9c · 10t · $0.10            |
-| [separate_formatter_noise](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/separate_formatter_noise.py)   | PASS · 4c · 5t · $0.08      | PASS · 25c · 26t · $0.26           |
-| [pick_duplicate_hunk](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/pick_duplicate_hunk.py)             | PASS · 3c · 4t · $0.04      | PASS · 9c · 10t · $0.09            |
-| [commit_parseable_subset](https://github.com/wkentaro/git-hunk/blob/5a05866e801d9d379fd79f3c117fb383b1056acf/eval/tasks/commit_parseable_subset.py)     | PASS · 5c · 6t · $0.08      | PASS · 11c · 12t · $0.13           |
-| **total**                                                                                                                                               | **8/8 · 29c · 37t · $0.45** | **7/8 · 78c · 86t · $0.80**        |
+| Task                                                                                                                                                    | git-hunk                            | bare Git                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------- |
+| [split_refactor_vs_feature](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/split_refactor_vs_feature.py) | PASS 3/3 · 3c [3-4] · 4t [4-5]      | PASS 3/3 · 4c · 5t                    |
+| [separate_mixed_hunks](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/separate_mixed_hunks.py)           | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 12c [10-14] · 13t [11-15]  |
+| [drop_debug_lines](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/drop_debug_lines.py)                   | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 17c [8-19] · 18t [9-20]    |
+| [protect_unrelated_work](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/protect_unrelated_work.py)       | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 2c [2-3] · 3t [3-4]        |
+| [split_single_hunk](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/split_single_hunk.py)                 | PASS 3/3 · 3c [3-4] · 4t [4-5]      | PASS 3/3 · 11c [9-20] · 12t [10-21]   |
+| [separate_formatter_noise](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/separate_formatter_noise.py)   | PASS 3/3 · 4c · 5t                  | PASS 3/3 · 16c [13-21] · 17t [14-22]  |
+| [pick_duplicate_hunk](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/pick_duplicate_hunk.py)             | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 9c [8-33] · 10t [9-34]     |
+| [commit_parseable_subset](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/commit_parseable_subset.py)     | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 12c [12-20] · 13t [13-21]  |
+| **total**                                                                                                                                               | **8/8 · 25c [25-27] · 33t [33-35]** | **8/8 · 83c [66-134] · 91t [74-142]** |
 
-`c` = tool calls, `t` = turns; `partition` = wrong commit partition. Costs
-include a small amount of harness-internal `claude-haiku-4-5` spend. Bare Git
-ran second in each pair, so its cost partly reads the prompt cache the git-hunk
-run warmed; the gap in tool calls is the sturdier signal. Single sample per
-task, dated 2026-08-09 at commit `5a05866`.
+`c` = tool calls, `t` = turns; a cell reports the median of its three repeats
+with the observed range in brackets, dropped where every repeat agreed, and the
+pass column counts passing repeats. The cost column is omitted until its
+accounting is order-neutral
+([#224](https://github.com/wkentaro/git-hunk/issues/224)): bare Git runs second
+in each pair and partly reads the prompt cache the git-hunk run warmed. Three
+samples per task variant, dated 2026-08-09 at commit `328392e`.
 
 ## Install
 

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -306,6 +306,18 @@ package gates, first passed on the frozen candidate, were then re-run on
 [issue #192](https://github.com/wkentaro/git-hunk/issues/192), and this ADR is
 Accepted on that evidence.
 
+After the release-candidate branch merged, the publication bar decided in
+[#231](https://github.com/wkentaro/git-hunk/issues/231) (ADR 0005) required a
+published table to report three repeats per variant, so the qualifier was
+re-run with `--repeat 3` on 2026-08-09 at commit
+`328392eae2856b38426e4918ac258edabc313201` — the merged candidate tip, whose
+diff from `5a05866` is doc-only, leaving the CLI, both skills, the tasks, and
+the runner unchanged. One uninterrupted invocation passed all eight subject
+variants on all three repeats with exit code 0, after the deterministic and
+lint gates passed on the same clean checkout. Its summary is recorded the same
+way, and the README's published table reports that run without its cost
+column, per the publication bar.
+
 ## Consequences
 
 - Normal tests stay deterministic and model-free.
@@ -326,5 +338,8 @@ Accepted on that evidence.
 - Repeating separates run-to-run noise from a real workflow change in one
   invocation, at N times the model usage of a single-sample run, and at a gate
   that the subject variant must clear on every repeat.
-- A later change to the CLI, either skill, an eval task, the runner, or the
-  Claude Code version makes an earlier model result stale.
+- A later change to the CLI, either skill, an eval task, or the runner makes
+  an earlier model result stale. The Claude Code version is provenance, not a
+  freshness constraint: an automatic update after a completed study does not
+  retroactively invalidate it, and a new study records the version it ran
+  under.

--- a/docs/adr/0005-eval-publication-bar.md
+++ b/docs/adr/0005-eval-publication-bar.md
@@ -1,0 +1,76 @@
+# ADR 0005: one publication bar for eval numbers
+
+**Status:** Accepted\
+**Proposed:** 2026-08-09\
+**Accepted:** 2026-08-09
+
+## Context
+
+ADR 0004 defines the paired git-hunk versus bare-Git eval and frames its
+result as an agent demonstration, not a statistical benchmark. The README's
+`## Eval` section publishes the qualifying run's table, and the package readme
+is assembled from `README.md` by `hatch-fancy-pypi-readme`, so each release's
+PyPI page freezes whatever table the README carries at upload. GitHub's README
+stays editable; a released PyPI page does not.
+
+[#231](https://github.com/wkentaro/git-hunk/issues/231) asked what the eval
+must satisfy before its numbers publish as adoption proof: repeat count and
+spread reporting, cost accounting, model coverage, and where results live. The
+v0.3.0 release forced the question, because shipping the README as it stood
+would have answered it permanently by default.
+
+## Decision
+
+One bar governs every publicly visible eval number. There is no lighter tier
+for a release record versus an adoption claim: the README table, the frozen
+PyPI page it becomes, and any announcement or post cite the same numbers held
+to the same bar.
+
+### Three repeats per task variant
+
+A published table reports `--repeat 3` output in ADR 0004's repeated-run
+format: median with the observed range in brackets, a pass column counting
+passing repeats, and qualification only when the subject variant passes every
+repeat. Three repeats show run-to-run stability without claiming statistical
+power; ADR 0004's demonstration framing is unchanged, and no success rate is
+claimed at any repeat count.
+
+### Cost is order-neutral or absent
+
+The runner's cost column is not order-neutral
+([#224](https://github.com/wkentaro/git-hunk/issues/224)): bare Git runs
+second and partly reads the prompt cache the git-hunk run warmed. Until cost
+is computed order-neutrally — the manifest already retains cache-creation and
+cache-read token counts separately — published tables omit the cost column and
+lead with tool calls and turns. Qualifying-run records on the release pull
+request and ticket keep the full runner table; its caveat travels with it, per
+ADR 0004.
+
+### One pinned model suffices
+
+`claude-sonnet-5` at the pinned reasoning effort meets the bar when the
+published table names the model, effort, and harness version prominently. The
+claim is scoped to that agent, not to agents generally. A model matrix is a
+possible later extension, not a requirement of the bar.
+
+### The README is the home
+
+The `## Eval` section carries the current qualifying table, dated and
+commit-pinned. Raw manifests, traces, and transcripts stay outside git, with
+summaries on the release pull request and release ticket, as ADR 0004 already
+requires.
+
+## Consequences
+
+- v0.3.0 ships the `## Eval` section rewritten from an N=3 re-qualification;
+  the single-sample table it replaces did not meet the bar.
+- A qualifying run costs three times a single-sample run, and its gate is
+  strictly harder: the subject variant must pass every repeat.
+- The cost column returns to published tables only when
+  [#224](https://github.com/wkentaro/git-hunk/issues/224) lands.
+- Announcements and positioning
+  ([#233](https://github.com/wkentaro/git-hunk/issues/233)) cite the published
+  table and no stronger claim.
+- The bar was decided in
+  [#231](https://github.com/wkentaro/git-hunk/issues/231); the grilling record
+  and the explicit v0.3.0 ship decision live on that issue.

--- a/docs/adr/0005-eval-publication-bar.md
+++ b/docs/adr/0005-eval-publication-bar.md
@@ -39,12 +39,13 @@ claimed at any repeat count.
 
 The runner's cost column is not order-neutral
 ([#224](https://github.com/wkentaro/git-hunk/issues/224)): bare Git runs
-second and partly reads the prompt cache the git-hunk run warmed. Until cost
-is computed order-neutrally — the manifest already retains cache-creation and
-cache-read token counts separately — published tables omit the cost column and
-lead with tool calls and turns. Qualifying-run records on the release pull
-request and ticket keep the full runner table; its caveat travels with it, per
-ADR 0004.
+second and partly reads the prompt cache the git-hunk run warmed. Published
+tables therefore omit the cost column and lead with tool calls and turns;
+cost is not part of the published claim, and making it order-neutral is not
+planned. If cost is ever computed order-neutrally — the manifest already
+retains cache-creation and cache-read token counts separately — the column
+may return. Qualifying-run records on the release pull request and ticket
+keep the full runner table; its caveat travels with it, per ADR 0004.
 
 ### One pinned model suffices
 
@@ -66,8 +67,9 @@ requires.
   the single-sample table it replaces did not meet the bar.
 - A qualifying run costs three times a single-sample run, and its gate is
   strictly harder: the subject variant must pass every repeat.
-- The cost column returns to published tables only when
-  [#224](https://github.com/wkentaro/git-hunk/issues/224) lands.
+- The cost column stays out of published tables;
+  [#224](https://github.com/wkentaro/git-hunk/issues/224) is closed as not
+  planned, and making cost order-neutral is the path to bringing it back.
 - Announcements and positioning
   ([#233](https://github.com/wkentaro/git-hunk/issues/233)) cite the published
   table and no stronger claim.


### PR DESCRIPTION
> *This was generated by AI.*

Executes the [#231 resolution](https://github.com/wkentaro/git-hunk/issues/231#issuecomment-5231703500) after PR #255 merged, so v0.3.0's README meets the publication bar before anything is tagged. **This must merge before the v0.3.0 tag** — the README becomes the frozen PyPI page for 0.3.0 (#193).

## What this does

- **README `## Eval`**: replaces the single-sample table with the N=3 qualifying run at `328392e` (summary recorded on PR #255 and #192 per ADR 0004). Cells report median with observed range, the pass column counts passing repeats, and the cost column is omitted until cost accounting is order-neutral (#224). Task and harness links re-pinned to `328392e`.
- **ADR 0005** (new): codifies the bar — one bar for all public eval numbers; N=3 repeats; cost order-neutral or omitted; one pinned model named prominently; README as the home.
- **ADR 0004**: folds in the pending provenance reword (a Claude Code auto-update no longer stales a completed study; a new study records its own version) and records the N=3 re-qualification in the qualifying-run section.

## Worth a reviewer's eye

- Bare Git scored **8/8 on all three repeats** in the N=3 run, where the n=1 run recorded 7/8. The old table's `FAIL partition` row is gone; the git-hunk advantage now reads as effort (25 vs 83 median tool calls, 33 vs 91 turns), not correctness. The new table publishes exactly what the run produced.
- Doc-only change: under ADR 0004 this does not stale the qualifying run.
- `make lint` passes (mdformat, typos, and friends).

Closes nothing by itself; #193 resumes once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
