### PR TITLE
test: cover parse_hunk_range directly, including omitted and zero counts

### DIFF
--- a/tests/unit/_hunk/parse_hunk_range_test.py
+++ b/tests/unit/_hunk/parse_hunk_range_test.py
@@ -1,0 +1,38 @@
+import pytest
+
+from git_hunk._hunk import HunkRange
+from git_hunk._hunk import parse_hunk_range
+
+
+def test_parses_both_counts() -> None:
+    assert parse_hunk_range("@@ -1,3 +4,5 @@") == HunkRange(1, 3, 4, 5)
+
+
+def test_omitted_count_means_one() -> None:
+    assert parse_hunk_range("@@ -1 +4 @@") == HunkRange(1, 1, 4, 1)
+
+
+def test_zero_count_stays_zero() -> None:
+    # git writes a 0,0 side for a created or deleted file; zero is a real
+    # count, not the 1 an omitted count defaults to.
+    assert parse_hunk_range("@@ -0,0 +1,3 @@") == HunkRange(0, 0, 1, 3)
+    assert parse_hunk_range("@@ -1,3 +0,0 @@") == HunkRange(1, 3, 0, 0)
+
+
+def test_keeps_git_heading_as_suffix() -> None:
+    assert parse_hunk_range("@@ -1,3 +1,3 @@ def foo():").suffix == " def foo():"
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "diff --git a/f.py b/f.py",
+        "@@ -a,3 +1,3 @@",
+        "@@ -1,3 +1,3 @",
+        "@@ -1,3 @@",
+        " @@ -1,3 +1,3 @@",
+    ],
+)
+def test_raises_when_header_does_not_match(header: str) -> None:
+    with pytest.raises(ValueError, match="cannot parse hunk header"):
+        parse_hunk_range(header)


### PR DESCRIPTION
Closes #247

`parse_hunk_range` had no direct test — every existing check reached it through callers. This pins the header grammar the common path never exercises: an omitted count (meaning 1), a real zero count, the trailing heading kept as suffix, and five malformed headers that must raise.

One non-obvious bit: the zero cases guard the omitted-count default. An omitted count captures `None` and falls back to 1, while `-0,0` captures the truthy string `"0"`, so zero survives; the neighbouring spelling `int(...) or 1` would silently turn a creation's or deletion's `0,0` side into a count of 1.

No changelog entry: repository-only tooling (`tests/`).

## Test plan

- [x] `uv run pytest tests/` — 819 passed

- [x] `make lint` — clean
