### PR TITLE
docs: README quick links and merged Comparison/Eval sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ Conditional IDs.
 `git-hunk` solves this by assigning each staged or unstaged Hunk a durable ID
 and exposing simple stage/unstage/discard commands.
 
-## Eval
+## Comparison
+
+|                  | Interactive | Programmatic | Hunk IDs | Line-level control | JSON output |
+| ---------------- | ----------- | ------------ | -------- | ------------------ | ----------- |
+| `git add -p`     | Yes         | No           | No       | Yes                | No          |
+| `git add <file>` | No          | Yes          | No       | No                 | No          |
+| **`git-hunk`**   | **No**      | **Yes**      | **Yes**  | **Yes**            | **Yes**     |
+
+### Eval
 
 One agent (Claude Code 2.1.226, `claude-sonnet-5`, reasoning effort `high`)
 attempted the same eight tasks from identical repository state, five times per
@@ -310,14 +318,6 @@ have one code path and strict JSON parsers never see a lone surrogate.
 Adding a new field is backward-compatible and does not change `schema_version`;
 renaming, removing, or changing the type of an existing field bumps it. (Before
 `schema_version` existed, `list --json` returned a bare array.)
-
-## Comparison
-
-|                  | Interactive | Programmatic | Hunk IDs | Line-level control | JSON output |
-| ---------------- | ----------- | ------------ | -------- | ------------------ | ----------- |
-| `git add -p`     | Yes         | No           | No       | Yes                | No          |
-| `git add <file>` | No          | Yes          | No       | No                 | No          |
-| **`git-hunk`**   | **No**      | **Yes**      | **Yes**  | **Yes**            | **Yes**     |
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Conditional IDs.
 
 <img src="assets/teaser.png" alt="git-hunk teaser" width="800">
 
+[Comparison](#comparison) • [Install](#install) • [For AI agents](#for-ai-agents) •
+[Quick start](#quick-start) • [Usage](#usage) • [JSON output](#json-output)
+
 ## Why?
 
 `git add -p` requires interactive input. That makes it unusable for:


### PR DESCRIPTION
Two README navigation changes, one commit each.

**Merge Comparison into Eval.** The two sections both answered "why git-hunk over plain Git" from opposite ends of the README. The feature matrix now opens a single `## Comparison` section near the top, with the eval as an `### Eval` subsection right after it — features first, then the measured evidence. Both heading anchors (`#comparison`, `#eval`) survive, so existing links from ADRs and release notes keep working.

**Quick-links row under the intro.** In-flow navigation to the sections readers jump to most (the fd/ripgrep pattern), including For AI agents — the audience the Why section names first. Kept to one compact row rather than a full nested table of contents, which would duplicate GitHub's built-in heading outline and drift stale. Note the links only work where the renderer generates heading anchors (GitHub does; PyPI does not — [readme_renderer#169](https://github.com/pypa/readme_renderer/issues/169) — where they render as plain dead links).

Per the policy in #269, no changelog entry.

## Test plan

- [x] Each quick-link matches an existing heading slug, verified in the rendered DOM on this branch: `#comparison`, `#install`, `#for-ai-agents`, `#quick-start`, `#usage`, `#json-output`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
