### PR TITLE
docs: stop logging eval and repo-only tooling in the changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,16 @@ User-facing changes go in `CHANGELOG.md` under `## [Unreleased]`
 ([Keep a Changelog](https://keepachangelog.com/) format), with the PR number.
 At release, that section is promoted to the new version.
 
-Documentation-only changes (README, CONTEXT.md, ADRs, `docs/`) get no
-changelog entry. The changelog records changes to the tool itself; docs that
-ship inside the package (`--help` text, bundled skills) still count as the
-tool.
+The changelog records changes to the tool as installed. If a change cannot
+reach a user through the published package, it gets no entry. That excludes
+documentation-only changes (README, CONTEXT.md, ADRs, `docs/`) and
+repository-only tooling (`tests/`, `eval/`, CI config, `Makefile` targets).
+Docs that ship inside the package (`--help` text, bundled skills) still count
+as the tool.
+
+An excluded change can still appear inside an entry as context for a
+user-facing one — an eval run that uncovered a bug belongs in the entry for
+the fix, not in an entry of its own.
 
 ## Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Agent eval task and grader criterion for a partial selection that would commit syntactically broken code: one hunk interleaves the change to keep with debug scaffolding, so every tempting whole-noise selection stages Python that no longer parses, and the grader now fails any commit in the graded range whose own tree holds an unparsable `.py` file, ahead of the commit-partition check (#242).
-- `python -m eval --repeat N` samples every selected task variant N times from the same prepared state. Each cell reports the median with its observed range for tool calls, turns, and cost, a variant that failed only some repeats reads `MIXED j/k` instead of a pass, and the run manifest keeps every individual repeat. `--repeat 1` stays the default and is unchanged (#237).
-- Three hard agent eval tasks covering the cases where non-interactive bare Git has no per-hunk answer: splitting two intents inside one hunk, lifting a fix out of formatter churn that shares its hunk, and committing one member of a Duplicate Hunk group while its identical twin stays in the worktree (#226).
-- Agent evals end with a Markdown summary table comparing git-hunk and bare Git per task, with outcome, turns, and cost per cell, a legend for the failure reasons that occurred, and the prompt-cache caveat that makes the cost column readable. The exit code now reports the subject under test (the git-hunk variant) and solver errors, so a graded bare-Git failure is evidence instead of a red run (#221).
-- Agent eval summary tables, usage lines, and run manifests count the tool calls each task variant made, so the workflow comparison reports the metric it is about (#220).
-- Agent evals run every task with git-hunk and bare Git from equivalent initial state for direct workflow and cost comparison, and `--help` lists the available tasks (#216).
-- Agent evals stream composed prompts and Bash calls, report normalized token and cost usage, and write human-readable transcripts (#215).
-- A repository-only agent eval (`python -m eval`): synthetic logical-commit tasks solved by a pinned model and graded from the exact resulting Repository state, with deterministic golden and adversarial coverage in the normal test suite and nothing added to the installed package (#203), plus a `make eval` entry point that forwards optional `EVAL_ARGS` to the evaluator (#207).
 - `skills` subcommand (`git-hunk skills list|get|path`) serving the bundled, version-matched core usage guide for AI agents (#8).
 - Examples section in `--help` for every subcommand (#7).
 - Accept a file path as shorthand for all hunks in a file, so `git-hunk stage src/foo.py` stages every hunk in that file (#43).
@@ -32,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Agent evals pin the solver's reasoning effort to `high` instead of relying on the claude CLI's default, and report the requested effort in the startup line and the run manifest (#257).
 - **Breaking:** Selecting exactly one side of a one-for-one replacement now exits 1 with an error naming the pair's line numbers, instead of exiting 0 after silently staging, committing, or discarding the deletion-only or addition-only half. `-l`, `--include-matching`, and `--exclude-matching` share the guard, and nothing is mutated when it fires. `stage`, `unstage`, `discard`, and `commit` take a new `--allow-one-sided` flag for the deliberate lone-half case; it requires one of the selection options and does not relax the wider grouped-replacement rule. An eval run first caught the silent half, and the core skill, README, and domain glossary documented the hazard (#226) before this release made it an error (#251).
 - Ask for a one-line-per-commit close in the core skill, so the agent's final report stops restating the diff it just committed (#220).
 - Condense the core skill to the rules an agent acts on, trimming the text it loads before its first inspection call (#220).


### PR DESCRIPTION
The changelog should describe the tool a user installs. `eval/` ships in neither the wheel (`packages = ["git_hunk"]`) nor the sdist (`include = ["/README.md", "/git_hunk"]`), so it is repository-only tooling in exactly the sense `tests/` is, and its entries were never reachable by a user of the published package.

The practical cost was readability: 8 of the 18 `Added` bullets in 0.3.0 covered the eval harness, and they were the longest ones, so the product changes that release actually delivered — the `skills` subcommand, `commit`, `--dry-run` — sat underneath grader criteria and `--repeat N` sampling semantics.

This generalizes the existing documentation-only rule in `AGENTS.md` to the underlying test — can the change reach a user through the published package? — and names `tests/`, `eval/`, CI config, and `Makefile` targets alongside docs. It also records the carve-out already in use: an excluded change may appear inside a user-facing entry as context, which is why the #251 breaking-change entry keeps its note that an eval run first caught the silent one-sided half.

Nine entries are removed from the released 0.3.0 section. The published v0.3.0 release notes are regenerated from the corrected section, which also drops a stale README Eval entry that `d8f9955` had already removed from `CHANGELOG.md`.

No `Unreleased` entry: this change is itself documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
