### PR TITLE
test: pin that a peer's position is read from its pre-image side

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -138,4 +138,6 @@
   the group are committed.
 - Ordering a Duplicate Hunk group's members counts only the unstaged Hunks with the
   same Repository path, so an unstaged change elsewhere cannot renumber the group.
+- Ordering a Duplicate Hunk group's members places each unstaged Hunk by its pre-image
+  start, because a staged member's own position is still in index coordinates.
 - Each Hunk ID in an inventory addresses exactly one Hunk.

--- a/tests/unit/_hunk/id_test.py
+++ b/tests/unit/_hunk/id_test.py
@@ -3,6 +3,7 @@ import re
 from git_hunk._hunk import Hunk
 from git_hunk._hunk import _compute_text_hunk_id
 from git_hunk._hunk import _compute_whole_file_hunk_id
+from git_hunk._hunk import _hash_id
 from git_hunk._hunk import assign_hunk_ids
 from git_hunk._hunk import count_changes
 
@@ -118,6 +119,26 @@ def test_conditional_ids_follow_duplicate_order_across_status_changes() -> None:
     )
 
     assert [hunk.id for hunk in after] == [hunk.id for hunk in before]
+
+
+def test_staged_position_reads_a_peer_start_from_its_pre_image_side() -> None:
+    # A staged member's own position is still in index coordinates, so the walk must
+    # place each unstaged peer by its pre-image start. The last peer straddles the
+    # staged member's start (pre-image 20 < 25 < post-image 30), so only the correct
+    # reading counts its +5: the staged member lands at 25 + 10 + 5 = 40, behind its
+    # group peer at 37, instead of at 35, ahead of it.
+    group_id = "a" * 64
+    staged = _make_hunk(hunk_id=group_id, header="@@ -25 +25 @@", status="staged")
+    peer_in_group = _make_hunk(hunk_id=group_id, header="@@ -22 +37 @@")
+    earlier_peer = _make_hunk(hunk_id="b" * 64, header="@@ -5 +5,11 @@")
+    straddling_peer = _make_hunk(hunk_id="c" * 64, header="@@ -20 +30,6 @@")
+
+    result = assign_hunk_ids([staged, peer_in_group, earlier_peer, straddling_peer])
+
+    # Ordinals spelled out, not reread from a second assignment run: an oracle that
+    # shares the sort cancels out the ordering under test.
+    assert result[0].id == _hash_id("conditional", group_id, "1")
+    assert result[1].id == _hash_id("conditional", group_id, "0")
 
 
 def test_single_group_member_uses_stable_base_id() -> None:


### PR DESCRIPTION
Closes #250.

Ordering a Duplicate Hunk group's members compares each unstaged peer's pre-image start against the staged member's position, because that member's own position is still in index coordinates. Reading the post-image start instead left all 811 tests green — nothing pinned which side is correct.

The two sides only diverge once an earlier unstaged peer has already shifted the coordinates, so the fixture puts two unstaged peers ahead of the staged member: the first adds 10 lines, which makes the second straddle the staged member's start (pre-image 20, post-image 30). The staged member lands at worktree line 40, behind its group peer at 37; the post-image reading puts it at 35, ahead.

The expected ordinals are spelled out rather than read back from a second assignment run, because an oracle that shares the sort cancels out the ordering under test — a version that derived them from a second `assign_hunk_ids` call stayed green under both a stubbed-out position walk and a reversed sort.

`CONTEXT.md` gains the matching invariant bullet, alongside the walk's other documented clauses.

## Test plan

- [x] `uv run pytest tests/` — 811 passed

- [x] `make lint` — clean

- [x] Mutation-proven, each mutant run in a throwaway clone: reading the peer's post-image start fails only this test (1 failed, 810 passed); the position walk returning `0` fails it; reversing the group sort fails it.

## Notes for review

Sibling issue #249 covers the function's other gap and is assigned separately, so it is not bundled here. That branch pins its gap with a direct position assertion; this one asserts on Hunk IDs because #250's acceptance criterion asks for the ordering, which is the observable behaviour. Worth reconciling the two styles once both land.
