### PR TITLE
docs: state the Duplicate Hunk group invariant and re-qualify v0.3.0

### DIFF
--- a/git_hunk/skills/core/SKILL.md
+++ b/git_hunk/skills/core/SKILL.md
@@ -74,6 +74,9 @@ member) renumbers its group. After either, only a bare Repository path may
 follow in that call, as above: `-l` and content matching need a single-hunk
 selection, so they need a fresh `git-hunk list`.
 
+An operation on a complete hunk outside the group leaves those `conditional`
+IDs byte-identical, so it may precede one in the same call.
+
 `--include-matching` and `--exclude-matching` match changed-line content as a
 literal substring; `--regex` switches to a regular expression. Each is
 repeatable and OR'd, but choose only one of `-l`, `--include-matching`, or


### PR DESCRIPTION
> *This was generated by AI.*

Closes #240.

## Why this is in v0.3.0

#240 was on the v0.3.0 milestone and edits a bundled skill, so it could not
land quietly after the tag: under ADR 0004, any change to either bundled skill
makes the qualifying eval result stale. The maintainer chose to land it and
re-qualify rather than defer it, so this PR carries both the text change and
the new qualifying run.

## The wording judgement

#240's body flagged that the wording is easy but the placement is a cost
decision: every byte of `core/SKILL.md` loads before an agent's first call and
re-reads each turn, and #220 cut output tokens from 3374 to 2399 by moving Hunk
ID nuance out of the core loop into the section where it applies.

The sentence therefore goes in **Splitting and cleanup**, beside the existing
Conditional Hunk ID paragraph, and the plan-and-chain rule in the core loop is
untouched. Cost: +138 bytes, in a section an agent reads only when it meets a
Duplicate Hunk group.

## Acceptance

- [x] The shipped `core` skill states that committing a complete non-member
      hunk leaves a Duplicate Hunk group's Conditional Hunk IDs valid
- [ ] An eval run confirms #220's tool-call and token gains survive the
      addition — pending, compared against the N=3 baseline below
- [x] The decision and its reasoning are recorded (here and in the commit)

## Baseline to beat

The current published N=3 run at `328392e`: git-hunk **8/8 · 25c [25-27] ·
33t [33-35]**. The re-qualification must hold that line and pass every repeat.