### PR TITLE
docs: publish the re-qualified eval table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to
   with git-hunk's bundled skills versus bare Git, each cell reporting the
   median with its observed range and the cost column omitted because raw
   costs are not order-neutral (#224) — with the checked-in harness linked for
-  reproduction (#255, #259).
+  reproduction (#255, #259, #263).
 - Agent eval task and grader criterion for a partial selection that would
   commit syntactically broken code: one hunk interleaves the change to keep
   with debug scaffolding, so every tempting whole-noise selection stages

--- a/README.md
+++ b/README.md
@@ -30,30 +30,32 @@ One agent (Claude Code 2.1.226, `claude-sonnet-5`, reasoning effort `high`)
 attempted the same eight tasks from identical repository state, three times per
 variant: organize a dirty working tree into correct, focused commits, once
 following git-hunk's bundled skills and once restricted to bare Git. The
-[checked-in eval harness](https://github.com/wkentaro/git-hunk/tree/328392eae2856b38426e4918ac258edabc313201/eval)
+[checked-in eval harness](https://github.com/wkentaro/git-hunk/tree/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval)
 grades the exact resulting repository state — commit partition and order, final
 tree, index, and leftovers. This table records the qualifying run; `make eval`
 reruns the protocol and prints a table in the same format.
 
-| Task                                                                                                                                                    | git-hunk                            | bare Git                              |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------- |
-| [split_refactor_vs_feature](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/split_refactor_vs_feature.py) | PASS 3/3 · 3c [3-4] · 4t [4-5]      | PASS 3/3 · 4c · 5t                    |
-| [separate_mixed_hunks](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/separate_mixed_hunks.py)           | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 12c [10-14] · 13t [11-15]  |
-| [drop_debug_lines](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/drop_debug_lines.py)                   | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 17c [8-19] · 18t [9-20]    |
-| [protect_unrelated_work](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/protect_unrelated_work.py)       | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 2c [2-3] · 3t [3-4]        |
-| [split_single_hunk](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/split_single_hunk.py)                 | PASS 3/3 · 3c [3-4] · 4t [4-5]      | PASS 3/3 · 11c [9-20] · 12t [10-21]   |
-| [separate_formatter_noise](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/separate_formatter_noise.py)   | PASS 3/3 · 4c · 5t                  | PASS 3/3 · 16c [13-21] · 17t [14-22]  |
-| [pick_duplicate_hunk](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/pick_duplicate_hunk.py)             | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 9c [8-33] · 10t [9-34]     |
-| [commit_parseable_subset](https://github.com/wkentaro/git-hunk/blob/328392eae2856b38426e4918ac258edabc313201/eval/tasks/commit_parseable_subset.py)     | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 12c [12-20] · 13t [13-21]  |
-| **total**                                                                                                                                               | **8/8 · 25c [25-27] · 33t [33-35]** | **8/8 · 83c [66-134] · 91t [74-142]** |
+| Task                                                                                                                                                    | git-hunk                            | bare Git                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------- |
+| [split_refactor_vs_feature](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/split_refactor_vs_feature.py) | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 3c [2-3] · 4t [3-4]                  |
+| [separate_mixed_hunks](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/separate_mixed_hunks.py)           | PASS 3/3 · 3c [3-4] · 4t [4-5]      | MIXED 1/3 partition · 15c [11-20] · 16t [12-21] |
+| [drop_debug_lines](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/drop_debug_lines.py)                   | PASS 3/3 · 3c · 4t                  | MIXED 2/3 partition · 16c [8-19] · 17t [9-20]   |
+| [protect_unrelated_work](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/protect_unrelated_work.py)       | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 2c [2-3] · 3t [3-4]                  |
+| [split_single_hunk](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/split_single_hunk.py)                 | PASS 3/3 · 5c [3-5] · 6t [4-6]      | PASS 3/3 · 14c [9-15] · 15t [10-16]             |
+| [separate_formatter_noise](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/separate_formatter_noise.py)   | PASS 3/3 · 4c [3-4] · 5t [4-5]      | PASS 3/3 · 16c [9-30] · 17t [10-31]             |
+| [pick_duplicate_hunk](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/pick_duplicate_hunk.py)             | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 10c [9-17] · 11t [10-18]             |
+| [commit_parseable_subset](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/commit_parseable_subset.py)     | PASS 3/3 · 5c [3-6] · 6t [4-7]      | PASS 3/3 · 14c [12-15] · 15t [13-16]            |
+| **total**                                                                                                                                               | **8/8 · 29c [24-31] · 37t [32-39]** | **6/8 (2 mixed) · 90c [62-122] · 98t [70-130]** |
 
 `c` = tool calls, `t` = turns; a cell reports the median of its three repeats
 with the observed range in brackets, dropped where every repeat agreed, and the
-pass column counts passing repeats. The cost column is omitted: bare Git runs
-second in each pair and partly reads the prompt cache the git-hunk run warmed,
-so raw costs are not order-neutral
-([#224](https://github.com/wkentaro/git-hunk/issues/224)). Three samples per
-task variant, dated 2026-08-09 at commit `328392e`.
+pass column counts passing repeats. `MIXED j/3` means the variant passed j of its
+three repeats, and `partition` names the failure: the commits made do not match
+the required change groups. The cost column is omitted: bare Git runs second in
+each pair and partly reads the prompt cache the git-hunk run warmed, so raw costs
+are not order-neutral
+([#224](https://github.com/wkentaro/git-hunk/issues/224)). Three samples per task
+variant, dated 2026-08-09 at commit `9829b7a`.
 
 ## Install
 


### PR DESCRIPTION
> *This was generated by AI.*

Required by ADR 0005: the README `## Eval` section must carry the current
qualifying run. #262 changed `eval/repo.py`, which made the previous result
stale under ADR 0004, so the qualifier was re-run and this table replaces it.

## Run 20260809T163652Z-9829b7a

One uninterrupted `python -m eval --repeat 3`, eight tasks, both variants, no
retry.

- **Commit:** `9829b7ac6fd871cd874d47e7424c9082bd58dbaf`, clean worktree
- **Started:** 2026-08-09T16:36:52Z, duration 1864.9 s
- **Model:** `claude-sonnet-5`, reasoning effort `high` (both runner-enforced);
  Claude Code 2.1.226; repeats 3
- **Gate:** `gate_passed: true`, exit code 0 — git-hunk passed 8/8 on every repeat
- **Cost:** $3.72 ($3.69 `claude-sonnet-5` + $0.03 harness-internal `claude-haiku-4-5`)
- **Skill SHA-256:** core `025c2dfe…`, logical-commits `7bae7012…` — byte-identical
  to the previously published run at `328392e`
- Deterministic gates green on the same clean checkout first: 810 tests, seven
  lint checks

## What moved, and what it means

The shipped surface did not change at all: `git diff 328392e..9829b7a -- git_hunk/`
is empty. Only the harness moved (+5 lines in `eval/repo.py`, popping
`FORCE_COLOR`/`CLICOLOR_FORCE` and setting `NO_COLOR=1`). Eval subprocesses never
had a TTY, so Rich already emitted plain text and the agent sees the same bytes it
saw before.

That makes this run a noise measurement, and it is worth recording what it shows.
Three N=3 samples now exist:

| Run | commit | core skill | git-hunk | bare Git |
| --- | --- | --- | --- | --- |
| 1 | `328392e` | `025c2dfe` | 8/8 · 25c [25-27] · 33t [33-35] | 8/8 · 83c |
| 2 | `482aa09` | `8d11e4e2` | 8/8 · 29c [25-34] · 37t [33-42] | 5/8 · 78c |
| 3 | `9829b7a` | `025c2dfe` | 8/8 · 29c [24-31] · 37t [32-39] | 6/8 · 90c |

Run 3 carries byte-identical skills to run 1 and reproduces run 2's medians, so
the 25 -> 29 shift seen when evaluating #240 was run-to-run noise rather than an
effect of that change. Run 1's tight 25c [25-27] reads as the outlier of the
three. bare Git has now scored 8/8, 5/8, and 6/8 on identical inputs.

git-hunk passed 8/8 in all three. The stable claim is correctness plus a large
effort gap; the exact medians are not stable to better than a few tool calls.

## Test plan

- [x] `make test` — 810 passed, and `make lint` — seven checks clean, at `9829b7a`
- [x] `python -m eval --repeat 3` — exit 0, `gate_passed: true`, 8/8 every repeat
- [x] Table cross-checked cell by cell against the runner output and run manifest
- [x] `mdformat --check README.md`