### PR TITLE
docs: date 0.3.0 as its actual release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-08-09
+## [0.3.0] - 2026-08-10
 
 ### Added
 


### PR DESCRIPTION
> *This was generated by AI.*

Last change before the v0.3.0 tag.

The `## [0.3.0]` heading read `2026-08-09`, the day the candidate was qualified.
The tag is being pushed on `2026-08-10`, so the heading should name the release
rather than the qualification. The promoted changelog is the source for the
GitHub Release notes, which makes the date publicly visible there and in the
repository record.

Docs-only: no CLI, bundled skill, eval task, or runner change, so the qualifying
run at `328392e` still describes what ships (ADR 0004).

The README's "dated 2026-08-09" line is untouched and correct — that is when the
published eval run was performed, not when the release goes out.

**Correction to this PR's original description:** it justified the change by
saying a released PyPI page freezes the date. That is wrong.
`hatch-fancy-pypi-readme` takes `README.md` as its only fragment, and the sdist
does not ship `CHANGELOG.md`, so the changelog never reaches PyPI. The PyPI
freeze argument applies to the README's eval table, not to this heading. The
change is still right for the reason above.