### PR TITLE
docs: raise the publication bar to five repeats and scope invalidation to agent-visible change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- The README's published eval table reports five repeats per task variant instead of three, after three separate studies — two of them on byte-identical bundled skills — reported medians four tool calls apart, and one of those differences was briefly read as a real effect. A qualifying run now costs five repeats and must pass every one of them (#267).
+- The eval's invalidation rule tracks what the agent is given and how its result is judged — the composed prompt, the tools offered, the repository state prepared, the bytes read back, and the grader — rather than which file a change lives in, so harness plumbing that cannot alter any of those records a note instead of forcing a re-qualification (#267).
+
 ## [0.3.0] - 2026-08-10
 
 ### Added

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,7 +114,7 @@
   compares git-hunk with bare Git from the same prepared state, and pins the
   model.
 - **ADR 0005** — eval publication bar. One bar for every publicly visible eval
-  number: three repeats reported as median with observed range, cost omitted,
+  number: five repeats reported as median with observed range, cost omitted,
   the pinned model named, and the README as the published table's home.
 
 ## Invariants

--- a/README.md
+++ b/README.md
@@ -27,35 +27,35 @@ and exposing simple stage/unstage/discard commands.
 ## Eval
 
 One agent (Claude Code 2.1.226, `claude-sonnet-5`, reasoning effort `high`)
-attempted the same eight tasks from identical repository state, three times per
+attempted the same eight tasks from identical repository state, five times per
 variant: organize a dirty working tree into correct, focused commits, once
 following git-hunk's bundled skills and once restricted to bare Git. The
