### PR TITLE
ci: rename the release workflow to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: Publish to PyPI
+name: Release
 on:
   push:
     tags: [v*]


### PR DESCRIPTION
Name the tag-triggered workflow `release.yml`, matching labelme and herdr, and rename the workflow itself from "Publish to PyPI" to "Release". The jobs are unchanged: `test` → `build` → `publish`, pinned action SHAs, and the `pypi` environment all stay as they are.

The workflow filename is part of the PyPI trusted-publisher claim, so this cannot land alone. The publisher for `git-hunk` already carries a `release.yml` entry alongside the existing `publish.yml` one, so tagging works either side of this merge; the `publish.yml` publisher can be removed once this is in.

`docs/research/230-install-friction-distribution.md` still mentions `.github/workflows/publish.yml`. That document is a dated snapshot of `main` at `64861ae`, so it is left as observed rather than rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)