### PR TITLE
fix: isolate color environment in tests and evals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ At release, that section is promoted to the new version.
 
 The suite removes inherited `GIT_*` variables that can make Git use the outer
 repository. You can run the suite from inside `git rebase --exec`, a hook,
-`filter-branch`, or `bisect run`. The `_scrubbed_git_env` fixture in
+`filter-branch`, or `bisect run`. The `_scrubbed_process_env` fixture in
 `tests/conftest.py` removes these variables and explains why this is necessary.
 Keep this behavior. `tests/git_env_test.py` verifies that the suite does not
 change the outer repository.

--- a/eval/repo.py
+++ b/eval/repo.py
@@ -390,10 +390,15 @@ def init_repo(path: str | Path) -> GitRepo:
 
 
 def make_subprocess_env() -> dict[str, str]:
+    """Build a reproducible environment for eval subprocesses."""
     env = os.environ.copy()
     for name in tuple(env):
         if name.startswith("GIT_"):
             del env[name]
+    # Keep eval output stable when the invoking shell forces or disables color.
+    for name in ("FORCE_COLOR", "CLICOLOR_FORCE"):
+        env.pop(name, None)
+    env["NO_COLOR"] = "1"
     env["GIT_CONFIG_GLOBAL"] = os.devnull
     env["GIT_CONFIG_NOSYSTEM"] = "1"
     env["GIT_CONFIG_SYSTEM"] = os.devnull

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ class GitRepo:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _scrubbed_git_env() -> Generator[None]:
+def _scrubbed_process_env() -> Generator[None]:
     # git exports GIT_DIR, GIT_INDEX_FILE, and friends to the commands it runs:
     # `rebase --exec`, hooks, `filter-branch`, `bisect run`. Those beat cwd, so
     # every git subprocess the suite starts (the fixtures' own, and the ones
@@ -45,11 +45,16 @@ def _scrubbed_git_env() -> Generator[None]:
     # Drop all of it, except the config overrides a caller may set to shield
     # the suite from the machine's gitconfig (e.g. GIT_CONFIG_GLOBAL=/dev/null
     # in CI); those improve hermeticity rather than break it.
+    # Also pin color output so inherited terminal preferences cannot change
+    # captured output assertions.
     KEEP: Final = {"GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM"}
     with pytest.MonkeyPatch.context() as monkeypatch:
         for name in list(os.environ):
             if name.startswith("GIT_") and name not in KEEP:
                 monkeypatch.delenv(name)
+        for name in ("FORCE_COLOR", "CLICOLOR_FORCE"):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("NO_COLOR", "1")
         yield
 
 

--- a/tests/git_env_test.py
+++ b/tests/git_env_test.py
@@ -8,7 +8,7 @@ def test_suite_ignores_an_inherited_git_environment(tmp_path: Path) -> None:
     """The suite must not write to whatever repository GIT_DIR names.
 
     Point GIT_DIR and friends at a decoy repository, run a slice of the suite,
-    and assert the decoy stays empty. `_scrubbed_git_env` in conftest.py
+    and assert the decoy stays empty. `_scrubbed_process_env` in conftest.py
     explains why the scrub exists.
     """
     decoy = tmp_path / "decoy"


### PR DESCRIPTION
Closes #256.

The test suite and eval subprocesses now use a deterministic plain-output environment, so inherited terminal color settings cannot alter captured `git-hunk` output. The application itself continues to respect user color preferences.

## Test plan
- [x] `FORCE_COLOR=3 CLICOLOR_FORCE=1 NO_COLOR= make test` (810 passed)
- [x] `make lint`
