### PR TITLE
docs: backfill 0.2.0 and 0.1.0 changelog sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,5 +242,34 @@ and this project adheres to
   working across multiple hunks when they share the same single-hunk
   constraint as `-l` (#155).
 
+## [0.2.0] - 2026-04-16
+
+### Changed
+
+- `show` no longer requires Hunk IDs. Running it bare prints every hunk, staged
+  and unstaged, the same set `list` reports. The `--all` flag is removed;
+  passing specific IDs still works (#4).
+
+### Fixed
+
+- Windows: git subprocess calls use binary mode, so CRLF translation no longer
+  mangles diffs. CI covers macOS and Windows alongside Linux (#2).
+
+## [0.1.0] - 2026-04-04
+
+### Added
+
+- Initial release. `git add -p` is interactive, so scripts and AI agents cannot
+  drive it; git-hunk parses `git diff` into individual Hunks and stages,
+  unstages, or discards them by ID from the command line.
+- Content-based Hunk IDs (SHA-256 prefix) that do not shift as other hunks are
+  staged.
+- `list`, `show`, `stage`, `unstage`, and `discard` commands.
+- Line-level selection with `-l 3,5-7`.
+- JSON output via `--json`.
+- Binary and untracked file handling.
+
+[0.1.0]: https://github.com/wkentaro/git-hunk/releases/tag/v0.1.0
+[0.2.0]: https://github.com/wkentaro/git-hunk/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/wkentaro/git-hunk/compare/v0.2.0...v0.3.0
 [unreleased]: https://github.com/wkentaro/git-hunk/compare/v0.3.0...HEAD


### PR DESCRIPTION
> *This was generated by AI.*

`CHANGELOG.md` was created during the 0.3.0 cycle (#18) and started at `0.3.0`,
so a file whose header claims to record *all* notable changes covered only the
newest release, and the `[0.3.0]` compare link pointed back at a version with no
section of its own.

## What is here

- `## [0.2.0] - 2026-04-16` — the bare `show` change (#4) and the Windows CRLF
  fix (#2). The other two PRs in range (#1, #3) are Makefile and module-privacy
  refactors with no user-facing effect, so they are deliberately absent.
- `## [0.1.0] - 2026-04-04` — the initial release and its feature set.
- Compare links for both, with `[0.1.0]` pointing at the tag since there is no
  earlier version to diff against, per Keep a Changelog.

Dates are the tag commit dates. Entries are taken from each version's shipped
GitHub Release notes and checked against `git log v0.1.0..v0.2.0` (25 commits,
4 PRs) so nothing user-facing was missed.

## What is deliberately not here

The v0.1.0 and v0.2.0 **GitHub Release notes are untouched**. v0.1.0's opens with
why the project exists — `git add -p` is interactive, so scripts and agents
cannot drive it — which is the project's first public statement and reads better
than any generated section. Overwriting shipped release notes has no upside; the
changelog being complete does.

Docs-only. No CLI, bundled skill, eval task, or runner change.