-[checked-in eval harness](https://github.com/wkentaro/git-hunk/tree/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval)
+[checked-in eval harness](https://github.com/wkentaro/git-hunk/tree/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval)
 grades the exact resulting repository state — commit partition and order, final
 tree, index, and leftovers. This table records the qualifying run; `make eval`
 reruns the protocol and prints a table in the same format.
 
 | Task                                                                                                                                                    | git-hunk                            | bare Git                                        |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------- |
-| [split_refactor_vs_feature](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/split_refactor_vs_feature.py) | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 3c [2-3] · 4t [3-4]                  |
-| [separate_mixed_hunks](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/separate_mixed_hunks.py)           | PASS 3/3 · 3c [3-4] · 4t [4-5]      | MIXED 1/3 partition · 15c [11-20] · 16t [12-21] |
-| [drop_debug_lines](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/drop_debug_lines.py)                   | PASS 3/3 · 3c · 4t                  | MIXED 2/3 partition · 16c [8-19] · 17t [9-20]   |
-| [protect_unrelated_work](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/protect_unrelated_work.py)       | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 2c [2-3] · 3t [3-4]                  |
-| [split_single_hunk](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/split_single_hunk.py)                 | PASS 3/3 · 5c [3-5] · 6t [4-6]      | PASS 3/3 · 14c [9-15] · 15t [10-16]             |
-| [separate_formatter_noise](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/separate_formatter_noise.py)   | PASS 3/3 · 4c [3-4] · 5t [4-5]      | PASS 3/3 · 16c [9-30] · 17t [10-31]             |
-| [pick_duplicate_hunk](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/pick_duplicate_hunk.py)             | PASS 3/3 · 3c · 4t                  | PASS 3/3 · 10c [9-17] · 11t [10-18]             |
-| [commit_parseable_subset](https://github.com/wkentaro/git-hunk/blob/9829b7ac6fd871cd874d47e7424c9082bd58dbaf/eval/tasks/commit_parseable_subset.py)     | PASS 3/3 · 5c [3-6] · 6t [4-7]      | PASS 3/3 · 14c [12-15] · 15t [13-16]            |
-| **total**                                                                                                                                               | **8/8 · 29c [24-31] · 37t [32-39]** | **6/8 (2 mixed) · 90c [62-122] · 98t [70-130]** |
+| [split_refactor_vs_feature](https://github.com/wkentaro/git-hunk/blob/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval/tasks/split_refactor_vs_feature.py) | PASS 5/5 · 3c · 4t                  | PASS 5/5 · 3c [2-5] · 4t [3-6]                  |
+| [separate_mixed_hunks](https://github.com/wkentaro/git-hunk/blob/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval/tasks/separate_mixed_hunks.py)           | PASS 5/5 · 3c · 4t                  | PASS 5/5 · 8c [7-12] · 9t [8-13]                |
+| [drop_debug_lines](https://github.com/wkentaro/git-hunk/blob/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval/tasks/drop_debug_lines.py)                   | PASS 5/5 · 3c [3-4] · 4t [4-5]      | MIXED 4/5 partition · 8c [7-27] · 9t [8-28]     |
+| [protect_unrelated_work](https://github.com/wkentaro/git-hunk/blob/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval/tasks/protect_unrelated_work.py)       | PASS 5/5 · 3c · 4t                  | PASS 5/5 · 3c [3-4] · 4t [4-5]                  |
+| [split_single_hunk](https://github.com/wkentaro/git-hunk/blob/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval/tasks/split_single_hunk.py)                 | PASS 5/5 · 4c [3-4] · 5t [4-5]      | PASS 5/5 · 11c [9-19] · 12t [10-20]             |
+| [separate_formatter_noise](https://github.com/wkentaro/git-hunk/blob/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval/tasks/separate_formatter_noise.py)   | PASS 5/5 · 4c [4-6] · 5t [5-7]      | PASS 5/5 · 13c [12-16] · 14t [13-17]            |
+| [pick_duplicate_hunk](https://github.com/wkentaro/git-hunk/blob/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval/tasks/pick_duplicate_hunk.py)             | PASS 5/5 · 3c · 4t                  | PASS 5/5 · 8c [7-25] · 9t [8-26]                |
+| [commit_parseable_subset](https://github.com/wkentaro/git-hunk/blob/0ef14bef657e187b5ab7283b0dbd64751a02736f/eval/tasks/commit_parseable_subset.py)     | PASS 5/5 · 4c [3-5] · 5t [4-6]      | MIXED 4/5 partition · 13c [10-23] · 14t [11-24] |
+| **total**                                                                                                                                               | **8/8 · 27c [25-31] · 35t [33-39]** | **6/8 (2 mixed) · 67c [57-131] · 75t [65-139]** |
 
-`c` = tool calls, `t` = turns; a cell reports the median of its three repeats
+`c` = tool calls, `t` = turns; a cell reports the median of its five repeats
 with the observed range in brackets, dropped where every repeat agreed, and the
-pass column counts passing repeats. `MIXED j/3` means the variant passed j of its
-three repeats, and `partition` names the failure: the commits made do not match
+pass column counts passing repeats. `MIXED j/5` means the variant passed j of its
+five repeats, and `partition` names the failure: the commits made do not match
 the required change groups. The cost column is omitted: bare Git runs second in
 each pair and partly reads the prompt cache the git-hunk run warmed, so raw costs
 are not order-neutral
-([#224](https://github.com/wkentaro/git-hunk/issues/224)). Three samples per task
-variant, dated 2026-08-09 at commit `9829b7a`.
+([#224](https://github.com/wkentaro/git-hunk/issues/224)). Five samples per task
+variant, dated 2026-08-10 at commit `0ef14be`.
 
 ## Install
 

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -315,8 +315,9 @@ diff from `5a05866` is doc-only, leaving the CLI, both skills, the tasks, and
 the runner unchanged. One uninterrupted invocation passed all eight subject
 variants on all three repeats with exit code 0, after the deterministic and
 lint gates passed on the same clean checkout. Its summary is recorded the same
-way, and the README's published table reports that run without its cost
-column, per the publication bar.
+way. That run's table was the README's published table for v0.3.0; ADR 0005
+later raised the bar to five repeats, and the README now reports a `--repeat 5`
+study in its place.
 
 ## Consequences
 

--- a/docs/adr/0004-agent-eval-design.md
+++ b/docs/adr/0004-agent-eval-design.md
@@ -338,8 +338,14 @@ column, per the publication bar.
 - Repeating separates run-to-run noise from a real workflow change in one
   invocation, at N times the model usage of a single-sample run, and at a gate
   that the subject variant must clear on every repeat.
-- A later change to the CLI, either skill, an eval task, or the runner makes
-  an earlier model result stale. The Claude Code version is provenance, not a
-  freshness constraint: an automatic update after a completed study does not
-  retroactively invalidate it, and a new study records the version it ran
-  under.
+- A later change to the CLI, either skill, an eval task, or the grader makes an
+  earlier model result stale, because each of those changes what the agent is
+  given or how its result is judged. Harness plumbing that cannot change either
+  — the composed prompt, the tools offered, the repository state prepared, or
+  the bytes the agent reads back — does not invalidate a completed study; the
+  change records a note saying why instead. A change that alters any of those
+  four does invalidate, whatever file it lives in. When it is unclear, re-run:
+  the rule exists to keep published numbers honest, not to avoid a run.
+- The Claude Code version is provenance, not a freshness constraint: an
+  automatic update after a completed study does not retroactively invalidate
+  it, and a new study records the version it ran under.

--- a/docs/adr/0005-eval-publication-bar.md
+++ b/docs/adr/0005-eval-publication-bar.md
@@ -26,14 +26,25 @@ for a release record versus an adoption claim: the README table, the frozen
 PyPI page it becomes, and any announcement or post cite the same numbers held
 to the same bar.
 
-### Three repeats per task variant
+### Five repeats per task variant
 
-A published table reports `--repeat 3` output in ADR 0004's repeated-run
+A published table reports `--repeat 5` output in ADR 0004's repeated-run
 format: median with the observed range in brackets, a pass column counting
 passing repeats, and qualification only when the subject variant passes every
-repeat. Three repeats show run-to-run stability without claiming statistical
+repeat. Five repeats show run-to-run stability without claiming statistical
 power; ADR 0004's demonstration framing is unchanged, and no success rate is
 claimed at any repeat count.
+
+The bar was three until three separate studies showed three was not enough to
+read. Two of them ran byte-identical bundled skills and still reported medians
+four tool calls apart, and the study between them was briefly read as evidence
+that a documentation sentence had cost those four calls — a verdict the next
+run overturned
+([#240](https://github.com/wkentaro/git-hunk/issues/240#issuecomment-5232789862)).
+A median over five samples moves less between studies, which is what a
+published number needs. The observed range will widen as more samples are
+drawn; that is the measurement becoming more honest, not the tool becoming
+less stable.
 
 ### Cost is order-neutral or absent
 
@@ -65,8 +76,9 @@ requires.
 
 - v0.3.0 ships the `## Eval` section rewritten from an N=3 re-qualification;
   the single-sample table it replaces did not meet the bar.
-- A qualifying run costs three times a single-sample run, and its gate is
-  strictly harder: the subject variant must pass every repeat.
+- A qualifying run costs five times a single-sample run — roughly 50 minutes and
+  $6 at the rates observed for v0.3.0 — and its gate is strictly harder: the
+  subject variant must pass all five repeats, so forty subject runs must succeed.
 - The cost column stays out of published tables;
   [#224](https://github.com/wkentaro/git-hunk/issues/224) is closed as not
   planned, and making cost order-neutral is the path to bringing it back.


### PR DESCRIPTION
> *This was generated by AI.*

Two changes to how eval numbers are qualified and published, plus the
qualifying run at the new bar. They are one PR because either alone makes
things worse.

## Five repeats, not three (ADR 0005)

Three repeats could not resolve the effects being asked of them. Across the
v0.3.0 release three N=3 studies ran, **two of them on byte-identical bundled
skills**, and they reported medians four tool calls apart:

| Study | commit | core skill | git-hunk |
| --- | --- | --- | --- |
| 1 | `328392e` | `025c2dfe` | 8/8 · 25c \[25-27] · 33t \[33-35] |
| 2 | `482aa09` | `8d11e4e2` | 8/8 · 29c \[25-34] · 37t \[33-42] |
| 3 | `9829b7a` | `025c2dfe` | 8/8 · 29c \[24-31] · 37t \[32-39] |
| **this PR** | `0ef14be` | `025c2dfe` | **8/8 · 27c \[25-31] · 35t \[33-39]** |

Study 2 was briefly read as evidence that a documentation sentence had cost
those four calls, and #240 was resolved on it. Study 3 — same skill bytes as
study 1 — reproduced study 2's medians, so the effect was noise and the verdict
was corrected
([#240](https://github.com/wkentaro/git-hunk/issues/240#issuecomment-5232789862)).

The five-repeat run lands at **27c \[25-31]**, between the two point estimates
that were mistaken for a difference, with a range spanning both. That is the
bar doing what it was raised to do.

## Invalidation follows the agent, not the file (ADR 0004)

The rule invalidated on any change to "the runner", so
[#262](https://github.com/wkentaro/git-hunk/pull/262) forced a full
re-qualification for setting `NO_COLOR=1` on a subprocess that never had a TTY.
Rich was already emitting plain text; the agent provably read identical bytes.
That cost 31 minutes and $3.72 to re-measure a no-op — and the re-run came back
with different medians anyway, from the very noise this PR's other half
addresses.

Invalidation now tracks **what the agent is given and how its result is judged**:
the composed prompt, the tools offered, the repository state prepared, the bytes
read back, and the grader. A change to any of those invalidates whatever file it
lives in. Plumbing that cannot touch them records a note instead. The rule ends
with "when it is unclear, re-run", so this is not licence to skip a run.

## Qualifying run 20260810T030108Z-0721669

One uninterrupted `python -m eval --repeat 5`, eight tasks, both variants, no
retry, after the deterministic and lint gates passed on the same clean checkout.

- **Commit:** `0721669`, clean worktree. The branch was rebased onto #266 during
  the run, replaying that commit as `0ef14be`;
  `git diff 0721669 0ef14be -- git_hunk/ eval/ tests/eval/ Makefile` is empty,
  so the run describes the tree in this PR exactly. The published table is
  pinned to `0ef14be`, the commit that is actually in history.
- **Started:** 2026-08-10T03:01:08Z, duration 2716.6 s
- **Model:** `claude-sonnet-5`, reasoning effort `high`, both runner-enforced;
  Claude Code 2.1.226; repeats 5
- **Gate:** `gate_passed: true`, exit 0 — **40 subject runs, all `PASS 5/5`**
- **Cost:** $5.66
- **Skill SHA-256:** core `025c2dfe…`, logical-commits `7bae7012…` — unchanged
  from every earlier study

bare Git scored 6/8 with two `MIXED 4/5` cells. Across five studies it has now
scored 8/8, 5/8, 6/8, and 6/8; git-hunk has not failed a graded run.

## Also here

ADR 0004's acceptance section claimed the README reports the N=3 run. It now
records that as v0.3.0's table and points at the five-repeat study.

## Test plan

- [x] `make lint` — seven checks clean
- [x] `make test` — 810 passed
- [x] `python -m eval --repeat 5` — `gate_passed: true`, exit 0, 40/40 subject
      runs `PASS 5/5`
- [x] README table cross-checked cell by cell against the runner output and the
      run manifest
- [x] Every table link re-pinned to `0ef14be` and confirmed to be a commit in
      this branch's history