### PR TITLE
fix: read the diff with color disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Read the diff with color disabled, so `color.ui` or `color.diff` set to `always` no longer hides every tracked hunk — `list` reported `No hunks.` on a dirty tree, and mutation commands could not resolve their targets (#275).
+
 ## [0.3.0] - 2026-08-10
 
 ### Added

--- a/git_hunk/_git.py
+++ b/git_hunk/_git.py
@@ -44,8 +44,11 @@ def get_diff(*, worktree_root: str, staged: bool) -> str:
     # --src-prefix/--dst-prefix override diff.noprefix and diff.mnemonicPrefix
     # the same way --default-prefix does, but predate it, so the supported git
     # floor stays at --no-relative's 2.28 instead of --default-prefix's 2.41.
+    # --no-color: a color.diff or color.ui set to always emits ANSI escapes
+    # even into a pipe, and the parse would find nothing.
     args = [
         "diff",
+        "--no-color",
         "--no-relative",
         "--src-prefix=a/",
         "--dst-prefix=b/",

--- a/tests/e2e/color_config_test.py
+++ b/tests/e2e/color_config_test.py
@@ -1,0 +1,26 @@
+import pytest
+
+from .conftest import GitHunkCLI
+
+REPORTS = (["list"], ["show"], ["list", "--json"])
+
+
+# color.ui and color.diff reach git's diff colorization through different
+# config lookups, so each key gets its own case. Both keys at once run in the
+# hostile diff config of the repository_path suite, which also covers the
+# mutation commands.
+@pytest.mark.parametrize("key", ["color.ui", "color.diff"])
+def test_forced_color_leaves_the_reports_unchanged(cli: GitHunkCLI, key: str) -> None:
+    # `always` makes git colorize into a pipe too, so the ANSI escapes land in
+    # the diff git-hunk parses rather than on a terminal.
+    cli.repo.write_file("changed.txt", "a\nb\nc\n")
+    cli.repo.git("add", ".")
+    cli.repo.git("commit", "-m", "init")
+    cli.repo.write_file("changed.txt", "a\nCHANGED\nc\n")
+
+    plain = [cli.run_ok(*args) for args in REPORTS]
+    # Guards the comparison below against holding for two empty inventories,
+    # which is the very failure it exists to catch.
+    assert all("changed.txt" in output for output in plain)
+    cli.repo.git("config", key, "always")
+    assert [cli.run_ok(*args) for args in REPORTS] == plain

--- a/tests/e2e/repository_path/conftest.py
+++ b/tests/e2e/repository_path/conftest.py
@@ -177,11 +177,14 @@ def get_target(
 
 
 def set_hostile_diff_config(cli: GitHunkCLI) -> None:
-    # Each of these shifts git's own diff path basis. git-hunk must ignore all
-    # three and still report stable Repository paths and Hunk IDs.
+    # The diff.* keys shift git's own diff path basis; the color.* ones make it
+    # colorize even into a pipe. git-hunk must ignore every one of them and
+    # still report stable Repository paths and Hunk IDs.
     cli.repo.git("config", "diff.relative", "true")
     cli.repo.git("config", "diff.noprefix", "true")
     cli.repo.git("config", "diff.mnemonicprefix", "true")
+    cli.repo.git("config", "color.ui", "always")
+    cli.repo.git("config", "color.diff", "always")
 
 
 @pytest.fixture


### PR DESCRIPTION
`git-hunk` parses patch-form `git diff` output, but Git emits ANSI escapes even into a pipe when `color.ui` or `color.diff` is set to `always`. Those escapes made `list` silently report `No hunks.` on a dirty tree and left mutation commands unable to resolve Repository paths or Hunk IDs.

`get_diff` now requests `--no-color` at the parse boundary. The separate `--name-status -z` query is unchanged because Git does not color that machine-readable format, even under forced color settings; keeping the override local also avoids exporting a global config override into commit hooks.

Closes #271

## Test plan

- [x] `tests/e2e/color_config_test.py` verifies `list`, `show`, and `list --json` are unchanged under `color.ui=always` and `color.diff=always`
- [x] the `repository_path` matrix runs stage, unstage, discard, and commit under both forced-color settings
- [x] counterfactual check: removing `--no-color` reproduces `No hunks.` and fails the regression coverage
- [x] `uv run pytest -q` — 822 passed
- [x] `make lint`